### PR TITLE
docs: add example schema to parent-favorites POST endpoint

### DIFF
--- a/src/parent-favorites/parent-favorites.controller.ts
+++ b/src/parent-favorites/parent-favorites.controller.ts
@@ -31,7 +31,17 @@ export class ParentFavoritesController {
     summary: 'Add a story to parent favorites',
     description: 'Adds a story to the authenticated parent\'s list of favorites.',
   })
-  @ApiBody({ type: CreateParentFavoriteDto })
+  @ApiBody({
+    type: CreateParentFavoriteDto,
+    examples: {
+      example1: {
+        summary: 'Add story to favorites',
+        value: {
+          storyId: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+        },
+      },
+    },
+  })
   @ApiOkResponse({
     description: 'Story successfully added to favorites',
     type: ParentFavoriteDto,


### PR DESCRIPTION
## Summary
- Added explicit example schema to the parent-favorites POST endpoint `@ApiBody` decorator
- Swagger UI now displays the request body example for adding a story to favorites

## Test plan
- [ ] Verify Swagger UI at `/docs` shows the example schema for POST `/parent-favorites`