### PR TITLE
fix: update the user's avatarUrl 

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -63,11 +63,20 @@ export class UserService {
       updateData.name = data.name;
     }
 
-    // Use avatarId if provided, otherwise fall back to avatarUrl for backward compatibility
     if (data.avatarId !== undefined) {
+      // If ID is provided, use it directly
       updateData.avatarId = data.avatarId;
     } else if (data.avatarUrl !== undefined) {
-      updateData.avatarId = data.avatarUrl;
+      // If URL is provided, CREATE the avatar first
+      const newAvatar = await prisma.avatar.create({
+        data: {
+          url: data.avatarUrl,
+          name: `Custom Avatar for ${id}`,
+          isSystemAvatar: false,
+        }
+      });
+      // Assign the NEW UUID, not the URL string
+      updateData.avatarId = newAvatar.id;
     }
 
     // Build profile update data


### PR DESCRIPTION

# Pull Request

## Description
we couldnt update the user profile with a url cause the backend expected an avatarId, so i made it that when it can see the id itll update directly, but if it doesnt , itll save to the avatar table in the db, and update the user with it

Fixes #(issue)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<img width="1872" height="940" alt="image" src="https://github.com/user-attachments/assets/6cbdba7d-6a90-46da-8296-725a42bbe9e4" />


## Additional context 