### PR TITLE
fix: import AuthModule into BiometricsModule to resolve JwtService in…

### DIFF
--- a/src/biometrics/biometrics.module.ts
+++ b/src/biometrics/biometrics.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { BiometricsService } from './biometrics.service';
 import { BiometricsController } from './biometrics.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [BiometricsController],
   providers: [BiometricsService],
   exports: [BiometricsService],
 })
-export class BiometricsModule {}
+export class BiometricsModule { }


### PR DESCRIPTION
# Pull Request

## Description
Imported `AuthModule` into `BiometricsModule` to ensure that `JwtService` is available for dependency injection.  
This resolves the `UnknownDependenciesException` error where NestJS could not inject `JwtService` into `AuthSessionGuard`.  
No new dependencies were added.

Fixes #<issue-number-if-tracked>

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development (application now starts successfully without dependency injection errors)
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional context
This fix aligns `BiometricsModule` with the rest of the project’s module structure, ensuring consistent availability of `JwtService` across guards and services.
