### PR TITLE
feat: add endpoint to remove story from user library

### DIFF
--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -630,6 +630,21 @@ export class StoryController {
     return this.storyService.getUserCompletedStories(req.authUserData.userId);
   }
 
+  @Delete('user/library/remove/:storyId')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove story from user library (resets progress and favorites)' })
+  @ApiParam({ name: 'storyId', type: String })
+  @ApiOkResponse({ description: 'Story removed from library successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized', type: ErrorResponseDto })
+  async removeFromUserLibrary(
+    @Req() req: AuthenticatedRequest,
+    @Param('storyId') storyId: string,
+  ) {
+    await this.storyService.removeFromUserLibrary(req.authUserData.userId, storyId);
+    return { message: 'Story removed from library successfully' };
+  }
+
   // --- Daily Challenge ---
   @Post('daily-challenge')
   @ApiOperation({ summary: 'Set daily challenge' })

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -625,6 +625,13 @@ export class StoryService {
     return records.map((r) => r.story);
   }
 
+  async removeFromUserLibrary(userId: string, storyId: string) {
+    return await this.prisma.$transaction([
+      this.prisma.parentFavorite.deleteMany({ where: { userId, storyId } }),
+      this.prisma.userStoryProgress.deleteMany({ where: { userId, storyId } }),
+    ]);
+  }
+
   async restrictStory(dto: RestrictStoryDto & { userId: string }) {
     const kid = await this.prisma.kid.findUnique({ where: { id: dto.kidId, isDeleted: false } });
     if (!kid) throw new NotFoundException('Kid not found');


### PR DESCRIPTION
## Summary
- Added `DELETE /stories/user/library/remove/:storyId` endpoint for authenticated users (parents) to remove stories from their library
- Removes story from both parent favorites and reading progress/history in a single transaction

## Test plan
- [ ] Call `DELETE /stories/user/library/remove/:storyId` with a valid auth token and storyId
- [ ] Verify the story is removed from `GET /stories/user/library/continue-reading`
- [ ] Verify the story is removed from `GET /stories/user/library/completed`
- [ ] Verify the story is removed from `GET /parent-favorites`