### PR TITLE
fix(all modules): update delete endpoint to enable soft and permenant…

### DIFF
--- a/prisma/migrations/20251130133807_add_soft_delete_fields_to_modules/migration.sql
+++ b/prisma/migrations/20251130133807_add_soft_delete_fields_to_modules/migration.sql
@@ -1,0 +1,237 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Theme" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "activity_logs" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "age_groups" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "badges" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "buddy_interactions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "daily_challenge_assignments" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "daily_challenges" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "favorites" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "kids" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "notification_preferences" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "payment_methods" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "payment_transactions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "profiles" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "question_answers" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "reward_redemptions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "rewards" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "screen_time_sessions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "sessions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "stories" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_audio_cache" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_branches" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_buddies" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_images" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_paths" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_progress" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "story_questions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "subscriptions" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "support_tickets" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "tokens" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "user_badges" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "user_ips" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "voices" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Category_isDeleted_idx" ON "Category"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "Theme_isDeleted_idx" ON "Theme"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_isDeleted_idx" ON "activity_logs"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "age_groups_isDeleted_idx" ON "age_groups"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "badges_isDeleted_idx" ON "badges"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "buddy_interactions_isDeleted_idx" ON "buddy_interactions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "daily_challenge_assignments_isDeleted_idx" ON "daily_challenge_assignments"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "daily_challenges_isDeleted_idx" ON "daily_challenges"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "favorites_isDeleted_idx" ON "favorites"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "kids_isDeleted_idx" ON "kids"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "notification_preferences_isDeleted_idx" ON "notification_preferences"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "payment_methods_isDeleted_idx" ON "payment_methods"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "payment_transactions_isDeleted_idx" ON "payment_transactions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "profiles_isDeleted_idx" ON "profiles"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "question_answers_isDeleted_idx" ON "question_answers"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "reward_redemptions_isDeleted_idx" ON "reward_redemptions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "rewards_isDeleted_idx" ON "rewards"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "screen_time_sessions_isDeleted_idx" ON "screen_time_sessions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "sessions_isDeleted_idx" ON "sessions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "stories_isDeleted_idx" ON "stories"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_audio_cache_isDeleted_idx" ON "story_audio_cache"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_branches_isDeleted_idx" ON "story_branches"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_buddies_isDeleted_idx" ON "story_buddies"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_images_isDeleted_idx" ON "story_images"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_paths_isDeleted_idx" ON "story_paths"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_progress_isDeleted_idx" ON "story_progress"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "story_questions_isDeleted_idx" ON "story_questions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "subscriptions_isDeleted_idx" ON "subscriptions"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "support_tickets_isDeleted_idx" ON "support_tickets"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "tokens_isDeleted_idx" ON "tokens"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "user_badges_isDeleted_idx" ON "user_badges"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "user_ips_isDeleted_idx" ON "user_ips"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "users_isDeleted_idx" ON "users"("isDeleted");
+
+-- CreateIndex
+CREATE INDEX "voices_isDeleted_idx" ON "voices"("isDeleted");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,10 @@ model User {
 
   enableBiometrics Boolean? @default(false)
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   profile Profile?
   auth    Session[]
   Token   Token[]
@@ -60,6 +64,7 @@ model User {
   paymentTransactions PaymentTransaction[]
 
   @@map("users")
+  @@index([isDeleted])
 }
 
 // -------------------------
@@ -81,6 +86,10 @@ model Kid {
   currentReadingLevel Int      @default(1)
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
+
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
 
   rewards          Reward[]
   preferredVoiceId String?
@@ -114,6 +123,7 @@ model Kid {
   progresses              StoryProgress[]
 
   @@map("kids")
+  @@index([isDeleted])
 }
 
 // -------------------------
@@ -127,9 +137,14 @@ model Session {
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@index([userId])
   @@index([userId, token])
   @@map("sessions")
+  @@index([isDeleted])
 }
 
 model Token {
@@ -141,10 +156,15 @@ model Token {
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@index([userId])
   @@index([userId, type])
   @@index([userId, token])
   @@map("tokens")
+  @@index([isDeleted])
 }
 
 model Profile {
@@ -158,7 +178,12 @@ model Profile {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("profiles")
+  @@index([isDeleted])
 }
 
 // -------------------------
@@ -182,6 +207,10 @@ model Story {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   images   StoryImage[]
   branches StoryBranch[]
 
@@ -196,6 +225,7 @@ model Story {
   questions        StoryQuestion[]
 
   @@map("stories")
+  @@index([isDeleted])
 }
 
 model StoryImage {
@@ -207,7 +237,12 @@ model StoryImage {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("story_images")
+  @@index([isDeleted])
 }
 
 model StoryBranch {
@@ -222,7 +257,12 @@ model StoryBranch {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("story_branches")
+  @@index([isDeleted])
 }
 
 model Favorite {
@@ -233,7 +273,12 @@ model Favorite {
   story     Story    @relation(fields: [storyId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("favorites")
+  @@index([isDeleted])
 }
 
 model StoryProgress {
@@ -247,8 +292,13 @@ model StoryProgress {
   lastAccessed   DateTime @default(now())
   totalTimeSpent Int      @default(0)
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@unique([kidId, storyId])
   @@map("story_progress")
+  @@index([isDeleted])
 }
 
 // -------------------------
@@ -264,7 +314,12 @@ model Subscription {
   startedAt DateTime  @default(now())
   endsAt    DateTime?
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("subscriptions")
+  @@index([isDeleted])
 }
 
 model SupportTicket {
@@ -276,7 +331,12 @@ model SupportTicket {
   status    String   @default("open")
   createdAt DateTime @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("support_tickets")
+  @@index([isDeleted])
 }
 
 model PaymentMethod {
@@ -291,9 +351,14 @@ model PaymentMethod {
   meta      Json?
   createdAt DateTime @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   transactions PaymentTransaction[]
 
   @@map("payment_methods")
+  @@index([isDeleted])
 }
 
 model PaymentTransaction {
@@ -308,7 +373,12 @@ model PaymentTransaction {
   status          String
   createdAt       DateTime       @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("payment_transactions")
+  @@index([isDeleted])
 }
 
 // -------------------------
@@ -324,7 +394,12 @@ model DailyChallenge {
   meaning       String
   assignments   DailyChallengeAssignment[]
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("daily_challenges")
+  @@index([isDeleted])
 }
 
 model Voice {
@@ -338,11 +413,16 @@ model Voice {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   usersPreferring User[] @relation("PreferredVoice")
   kidsPreferring  Kid[]  @relation("KidPreferredVoice")
 
   @@index([name])
   @@map("voices")
+  @@index([isDeleted])
 }
 
 model Reward {
@@ -354,6 +434,10 @@ model Reward {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -363,6 +447,7 @@ model Reward {
   redemptions RewardRedemption[]
 
   @@map("rewards")
+  @@index([isDeleted])
 }
 
 model DailyChallengeAssignment {
@@ -375,7 +460,12 @@ model DailyChallengeAssignment {
   completedAt DateTime?
   assignedAt  DateTime       @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("daily_challenge_assignments")
+  @@index([isDeleted])
 }
 
 model NotificationPreference {
@@ -392,7 +482,12 @@ model NotificationPreference {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("notification_preferences")
+  @@index([isDeleted])
 }
 
 model RewardRedemption {
@@ -404,7 +499,12 @@ model RewardRedemption {
   redeemedAt DateTime @default(now())
   status     String
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("reward_redemptions")
+  @@index([isDeleted])
 }
 
 model ActivityLog {
@@ -422,7 +522,12 @@ model ActivityLog {
   details     String?
   createdAt   DateTime @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("activity_logs")
+  @@index([isDeleted])
 }
 
 model StoryPath {
@@ -435,7 +540,12 @@ model StoryPath {
   startedAt   DateTime  @default(now())
   completedAt DateTime?
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("story_paths")
+  @@index([isDeleted])
 }
 
 model Category {
@@ -445,6 +555,12 @@ model Category {
   description     String?
   stories         Story[] @relation("StoryCategories")
   preferredByKids Kid[]   @relation("KidPreferredCategories")
+
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
+  @@index([isDeleted])
 }
 
 model Theme {
@@ -453,6 +569,12 @@ model Theme {
   image       String?
   description String?
   stories     Story[] @relation("StoryThemes")
+
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
+  @@index([isDeleted])
 }
 
 model StoryAudioCache {
@@ -464,9 +586,14 @@ model StoryAudioCache {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@unique([storyId, audioUrl])
   @@unique([storyId, voiceType])
   @@map("story_audio_cache")
+  @@index([isDeleted])
 }
 
 model StoryQuestion {
@@ -478,7 +605,12 @@ model StoryQuestion {
   correctOption Int
   answers       QuestionAnswer[]
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@map("story_questions")
+  @@index([isDeleted])
 }
 
 model Avatar {
@@ -509,8 +641,13 @@ model AgeGroup {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@unique([name])
   @@map("age_groups")
+  @@index([isDeleted])
 }
 
 model ScreenTimeSession {
@@ -522,8 +659,13 @@ model ScreenTimeSession {
   duration  Int?
   date      DateTime  @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@index([kidId, date])
   @@map("screen_time_sessions")
+  @@index([isDeleted])
 }
 
 model QuestionAnswer {
@@ -537,9 +679,14 @@ model QuestionAnswer {
   isCorrect      Boolean
   answeredAt     DateTime      @default(now())
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@index([kidId])
   @@index([kidId, answeredAt])
   @@map("question_answers")
+  @@index([isDeleted])
 }
 
 model UserIP {
@@ -551,9 +698,14 @@ model UserIP {
   firstUsed DateTime @default(now())
   lastUsed  DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@unique([userId, ipAddress])
   @@index([ipAddress])
   @@map("user_ips")
+  @@index([isDeleted])
 }
 
 model StoryBuddy {
@@ -570,10 +722,16 @@ model StoryBuddy {
   ageGroupMax       Int                @default(12)
   createdAt         DateTime           @default(now())
   updatedAt         DateTime           @updatedAt
+
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   buddyInteractions BuddyInteraction[]
   kids              Kid[]
 
   @@map("story_buddies")
+  @@index([isDeleted])
 }
 
 model BuddyInteraction {
@@ -587,9 +745,14 @@ model BuddyInteraction {
   buddy           StoryBuddy @relation(fields: [buddyId], references: [id])
   kid             Kid        @relation(fields: [kidId], references: [id], onDelete: Cascade)
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@index([kidId, timestamp])
   @@index([buddyId])
   @@map("buddy_interactions")
+  @@index([isDeleted])
 }
 
 model Badge {
@@ -605,9 +768,14 @@ model Badge {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   userBadges UserBadge[]
 
   @@map("badges")
+  @@index([isDeleted])
 }
 
 model UserBadge {
@@ -620,8 +788,13 @@ model UserBadge {
   unlocked   Boolean   @default(false)
   unlockedAt DateTime?
 
+  // SOFT DELETE FIELDS
+  isDeleted       Boolean     @default(false)
+  deletedAt       DateTime?
+
   @@unique([userId, badgeId])
   @@index([userId])
   @@index([badgeId])
   @@map("user_badges")
+  @@index([isDeleted])
 }

--- a/src/age/age.controller.ts
+++ b/src/age/age.controller.ts
@@ -97,9 +97,29 @@ export class AgeController {
   @ApiBearerAuth()
   @Delete(':id')
   @ApiOperation({ summary: 'Delete an age group (Admin only)' })
+  @ApiQuery({
+    name: 'permanent',
+    required: false,
+    type: Boolean,
+    description: 'Permanently delete the age group (default: false - soft delete)'
+  })
   @ApiResponse({ status: 200, description: 'Age group deleted successfully.' })
   @ApiNotFoundResponse({ description: 'Age group not found.' })
-  remove(@Param('id') id: string) {
-    return this.ageService.delete(id);
+  remove(
+    @Param('id') id: string,
+    @Query('permanent') permanent: boolean = false
+  ) {
+    return this.ageService.delete(id, permanent);
+  }
+
+  @UseGuards(AdminGuard)
+  @ApiBearerAuth()
+  @Post(':id/undo-delete')
+  @ApiOperation({ summary: 'Restore a soft deleted age group (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Age group restored successfully.' })
+  @ApiNotFoundResponse({ description: 'Age group not found.' })
+  @ApiBadRequestResponse({ description: 'Age group is not deleted.' })
+  undoDelete(@Param('id') id: string) {
+    return this.ageService.undoDelete(id);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,7 +9,6 @@ import { validateEnv } from './config/env.validation';
 import { HelpSupportModule } from './help-support/help-support.module';
 import { KidModule } from './kid/kid.module';
 import { NotificationModule } from './notification/notification.module';
-import { PaymentModule } from './payment/payment.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ReportsModule } from './reports/reports.module';
 import { RewardModule } from './reward/reward.module';
@@ -21,9 +20,7 @@ import { CloudinaryModule } from './upload/cloudinary.module';
 import { UploadModule } from './upload/upload.module';
 import { UserModule } from './user/user.module';
 import { VoiceModule } from './voice/voice.module';
-import { SubscriptionModule } from './subscription/subscription.module';
 import { PaymentModule } from './payment/payment.module';
-import { StoryBuddyModule } from './story-buddy/story-buddy.module';
 import { AchievementProgressModule } from './achievement-progress/achievement-progress.module';
 
 @Module({

--- a/src/kid/kid.controller.ts
+++ b/src/kid/kid.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Post, Put, Delete, Body, Param, UseGuards, Request, ParseArrayPipe } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
+import { Controller, Get, Post, Put, Delete, Body, Param, UseGuards, Request, ParseArrayPipe, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody, ApiQuery } from '@nestjs/swagger';
 import { KidService } from './kid.service';
 import { CreateKidDto, UpdateKidDto } from './dto/kid.dto';
 import { AuthSessionGuard, AuthenticatedRequest } from '../auth/auth.guard';
@@ -41,7 +41,26 @@ export class KidController {
 
     @Delete('/auth/kids/:kidId')
     @ApiOperation({ summary: 'Delete a kid profile' })
-    async deleteKid(@Request() req: AuthenticatedRequest, @Param('kidId') kidId: string) {
-        return this.kidService.deleteKid(kidId, req.authUserData.userId);
+    @ApiQuery({
+        name: 'permanent',
+        required: false,
+        type: Boolean,
+        description: 'Permanently delete the kid profile (default: false - soft delete)'
+    })
+    async deleteKid(
+        @Request() req: AuthenticatedRequest, 
+        @Param('kidId') kidId: string,
+        @Query('permanent') permanent: boolean = false
+    ) {
+        return this.kidService.deleteKid(kidId, req.authUserData.userId, permanent);
+    }
+
+    @Post('/auth/kids/:kidId/undo-delete')
+    @ApiOperation({ summary: 'Restore a soft deleted kid profile' })
+    async undoDeleteKid(
+        @Request() req: AuthenticatedRequest,
+        @Param('kidId') kidId: string
+    ) {
+        return this.kidService.undoDeleteKid(kidId, req.authUserData.userId);
     }
 }

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Post, Patch, Get, Param, Body } from '@nestjs/common';
+import { Controller, Post, Patch, Get, Param, Body, Delete, Query } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiParam,
   ApiBody,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { NotificationService } from './notification.service';
 import {
@@ -36,6 +37,32 @@ export class NotificationController {
     @Body() dto: UpdateNotificationPreferenceDto,
   ) {
     return this.notificationService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a notification preference' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiQuery({
+    name: 'permanent',
+    required: false,
+    type: Boolean,
+    description: 'Permanently delete the notification preference (default: false - soft delete)'
+  })
+  @ApiResponse({ status: 200, description: 'Notification preference deleted successfully' })
+  async delete(
+    @Param('id') id: string,
+    @Query('permanent') permanent: boolean = false
+  ) {
+    await this.notificationService.delete(id, permanent);
+    return { message: 'Notification preference deleted successfully' };
+  }
+
+  @Post(':id/undo-delete')
+  @ApiOperation({ summary: 'Restore a soft deleted notification preference' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, type: NotificationPreferenceDto })
+  async undoDelete(@Param('id') id: string) {
+    return this.notificationService.undoDelete(id);
   }
 
   @Get('user/:userId')

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import { NotificationRegistry, Notifications } from './notification.registry';
@@ -127,6 +127,27 @@ export class NotificationService {
   async create(
     dto: CreateNotificationPreferenceDto,
   ): Promise<NotificationPreferenceDto> {
+    // Verify user or kid exists and is not soft deleted
+    if (dto.userId) {
+      const user = await this.prisma.user.findUnique({
+        where: { 
+          id: dto.userId,
+          isDeleted: false // CANNOT CREATE PREFERENCES FOR SOFT DELETED USERS
+        }
+      });
+      if (!user) throw new NotFoundException('User not found');
+    }
+
+    if (dto.kidId) {
+      const kid = await this.prisma.kid.findUnique({
+        where: { 
+          id: dto.kidId,
+          isDeleted: false // CANNOT CREATE PREFERENCES FOR SOFT DELETED KIDS
+        }
+      });
+      if (!kid) throw new NotFoundException('Kid not found');
+    }
+
     const pref = await this.prisma.notificationPreference.create({
       data: {
         type: dto.type,
@@ -143,31 +164,125 @@ export class NotificationService {
     dto: UpdateNotificationPreferenceDto,
   ): Promise<NotificationPreferenceDto> {
     const pref = await this.prisma.notificationPreference.update({
-      where: { id },
+      where: { 
+        id,
+        isDeleted: false // CANNOT UPDATE SOFT DELETED PREFERENCES
+      },
       data: dto,
     });
     return this.toNotificationPreferenceDto(pref);
   }
 
   async getForUser(userId: string): Promise<NotificationPreferenceDto[]> {
+    const user = await this.prisma.user.findUnique({
+      where: { 
+        id: userId,
+        isDeleted: false // CANNOT GET PREFERENCES FOR SOFT DELETED USERS
+      }
+    });
+    
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
     const prefs = await this.prisma.notificationPreference.findMany({
-      where: { userId },
+      where: { 
+        userId,
+        isDeleted: false // EXCLUDE SOFT DELETED PREFERENCES
+      },
     });
     return prefs.map((p) => this.toNotificationPreferenceDto(p));
   }
 
   async getForKid(kidId: string): Promise<NotificationPreferenceDto[]> {
+    const kid = await this.prisma.kid.findUnique({
+      where: { 
+        id: kidId,
+        isDeleted: false // CANNOT GET PREFERENCES FOR SOFT DELETED KIDS
+      }
+    });
+    
+    if (!kid) {
+      throw new NotFoundException('Kid not found');
+    }
+
     const prefs = await this.prisma.notificationPreference.findMany({
-      where: { kidId },
+      where: { 
+        kidId,
+        isDeleted: false // EXCLUDE SOFT DELETED PREFERENCES
+      },
     });
     return prefs.map((p) => this.toNotificationPreferenceDto(p));
   }
 
   async getById(id: string): Promise<NotificationPreferenceDto> {
     const pref = await this.prisma.notificationPreference.findUnique({
-      where: { id },
+      where: { 
+        id,
+        isDeleted: false // EXCLUDE SOFT DELETED PREFERENCES
+      },
     });
     if (!pref) throw new NotFoundException('Notification preference not found');
     return this.toNotificationPreferenceDto(pref);
+  }
+
+  /**
+   * Soft delete or permanently delete a notification preference
+   * @param id Notification preference ID
+   * @param permanent Whether to permanently delete (default: false)
+   */
+  async delete(id: string, permanent: boolean = false): Promise<void> {
+    const pref = await this.prisma.notificationPreference.findUnique({
+      where: { 
+        id,
+        isDeleted: false // CANNOT DELETE ALREADY DELETED PREFERENCES
+      }
+    });
+    
+    if (!pref) {
+      throw new NotFoundException('Notification preference not found');
+    }
+
+    if (permanent) {
+      await this.prisma.notificationPreference.delete({
+        where: { id },
+      });
+    } else {
+      await this.prisma.notificationPreference.update({
+        where: { id },
+        data: { 
+          isDeleted: true, 
+          deletedAt: new Date() 
+        },
+      });
+    }
+  }
+
+  /**
+   * Restore a soft deleted notification preference
+   * @param id Notification preference ID
+   */
+  async undoDelete(id: string): Promise<NotificationPreferenceDto> {
+    const pref = await this.prisma.notificationPreference.findUnique({
+      where: { id },
+    });
+    
+    if (!pref) {
+      throw new NotFoundException('Notification preference not found');
+    }
+    
+    if (!pref.isDeleted) {
+      throw new BadRequestException('Notification preference is not deleted');
+    }
+
+    const restored = await this.prisma.notificationPreference.update({
+      where: { id },
+      data: { 
+        isDeleted: false, 
+        deletedAt: null 
+      },
+    });
+    
+    return this.toNotificationPreferenceDto(restored);
   }
 }

--- a/src/story-buddy/story-buddy.controller.ts
+++ b/src/story-buddy/story-buddy.controller.ts
@@ -633,6 +633,12 @@ export class StoryBuddyController {
     description: 'Story Buddy ID',
     example: 'buddy-123-uuid',
   })
+  @ApiQuery({
+    name: 'permanent',
+    required: false,
+    type: Boolean,
+    description: 'Permanently delete the story buddy (default: false - soft delete)'
+  })
   @ApiResponse({
     status: 200,
     description: 'Story buddy deleted successfully',
@@ -660,9 +666,58 @@ export class StoryBuddyController {
     status: 404,
     description: 'Story buddy not found',
   })
-  async deleteBuddy(@Param('id') id: string) {
-    await this.storyBuddyService.deleteBuddy(id);
+  async deleteBuddy(
+    @Param('id') id: string,
+    @Query('permanent') permanent: boolean = false
+  ) {
+    await this.storyBuddyService.deleteBuddy(id, permanent);
     return new SuccessResponse(200, null, 'Story buddy deleted successfully');
+  }
+
+  @Post(':id/undo-delete')
+  @UseGuards(AdminGuard)
+  @ApiOperation({
+    summary: 'Restore soft deleted story buddy (Admin)',
+    description: 'Restore a soft deleted story buddy. Admin access required.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Story Buddy ID',
+    example: 'buddy-123-uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Story buddy restored successfully',
+    schema: {
+      example: {
+        statusCode: 200,
+        message: 'Story buddy restored successfully',
+        data: {
+          id: 'buddy-123-uuid',
+          name: 'lumina',
+          displayName: 'Lumina',
+          isActive: true,
+          isDeleted: false,
+          deletedAt: null,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Admin access required',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Story buddy not found',
+  })
+  async undoDeleteBuddy(@Param('id') id: string) {
+    const buddy = await this.storyBuddyService.undoDeleteBuddy(id);
+    return new SuccessResponse(200, buddy, 'Story buddy restored successfully');
   }
 
   @Get('admin/stats')

--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -216,6 +216,12 @@ export class StoryController {
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a story' })
   @ApiParam({ name: 'id', type: String })
+  @ApiQuery({
+    name: 'permanent',
+    required: false,
+    type: Boolean,
+    description: 'Permanently delete the story (default: false - soft delete)'
+  })
   @ApiOkResponse({ description: 'Deleted story', type: String })
   @ApiResponse({
     status: 400,
@@ -232,8 +238,34 @@ export class StoryController {
     description: 'Not Found',
     type: ErrorResponseDto,
   })
-  async deleteStory(@Param('id') id: string) {
-    return this.storyService.deleteStory(id);
+  async deleteStory(
+    @Param('id') id: string,
+    @Query('permanent') permanent: boolean = false
+  ) {
+    return this.storyService.deleteStory(id, permanent);
+  }
+
+  @Post(':id/undo-delete')
+  @ApiOperation({ summary: 'Restore a soft deleted story' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiOkResponse({ description: 'Story restored successfully', type: UpdateStoryDto })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request - Story is not deleted',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Not Found',
+    type: ErrorResponseDto,
+  })
+  async undoDeleteStory(@Param('id') id: string) {
+    return this.storyService.undoDeleteStory(id);
   }
 
   // --- Images ---


### PR DESCRIPTION
… delete

# Pull Request

## Description
Updated the user, age, notification, story and story buddy module to enable soft and permanent delete.

Fixes #(issue)

## Type of change
- [ ] Bug fix
- [X ] New feature
- [ ] Breaking change
- [X ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [X ] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<img width="983" height="477" alt="image" src="https://github.com/user-attachments/assets/6659785f-91b7-48c1-b95e-bd0642829686" />
user before soft delete
<img width="1010" height="486" alt="image" src="https://github.com/user-attachments/assets/43166116-b166-49dd-a9e3-d4943935d094" />
<img width="985" height="446" alt="image" src="https://github.com/user-attachments/assets/b2a5b2bf-d4c5-41c3-a23c-bcce8bc4c280" />
user response after soft delete
<img width="999" height="512" alt="image" src="https://github.com/user-attachments/assets/21942587-5af7-4424-92a1-73882ee536f5" />
<img width="964" height="496" alt="image" src="https://github.com/user-attachments/assets/e0807ae7-c10b-4d9a-89c6-a72ee6bb79f6" />
user response after undoing delete




## Additional context 