### PR TITLE
chore(migration): add unique constraint on subscription userId

### DIFF
--- a/prisma/migrations/20260213154317_add_subscription_user_unique_constraint/migration.sql
+++ b/prisma/migrations/20260213154317_add_subscription_user_unique_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "subscriptions_userId_key" ON "subscriptions"("userId");


### PR DESCRIPTION
## Description
This PR adds the database migration for the subscription unique constraint that was introduced in PR #231. The schema change (userId @unique) and code refactoring (subscriptions → subscription) were already merged, but the corresponding Prisma migration was missing.

This migration enforces the one-to-one relationship between User and Subscription at the database level by adding a unique index on the `subscriptions.userId` column.

Related: #231

## Type of change
- [x] Other (please describe): Database migration

## How Has This Been Tested?
- [x] Local development - Migration file created and validated
- [ ] Unit tests - N/A (migration only)
- [ ] E2E tests - N/A (migration only)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A (migration only)
- [ ] New and existing unit tests pass locally with my changes - N/A (migration only)
- [x] Any dependent changes have been merged and published in downstream modules

## ⚠️ Important: Pre-Migration Steps

Before applying this migration, check for and clean up any duplicate subscriptions:

\`\`\`sql
-- Check for duplicates
SELECT "userId", COUNT(*) 
FROM subscriptions 
WHERE "isDeleted" = false 
GROUP BY "userId" 
HAVING COUNT(*) > 1;

-- If duplicates exist, keep only the most recent subscription per user
DELETE FROM subscriptions
WHERE id NOT IN (
  SELECT DISTINCT ON ("userId") id
  FROM subscriptions
  WHERE "isDeleted" = false
  ORDER BY "userId", "createdAt" DESC
) AND "isDeleted" = false;
\`\`\`

Then apply the migration:
\`\`\`bash
pnpm prisma migrate deploy
\`\`\`

## Additional context
This completes the subscription model refactoring that changed the User-Subscription relationship from one-to-many to one-to-one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a database constraint to ensure each user can only have one active subscription, preventing duplicate subscription records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->