### PR TITLE
perf: resilience improvements and type safety fixes

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -22,6 +22,7 @@ import {
   updateProfileDto,
 } from './dto/auth.dto';
 import { PrismaService } from '@/prisma/prisma.service';
+import { Role } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { generateToken } from '@/utils/generate-token';
 import { GoogleOAuthProfile } from '@/shared/types';
@@ -126,12 +127,12 @@ export class AuthService {
       throw new BadRequestException('Email already exists');
     }
 
-    let role = 'parent';
+    let role: Role = Role.parent;
     if (data.role === 'admin') {
       if (data.adminSecret !== process.env.ADMIN_SECRET) {
         throw new ForbiddenException('Invalid admin secret');
       }
-      role = 'admin';
+      role = Role.admin;
     }
 
     const hashedPassword = await this.passwordService.hashPassword(
@@ -143,7 +144,7 @@ export class AuthService {
         name: data.fullName,
         email: data.email,
         passwordHash: hashedPassword,
-        role: role as any,
+        role,
         onboardingStatus: 'account_created',
       },
       include: {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -382,9 +382,9 @@ export class UserService {
     });
     if (!user) throw new NotFoundException('User not found');
 
-    const updateData: Record<string, any> = {};
+    const updateData: Prisma.UserUncheckedUpdateInput = {};
 
-    const profileUpdate: Record<string, any> = {};
+    const profileUpdate: Prisma.ProfileUpdateInput = {};
 
     // -------- USER FIELDS --------
     if (data.name !== undefined) updateData.name = data.name;
@@ -479,9 +479,9 @@ export class UserService {
     });
     if (!existing) throw new NotFoundException('User not found');
 
-    const updateUser: Record<string, any> = {};
+    const updateUser: Prisma.UserUpdateInput = {};
 
-    const updateProfile: Record<string, any> = {};
+    const updateProfile: Prisma.ProfileUpdateInput = {};
 
     if (data.name !== undefined) updateUser.name = data.name;
     if (data.biometricsEnabled !== undefined)

--- a/src/voice/providers/eleven-labs-tts.provider.ts
+++ b/src/voice/providers/eleven-labs-tts.provider.ts
@@ -184,7 +184,7 @@ export class ElevenLabsTTSProvider
     }
   }
 
-  async getSubscriptionInfo(): Promise<any> {
+  async getSubscriptionInfo(): Promise<unknown> {
     if (!this.client) {
       throw new ServiceUnavailableException(
         'ElevenLabs client is not initialized',


### PR DESCRIPTION
## Summary
- Added retry logic with exponential backoff to GeminiService
- Added atomic transactions to PaymentService for payment + subscription operations
- Replaced `any` types with proper TypeScript types in auth, user, and voice services

## Changes
- `gemini.service.ts`: Retry logic with configurable attempts and backoff
- `payment.service.ts`: Atomic transactions with cache invalidation
- `auth.service.ts`: Use Prisma `Role` enum instead of `as any`
- `user.service.ts`: Use `Prisma.UserUncheckedUpdateInput` for type safety
- `eleven-labs-tts.provider.ts`: Use `Promise<unknown>` instead of `Promise<any>`

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint`)
- [ ] Manual testing of auth flows
- [ ] Manual testing of payment flows