### PR TITLE
fix(auth): TC_AUTH_011 ensure verify-email returns 200 OK

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,11 +30,12 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthenticatedRequest, AuthSessionGuard } from './auth.guard';
+import { HttpCode, HttpStatus } from '@nestjs/common';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) { }
 
   @Post('login')
   @ApiOperation({ summary: 'User login', description: 'Login for all roles.' })
@@ -83,6 +84,7 @@ export class AuthController {
   }
 
   @Post('verify-email')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Verify email with token' })
   @ApiResponse({ status: 200, description: 'Email verified.' })
   async verifyEmail(@Body('token') token: string) {
@@ -162,15 +164,15 @@ export class AuthController {
   @ApiOperation({ summary: 'Validate password reset token' })
   @ApiBody({ type: ValidateResetTokenDto })
   @ApiResponse({ status: 200, description: 'Token is valid.' })
-async validateResetToken(@Body() body: ValidateResetTokenDto) {
-  return this.authService.validateResetToken(body.token, body.email, body);
-}
+  async validateResetToken(@Body() body: ValidateResetTokenDto) {
+    return this.authService.validateResetToken(body.token, body.email, body);
+  }
 
   @Post('reset-password')
   @ApiOperation({ summary: 'Reset password with token' })
   @ApiBody({ type: ResetPasswordDto })
   @ApiResponse({ status: 200, description: 'Password reset successful.' })
   async resetPassword(@Body() body: ResetPasswordDto) {
-    return this.authService.resetPassword(body.token, body.email, body.newPassword,body);
+    return this.authService.resetPassword(body.token, body.email, body.newPassword, body);
   }
 }


### PR DESCRIPTION
## Summary
Fixes the verify-email endpoint to return HTTP 200 OK instead of 201 Created.

## Test Case Reference
- TC_AUTH_011: Verify Email Verification
- Steps: POST /api/v1/auth/verify-email with valid token
- Expected: 200 OK with success message
- Actual (before fix): 201 Created
- Fixed: Now returns 200 OK

## Verification
- Tested with Postman using valid token
- Response now returns 200 OK
