### PR TITLE
feat(cors): allow storytimeapp.me and all subdomains

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,15 +22,24 @@ async function bootstrap() {
   app.setGlobalPrefix('api/v1');
   app.use(helmet());
   app.enableCors({
-    origin: [
-      'http://localhost:3000',
-      'http://localhost:5173',
-      'http://localhost:3001',
-      'http://localhost:4200',
-      'http://localhost:8080',
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:5173',
-    ],
+    origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+      // Allow requests with no origin (mobile apps, curl, etc.)
+      if (!origin) {
+        return callback(null, true);
+      }
+
+      // Allow storytimeapp.me and all subdomains
+      const storytimePattern = /^https?:\/\/([a-z0-9-]+\.)*storytimeapp\.me$/;
+
+      // Allow localhost for development
+      const localhostPattern = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/;
+
+      if (storytimePattern.test(origin) || localhostPattern.test(origin)) {
+        return callback(null, true);
+      }
+
+      callback(new Error('Not allowed by CORS'));
+    },
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: [
       'Content-Type',


### PR DESCRIPTION
## Summary
- Replaces static localhost-only CORS origins with dynamic origin validation
- Allows `storytimeapp.me` and all its subdomains (e.g., `www.storytimeapp.me`, `app.storytimeapp.me`)
- Keeps localhost/127.0.0.1 access on any port for development

## Test plan
- [ ] Verify requests from `storytimeapp.me` are allowed
- [ ] Verify requests from subdomains like `www.storytimeapp.me` are allowed
- [ ] Verify localhost requests still work for development
- [ ] Verify requests from unauthorized origins are blocked