### PR TITLE
feat: add ParentFavorites module

### DIFF
--- a/prisma/migrations/20251201093313_add_parent_favorites/migration.sql
+++ b/prisma/migrations/20251201093313_add_parent_favorites/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "parent_favorites" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "storyId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "parent_favorites_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "parent_favorites_userId_storyId_key" ON "parent_favorites"("userId", "storyId");
+
+-- AddForeignKey
+ALTER TABLE "parent_favorites" ADD CONSTRAINT "parent_favorites_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "parent_favorites" ADD CONSTRAINT "parent_favorites_storyId_fkey" FOREIGN KEY ("storyId") REFERENCES "stories"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   auth    Session[]
   Token   Token[]
   kids    Kid[]
+  parentFavorites ParentFavorite[]
 
   voices           Voice[]
   preferredVoiceId String?
@@ -215,6 +216,8 @@ model Story {
   branches StoryBranch[]
 
   favorites       Favorite[]
+
+  parentFavorites ParentFavorite[]
   progresses      StoryProgress[]
   dailyChallenges DailyChallenge[]
   paths           StoryPath[]
@@ -279,6 +282,21 @@ model Favorite {
 
   @@map("favorites")
   @@index([isDeleted])
+}
+
+model ParentFavorite {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  storyId   String
+  story     Story    @relation(fields: [storyId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  isDeleted Boolean     @default(false)
+  deletedAt DateTime?
+
+  @@map("parent_favorites")
+  @@unique([userId, storyId])
 }
 
 model StoryProgress {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { UserModule } from './user/user.module';
 import { VoiceModule } from './voice/voice.module';
 import { PaymentModule } from './payment/payment.module';
 import { AchievementProgressModule } from './achievement-progress/achievement-progress.module';
+import { ParentFavoriteModule } from './parent-favorites/parent-favorites.module';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { AchievementProgressModule } from './achievement-progress/achievement-pr
     StoryBuddyModule,
     HelpSupportModule,
     AchievementProgressModule,
+    ParentFavoriteModule,
   ],
 })
 export class AppModule {}

--- a/src/parent-favorites/dto/create-parent-favorite.dto.ts
+++ b/src/parent-favorites/dto/create-parent-favorite.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateParentFavoriteDto {
+  @IsString()
+  @IsNotEmpty()
+  storyId: string;
+}

--- a/src/parent-favorites/dto/parent-favorite.dto.ts
+++ b/src/parent-favorites/dto/parent-favorite.dto.ts
@@ -1,0 +1,16 @@
+// src/parent-favorites/dto/parent-favorite.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ParentFavoriteDto {
+  @ApiProperty({ description: 'ID of the favorite entry' })
+  id: string;
+
+  @ApiProperty({ description: 'ID of the parent user' })
+  parentId: string;
+
+  @ApiProperty({ description: 'ID of the favorite story' })
+  storyId: string;
+
+  @ApiProperty({ description: 'Date the story was favorited' })
+  createdAt: Date;
+}

