### PR TITLE
fix: treat admin users as premium for voice access

### DIFF
--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -211,6 +211,12 @@ export class VoiceQuotaService {
    * Check if user has an active premium subscription
    */
   async isPremiumUser(userId: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+    if (user?.role === 'admin') return true;
+
     const subscription = await this.prisma.subscription.findFirst({
       where: {
         userId,


### PR DESCRIPTION
## Summary
- Admin users now bypass the premium subscription check in `isPremiumUser()`
- Fixes 403 "You do not have access to this voice" error for admin users
- `isPremiumUser()` checks `user.role === 'admin'` before checking subscription status

## Test plan
- [ ] Admin user can access all voices without an active subscription
- [ ] Regular free users still restricted to LILY (default voice)
- [ ] Premium subscribers still have full voice access
- [ ] No regression in voice quota checks