### PR TITLE
fix(ci): use vars instead of secrets for environment URL

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -256,7 +256,7 @@ jobs:
     timeout-minutes: 20
     environment:
       name: development
-      url: ${{ secrets.DEV_APP_URL }}
+      url: ${{ vars.DEV_APP_URL }}
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes the workflow validation error:
```
Invalid workflow file: .github/workflows/dev-deploy.yml#L1
(Line: 259, Col: 12): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.DEV_APP_URL
```

The `environment.url` field doesn't have access to the `secrets` context - it's evaluated at workflow parse time, not runtime.

### Change
- `secrets.DEV_APP_URL` → `vars.DEV_APP_URL`

### Setup Required
Set the repository variable:
```bash
gh variable set DEV_APP_URL --body "https://your-dev-api-url.com"
```

## Type of change
- [x] Bug fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to source environment URL from a different configuration source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->