### PR TITLE
feat: add automatic activity logging with device tracking when kid acount is accessed

### DIFF
--- a/src/analytics/analytics.dto.ts
+++ b/src/analytics/analytics.dto.ts
@@ -21,7 +21,7 @@ export class CreateActivityLogDto {
   @ApiProperty({ required: false, description: 'Kid ID for the activity', example: 'c182daa8-723c-4020-bcd4-ad01cb026b90' })
   @IsOptional()
   @IsUUID('4', { message: 'kidId must be a valid UUID' })
-  kidId: string;
+  kidId?: string;
 
   @ApiProperty({ required: true, description: 'Action performed', example: 'START_STORY' })
   @IsString({ message: 'action must be a string' })

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -8,5 +8,6 @@ import { AuthModule } from '../auth/auth.module';
   imports: [AuthModule],
   controllers: [AnalyticsController, ActivityLogController],
   providers: [AnalyticsService],
+  exports: [AnalyticsService],
 })
 export class AnalyticsModule {}

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -39,6 +39,32 @@ export class AnalyticsService {
     return this.toActivityLogDto(log);
   }
 
+  async logActivity(params: {
+    userId?: string;
+    kidId?: string;
+    action: string;
+    status: 'SUCCESS' | 'FAILED' | string;
+    details?: string;
+    ipAddress?: string;
+    deviceName?: string;
+    deviceModel?: string;
+    os?: string;
+  }): Promise<ActivityLogDto> {
+    // Map params to DTO and call create()
+    const dto: CreateActivityLogDto = {
+      userId: params.userId,
+      kidId: params.kidId,
+      action: params.action,
+      status: params.status,
+      details: params.details,
+      ipAddress: params.ipAddress,
+      deviceName: params.deviceName,
+      deviceModel: params.deviceModel,
+      os: params.os,
+    };
+    return this.create(dto);
+  }
+
   async getForUser(userId: string): Promise<ActivityLogDto[]> {
     const logs = await prisma.activityLog.findMany({ where: { userId } });
     return logs.map((l: any) => this.toActivityLogDto(l));

--- a/src/kid/kid.controller.ts
+++ b/src/kid/kid.controller.ts
@@ -3,13 +3,17 @@ import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { KidService } from './kid.service';
 import { CreateKidDto, UpdateKidDto } from './dto/kid.dto';
 import { AuthSessionGuard, AuthenticatedRequest } from '../auth/auth.guard';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @ApiTags('Kids Management')
 @ApiBearerAuth()
 @UseGuards(AuthSessionGuard)
 @Controller()
 export class KidController {
-    constructor(private readonly kidService: KidService) { }
+    constructor(
+        private readonly kidService: KidService,
+        private readonly analyticsService: AnalyticsService
+    ) { }
 
     @Get('/auth/kids')
     @ApiOperation({ summary: 'Get all kids for the logged-in user' })
@@ -29,8 +33,40 @@ export class KidController {
 
     @Get('/user/kids/:kidId')
     @ApiOperation({ summary: 'Get details of a specific kid' })
-    async getKid(@Request() req: AuthenticatedRequest, @Param('kidId') kidId: string) {
-        return this.kidService.findOne(kidId, req.authUserData.userId);
+    async getKid(
+        @Request() req: AuthenticatedRequest, 
+        @Param('kidId') kidId: string
+    ){  
+        // Get the kid details first
+        const kid = await this.kidService.findOne(kidId, req.authUserData.userId);
+        
+        // Extract device information from the request
+        // This captures IP address, device name, OS, etc.
+        const ip = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
+        
+        // Parse User-Agent to get device details
+        const UAParser = require('ua-parser-js');
+        const parser = new UAParser(req.headers['user-agent'] as string);
+        const ua = parser.getResult();
+        
+        // Log the activity with full device information
+        // This runs in the background and doesn't block the response
+        this.analyticsService.logActivity({
+            userId: req.authUserData.userId,
+            kidId: kidId,
+            action: 'ACCESS_KID_ACCOUNT',
+            status: 'SUCCESS',
+            details: `Parent accessed kid account from home page`,
+            ipAddress: ip as string,
+            deviceName: ua.device.model || ua.browser.name || 'unknown',
+            deviceModel: ua.device.vendor || 'unknown',
+            os: `${ua.os.name || 'unknown'} ${ua.os.version || ''}`.trim(),
+        }).catch(err => {
+            // Silently catch errors so logging failures don't affect user experience
+            console.error('Failed to log activity:', err);
+        });
+        
+        return kid;
     }
 
     @Put('/auth/kids/:kidId')

--- a/src/kid/kid.module.ts
+++ b/src/kid/kid.module.ts
@@ -4,9 +4,14 @@ import { KidService } from './kid.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthModule } from '../auth/auth.module';
 import { VoiceModule } from '../voice/voice.module';
+import { AnalyticsModule } from '@/analytics/analytics.module';
 
 @Module({
-    imports: [AuthModule, VoiceModule],
+    imports: [
+        AuthModule, 
+        VoiceModule,
+        AnalyticsModule
+    ],
     controllers: [KidController],
     providers: [KidService, PrismaService],
     exports: [KidService],


### PR DESCRIPTION
# Pull Request

## Description
This change adds automatic activity logging whenever the kid’s profile is accessed via the endpoint GET /user/kids/:kidId. The log records the parent’s userId, the kidId, the action performed (ACCESS_KID_ACCOUNT), and the status (SUCCESS). This enables tracking of kid account access for analytics and auditing purposes.

Fixes #(issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (enhancement: automatic activity logging when kid profile is accessed)

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<img width="964" height="732" alt="Screenshot 2025-11-29 134917" src="https://github.com/user-attachments/assets/83df1cb0-be4c-4830-82a1-79898caf77e4" />


## Additional context 