### PR TITLE
fix(ci): fix Redis container config and update pnpm version

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -183,8 +183,8 @@ jobs:
       - name: Generate Prisma client
         run: pnpm db:generate
 
-      - name: Push database schema
-        run: pnpm db:push
+      - name: Run database migrations
+        run: pnpm db:migrate:deploy
 
       - name: Run tests
         continue-on-error: true


### PR DESCRIPTION
# Pull Request

## Description
Fixes the CI container initialization error:
```
unknown flag: --requirepass
```

### Issues Fixed
1. **Redis container config**: `--requirepass` is a Redis server argument, not a Docker option. Removed it and using Redis without password for CI (isolated environment).

2. **pnpm version mismatch**: Workflow had `PNPM_VERSION: '9'` but `package.json` requires `>=10.0.0`.

### Changes
- Remove `--requirepass redis_password` from Redis options
- Update `REDIS_URL` to `redis://localhost:6379` (no password)
- Fix health check: `redis-cli ping` (no `-a` flag)
- Update `PNPM_VERSION: '9'` → `'10'`

## Type of change
- [x] Bug fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit PNPM version pinning in CI workflows.
  * Simplified Redis configuration across test/build/deploy pipelines (switched to no password and streamlined health checks).
  * Cleaned up CI workflow steps to use a unified, simpler Redis health-check command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->