### PR TITLE
fix: release-tag workflow tag existence check

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check if tag already exists
         id: check_tag
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag v${{ steps.version.outputs.version }} already exists — skipping"
           else


### PR DESCRIPTION
## Summary
- Fix `release-tag.yml` to use `git ls-remote` instead of `git rev-parse` for tag existence check (shallow clones don't have tags locally)

## Context
The v1.0.0 release-tag workflow failed because `git rev-parse` couldn't find the existing tag in a shallow clone. This switches to `git ls-remote --tags` which checks the remote directly.