### PR TITLE
feat: add displayName to voice available response

### DIFF
--- a/src/voice/dto/voice.dto.ts
+++ b/src/voice/dto/voice.dto.ts
@@ -41,8 +41,8 @@ export class VoiceResponseDto {
   @ApiProperty()
   name: string;
 
-  @ApiProperty({ required: false, description: 'User-facing display name' })
-  displayName?: string;
+  @ApiProperty({ description: 'User-facing display name' })
+  displayName: string;
 
   @ApiProperty({
     description: "'uploaded' or 'elevenlabs'",


### PR DESCRIPTION
## Summary
- Adds `displayName` field to the `/voice/available` API response, mapping user-facing names (Milo, Nimbus, Bella, etc.) from `VOICE_CONFIG`
- Falls back to `voice.name` (enum key) when no config entry exists
- The `name` field remains unchanged for backward compatibility

## Test plan
- [ ] Call `GET /voice/available` and verify each voice object includes a `displayName` field
- [ ] Confirm `name` still returns the enum key (e.g. `LILY`, `CHARLIE`)
- [ ] Confirm `displayName` returns the friendly name (e.g. `Lily`, `Charlie`)
- [ ] Verify custom/uploaded voices fall back to `voice.name` for `displayName`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voices now include a user-facing display name across the UI: listings of available voices, preferred-voice results, uploaded/third-party voices, and voice previews will show a clearer display name (falls back to the existing name when not configured).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->