### PR TITLE
feat: include story categories in library endpoints

### DIFF
--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -783,7 +783,11 @@ export class StoryService {
         isDeleted: false,
       },
       orderBy: { lastAccessed: 'desc' },
-      include: { story: true },
+      include: {
+        story: {
+          include: { categories: true },
+        },
+      },
     });
 
     return progressRecords.map((record) => ({
@@ -798,7 +802,11 @@ export class StoryService {
     const records = await this.prisma.userStoryProgress.findMany({
       where: { userId, completed: true, isDeleted: false },
       orderBy: { lastAccessed: 'desc' },
-      include: { story: true },
+      include: {
+        story: {
+          include: { categories: true },
+        },
+      },
     });
 
     return records.map((r) => r.story);
@@ -1532,7 +1540,11 @@ export class StoryService {
     const progressRecords = await this.prisma.storyProgress.findMany({
       where: { kidId, progress: { gt: 0 }, completed: false, isDeleted: false },
       orderBy: { lastAccessed: 'desc' },
-      include: { story: true },
+      include: {
+        story: {
+          include: { categories: true },
+        },
+      },
     });
     return progressRecords.map((record) => ({
       ...record.story,
@@ -1546,7 +1558,11 @@ export class StoryService {
     const records = await this.prisma.storyProgress.findMany({
       where: { kidId, completed: true, isDeleted: false },
       orderBy: { lastAccessed: 'desc' },
-      include: { story: true },
+      include: {
+        story: {
+          include: { categories: true },
+        },
+      },
     });
     return records.map((r) => r.story);
   }


### PR DESCRIPTION
# Pull Request

## Description
Include story categories in the response for library endpoints so the mobile app can display category tags on stories.

- `GET /user/library/continue-reading` — now includes `categories` array on each story
- `GET /user/library/completed` — now includes `categories` array on each story
- `GET /library/:kidId/continue-reading` — now includes `categories` array on each story
- `GET /library/:kidId/completed` — now includes `categories` array on each story

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Stories now return with associated category information for more complete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->