--- a/src/parent-favorites/parent-favorites.controller.spec.ts
+++ b/src/parent-favorites/parent-favorites.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParentFavoritesController } from './parent-favorites.controller';
+
+describe('ParentFavoritesController', () => {
+  let controller: ParentFavoritesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ParentFavoritesController],
+    }).compile();
+
+    controller = module.get<ParentFavoritesController>(ParentFavoritesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/parent-favorites/parent-favorites.controller.ts
+++ b/src/parent-favorites/parent-favorites.controller.ts
@@ -1,0 +1,71 @@
+// src/parent-favorites/parent-favorites.controller.ts
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+  Logger,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiBody, ApiOkResponse, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { AuthSessionGuard, AuthenticatedRequest } from '../auth/auth.guard';
+import { ParentFavoritesService } from './parent-favorites.service';
+import { CreateParentFavoriteDto } from './dto/create-parent-favorite.dto';
+import { ParentFavoriteDto } from './dto/parent-favorite.dto';
+import { ErrorResponseDto } from '@/story/story.dto';
+
+@ApiTags('parent-favorites')
+@Controller('parent-favorites')
+export class ParentFavoritesController {
+  private readonly logger = new Logger(ParentFavoritesController.name);
+
+  constructor(private readonly parentFavoritesService: ParentFavoritesService) {}
+
+  @Post()
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Add a story to parent favorites' })
+  @ApiBody({ type: CreateParentFavoriteDto })
+  @ApiOkResponse({ description: 'Added favorite', type: ParentFavoriteDto })
+  @ApiResponse({ status: 400, description: 'Bad Request', type: ErrorResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized', type: ErrorResponseDto })
+  async addFavorite(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreateParentFavoriteDto,
+  ) {
+    const userId = req.authUserData.userId;
+    this.logger.log(`Adding favorite for parent ${userId} and story ${dto.storyId}`);
+    return this.parentFavoritesService.addFavorite(userId, dto);
+  }
+
+  @Get()
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get all parent favorites' })
+  @ApiOkResponse({ description: 'List of parent favorites', type: ParentFavoriteDto, isArray: true })
+  @ApiResponse({ status: 401, description: 'Unauthorized', type: ErrorResponseDto })
+  async getFavorites(@Req() req: AuthenticatedRequest) {
+    const userId = req.authUserData.userId;
+    this.logger.log(`Fetching favorites for parent ${userId}`);
+    return this.parentFavoritesService.getFavorites(userId);
+  }
+
+  @Delete(':storyId')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a story from parent favorites' })
+  @ApiParam({ name: 'storyId', type: String })
+  @ApiOkResponse({ description: 'Removed favorite', type: String })
+  @ApiResponse({ status: 401, description: 'Unauthorized', type: ErrorResponseDto })
+  async removeFavorite(
+    @Req() req: AuthenticatedRequest,
+    @Param('storyId') storyId: string,
+  ) {
+    const userId = req.authUserData.userId;
+    this.logger.log(`Removing favorite for parent ${userId} and story ${storyId}`);
+    return this.parentFavoritesService.removeFavorite(userId, storyId);
+  }
+}

--- a/src/parent-favorites/parent-favorites.module.ts
+++ b/src/parent-favorites/parent-favorites.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ParentFavoritesController } from './parent-favorites.controller';
+import { ParentFavoritesService } from './parent-favorites.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [ParentFavoritesController],
+  providers: [ParentFavoritesService, PrismaService],
+  exports: [ParentFavoritesService],
+})
+export class ParentFavoriteModule {}

--- a/src/parent-favorites/parent-favorites.service.spec.ts
+++ b/src/parent-favorites/parent-favorites.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParentFavoritesService } from './parent-favorites.service';
+
+describe('ParentFavoritesService', () => {
+  let service: ParentFavoritesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ParentFavoritesService],
+    }).compile();
+
+    service = module.get<ParentFavoritesService>(ParentFavoritesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/parent-favorites/parent-favorites.service.ts
+++ b/src/parent-favorites/parent-favorites.service.ts
@@ -1,0 +1,54 @@
+// src/parent-favorites/parent-favorites.service.ts
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateParentFavoriteDto } from './dto/create-parent-favorite.dto';
+import { ParentFavoriteDto } from './dto/parent-favorite.dto';
+
+@Injectable()
+export class ParentFavoritesService {
+  constructor(private prisma: PrismaService) {}
+
+  async addFavorite(userId: string, dto: CreateParentFavoriteDto): Promise<ParentFavoriteDto> {
+    const favorite = await this.prisma.parentFavorite.create({
+      data: {
+        userId,
+        storyId: dto.storyId,
+      },
+    });
+
+    return {
+      id: favorite.id,
+      parentId: favorite.userId,
+      storyId: favorite.storyId,
+      createdAt: favorite.createdAt,
+    };
+  }
+
+  async getFavorites(userId: string): Promise<ParentFavoriteDto[]> {
+    const favorites = await this.prisma.parentFavorite.findMany({
+      where: { userId },
+    });
+
+    return favorites.map(fav => ({
+      id: fav.id,
+      parentId: fav.userId,
+      storyId: fav.storyId,
+      createdAt: fav.createdAt,
+    }));
+  }
+
+ async removeFavorite(userId: string, storyId: string): Promise<string> {
+  const favorite = await this.prisma.parentFavorite.findFirst({
+    where: { userId, storyId },
+  });
+
+  if (!favorite) throw new NotFoundException('Favorite not found');
+
+  await this.prisma.parentFavorite.delete({
+    where: { id: favorite.id },
+  });
+
+  return 'Favorite removed successfully';
+}
+
+}


### PR DESCRIPTION
# Pull Request

## Description
.This PR introduces a full Parent Favorites module with the following capabilities:

- Add a new favorite for a parent

- Fetch all favorites belonging to a parent

- Remove a favorite (soft delete or permanent removal depending on design choice)

- Integrated with Prisma models and parent authentication (req.user.id)

No new external dependencies were added.

Fixes #(issue)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context 
This PR sets up all backend endpoints needed for parent favorites as aligned with the updated design.