### PR TITLE
fix: allow free users to select first voice before locking

### DIFF
--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -386,12 +386,14 @@ export class VoiceQuotaService {
     const usage = await this.prisma.userUsage.findUnique({
       where: { userId },
     });
-    if (usage?.selectedSecondVoiceId) {
-      const lockedCanonical = await this.resolveCanonicalVoiceId(
-        usage.selectedSecondVoiceId,
-      );
-      if (lockedCanonical === requestedCanonical) return true;
-    }
+
+    // No voice locked yet — allow any voice (locking happens downstream in canFreeUserUseElevenLabs)
+    if (!usage?.selectedSecondVoiceId) return true;
+
+    const lockedCanonical = await this.resolveCanonicalVoiceId(
+      usage.selectedSecondVoiceId,
+    );
+    if (lockedCanonical === requestedCanonical) return true;
 
     return false;
   }


### PR DESCRIPTION
## Summary
- `canUseVoice` was rejecting non-default voices when no `selectedSecondVoiceId` was set, blocking free users from ever making their first voice pick
- Voice locking happens downstream in `canFreeUserUseElevenLabs`, so `canUseVoice` must allow the request through when no voice is locked yet

## Test plan
- [ ] Free user with no locked voice can select any voice and hear audio
- [ ] Free user with a locked voice can only use that locked voice (+ default)
- [ ] Premium user is unaffected