### PR TITLE
fix(payment): explicitly null platform fields when absent

### DIFF
--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -253,11 +253,9 @@ export class PaymentService {
       status: 'active',
       startedAt: now,
       endsAt,
-      ...(platformDetails && {
-        platform: platformDetails.platform,
-        productId: platformDetails.productId,
-        purchaseToken: platformDetails.purchaseToken,
-      }),
+      platform: platformDetails?.platform ?? null,
+      productId: platformDetails?.productId ?? null,
+      purchaseToken: platformDetails?.purchaseToken ?? null,
     };
 
     const subscription = existingSub


### PR DESCRIPTION
# Pull Request

## Description
Addresses the remaining CodeRabbit review comment from PR #237. In `upsertSubscriptionWithExpiry`, platform fields (`platform`, `productId`, `purchaseToken`) are now explicitly set to `null` when `platformDetails` is absent, instead of being omitted from the update data. This prevents stale store credentials from persisting on subscription updates.

The other 5 CodeRabbit comments from #237 were already addressed on `develop-v0.0.1`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context
CodeRabbit review reference: https://github.com/Bolt-Silverfox/storytime_be/pull/237#discussion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced subscription data consistency by ensuring all platform-related fields are properly recorded in subscription records, with null values assigned when information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->