### PR TITLE
fix: address code review findings from CodeRabbit

### DIFF
--- a/src/story/gemini.service.ts
+++ b/src/story/gemini.service.ts
@@ -215,10 +215,10 @@ export class GeminiService {
       // Only count transient API errors toward circuit breaker
       // Parse errors and validation errors are not API instability
       const errorObj =
-        error instanceof Error
-          ? (error as unknown as Record<string, unknown>)
+        error != null && typeof error === 'object'
+          ? (error as Record<string, unknown>)
           : {};
-      const httpStatus = errorObj.status ?? errorObj.code;
+      const httpStatus = Number(errorObj.status ?? errorObj.code);
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       const isTransientError =
@@ -361,8 +361,10 @@ Important: Return ONLY the JSON object, no additional text or markdown formattin
       );
 
       const buffer = Buffer.from(response.data as ArrayBuffer);
-      if (buffer.length === 0) {
-        throw new Error('Hugging Face returned empty image data');
+      if (buffer.length < 1024) {
+        throw new Error(
+          `Hugging Face returned invalid image data (${buffer.length} bytes)`,
+        );
       }
 
       const result = await this.uploadService.uploadImageFromBuffer(

--- a/src/story/text-to-speech.service.spec.ts
+++ b/src/story/text-to-speech.service.spec.ts
@@ -51,7 +51,9 @@ describe('TextToSpeechService', () => {
     mockCanFreeUserUseElevenLabs.mockResolvedValue(true);
     // Default: return input as-is (tests for known VoiceTypes will get
     // elevenLabsId from VOICE_CONFIG in the service's own resolution)
-    mockResolveCanonicalVoiceId.mockImplementation(async (id: string) => id);
+    mockResolveCanonicalVoiceId.mockImplementation((id: string) =>
+      Promise.resolve(id),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -181,6 +183,10 @@ describe('TextToSpeechService', () => {
         userId,
       );
 
+      expect(mockCanFreeUserUseElevenLabs).toHaveBeenCalledWith(
+        userId,
+        'NFG5qt843uXKj4pFvR7C', // CHARLIE's ElevenLabs ID
+      );
       expect(mockElevenLabsGenerate).not.toHaveBeenCalled();
       expect(mockDeepgramGenerate).toHaveBeenCalled();
       expect(result).toBe('https://uploaded-audio.com/deepgram.mp3');

--- a/src/story/text-to-speech.service.ts
+++ b/src/story/text-to-speech.service.ts
@@ -482,7 +482,7 @@ export class TextToSpeechService {
         }
       }
 
-      if (useElevenLabsBatch) {
+      if (useElevenLabsBatch && isPremium) {
         reservedCredits = await this.voiceQuota.recordUsage(
           userId,
           uncached.length,

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -20,12 +20,19 @@ export class UploadService {
           folder: 'storytime',
           resource_type: 'auto',
         },
-        (error: UploadApiErrorResponse, result: UploadApiResponse) => {
+        (error: UploadApiErrorResponse, result?: UploadApiResponse) => {
           if (error) {
             this.logger.error('Cloudinary upload error:', error);
             return reject(
               new InternalServerErrorException(
                 `Upload failed: ${error.message}`,
+              ),
+            );
+          }
+          if (!result) {
+            return reject(
+              new InternalServerErrorException(
+                'Cloudinary upload returned no result',
               ),
             );
           }
@@ -51,12 +58,19 @@ export class UploadService {
             { format: 'webp' },
           ],
         },
-        (error: UploadApiErrorResponse, result: UploadApiResponse) => {
+        (error: UploadApiErrorResponse, result?: UploadApiResponse) => {
           if (error) {
             this.logger.error('Cloudinary image upload error:', error);
             return reject(
               new InternalServerErrorException(
                 `Image upload failed: ${error.message}`,
+              ),
+            );
+          }
+          if (!result) {
+            return reject(
+              new InternalServerErrorException(
+                'Cloudinary image upload returned no result',
               ),
             );
           }
@@ -82,12 +96,19 @@ export class UploadService {
             { format: 'webp' },
           ],
         },
-        (error: UploadApiErrorResponse, result: UploadApiResponse) => {
+        (error: UploadApiErrorResponse, result?: UploadApiResponse) => {
           if (error) {
             this.logger.error('Cloudinary buffer upload error:', error);
             return reject(
               new InternalServerErrorException(
                 `Image buffer upload failed: ${error.message}`,
+              ),
+            );
+          }
+          if (!result) {
+            return reject(
+              new InternalServerErrorException(
+                'Cloudinary buffer upload returned no result',
               ),
             );
           }
@@ -149,12 +170,19 @@ export class UploadService {
           resource_type: 'video',
           public_id: filename,
         },
-        (error: UploadApiErrorResponse, result: UploadApiResponse) => {
+        (error: UploadApiErrorResponse, result?: UploadApiResponse) => {
           if (error) {
             this.logger.error('Cloudinary audio upload error:', error);
             return reject(
               new InternalServerErrorException(
                 `Audio upload failed: ${error.message}`,
+              ),
+            );
+          }
+          if (!result) {
+            return reject(
+              new InternalServerErrorException(
+                'Cloudinary audio upload returned no result',
               ),
             );
           }

--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -207,8 +207,11 @@ export class VoiceQuotaService {
     });
     const uniqueCachedIds = [...new Set(canonicalCachedIds)];
 
+    // Normalize the incoming voiceId the same way cached IDs are resolved
+    const canonicalVoiceId = await this.resolveCanonicalVoiceId(voiceId);
+
     // Already cached for this story — always allowed (zero cost)
-    if (uniqueCachedIds.includes(voiceId)) {
+    if (uniqueCachedIds.includes(canonicalVoiceId)) {
       return true;
     }
 


### PR DESCRIPTION
# Pull Request

## Description
Addresses 7 actionable findings from CodeRabbit's review of PR #266. Each finding was verified against the current code before applying fixes.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes

### Bug fixes
- **Transient error detection** (`gemini.service.ts`): Extract `status`/`code` from any thrown value (not just `Error` instances) and coerce to `Number` before comparing against 429/503
- **Cloudinary undefined result** (`upload.service.ts`): Guard all 4 upload callbacks against `result` being `undefined` even when `error` is falsy
- **Free-user double-counting** (`text-to-speech.service.ts`): Skip `recordUsage` for free users in batch TTS — per-generation `incrementUsage` already handles their quota
- **Voice ID normalization** (`voice-quota.service.ts`): Canonicalize incoming `voiceId` in `canUseVoiceForStory` so enum names and UUIDs match against cached ElevenLabs IDs

### Defensive improvements
- **HF image buffer check** (`gemini.service.ts`): Reject buffers < 1KB to catch HTML/JSON error bodies returned with HTTP 200
- **Migration fetch timeout** (`migrate-pollinations-to-cloudinary.ts`): Add 60s `AbortController` timeout to prevent hanging on unresponsive HF API

### Test improvements
- **TTS spec** (`text-to-speech.service.spec.ts`): Assert `canFreeUserUseElevenLabs` is called with correct `(userId, elevenLabsId)` args

## How Has This Been Tested?
- [x] Local development
- [x] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
N/A

## Additional context
All findings were triaged — 2 nitpicks were skipped (prompt injection sanitization in a migration script using our own DB data, and a formatting issue that already passes lint/format).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and timeout management for API calls to prevent hanging requests.
  * Enhanced upload operation reliability with better error responses and validation.
  * Refined voice service request processing for more accurate data validation.

* **Improvements**
  * Optimized premium user access to enhanced voice services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->