### PR TITLE
fix: server-side read-status sort & resolve preferred voice ID

### DIFF
--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -409,7 +409,7 @@ export class StoryService {
     );
     const enriched = await this.enrichWithReadStatus(filter.userId, data);
 
-    return { data: enriched, pagination };
+    return { data: this.sortByReadStatus(enriched), pagination };
   }
 
   private mapProgressRecord(record: {
@@ -428,10 +428,8 @@ export class StoryService {
     };
   }
 
-  /**
-   * Sort stories so unread appear first, then reading, then done.
-   * Preserves original order within each group (stable sort).
-   */
+  // Sort stories so unread appear first, then reading, then done.
+  // Preserves original order within each group (stable sort).
   private sortByReadStatus<T extends { readStatus: 'done' | 'reading' | null }>(
     stories: T[],
   ): T[] {

--- a/src/voice/voice.service.ts
+++ b/src/voice/voice.service.ts
@@ -174,7 +174,6 @@ export class VoiceService {
     const response = this.toVoiceResponse(user.preferredVoice);
 
     // Resolve DB UUID to VoiceType key so mobile can match against available voices
-    // (fetchAvailableVoices uses VoiceType keys as ids, not DB UUIDs)
     const elevenLabsId = user.preferredVoice.elevenLabsVoiceId;
     if (elevenLabsId) {
       const voiceTypeKey = Object.entries(VOICE_CONFIG).find(


### PR DESCRIPTION
## Summary
- **Story sorting**: Added `sortByReadStatus()` in story service — sorts enriched stories so unread appear first, then reading, then done. Applied in both `getStories()` (home screen carousels + "View all" pages) and `getHomePageStories()` (recommended, seasonal, topLiked sections). This moves sorting responsibility from mobile to backend, eliminating client-side re-sort jank on pagination.
- **Voice ID mismatch**: `getPreferredVoice()` was returning the DB UUID as the voice `id`, but `fetchAvailableVoices()` uses VoiceType enum keys (e.g., "COSMO", "NIMBUS"). Mobile couldn't match the preferred voice against available voices, causing the raw UUID to display instead of the voice name. Now resolves the DB UUID to VoiceType key via `VOICE_CONFIG` lookup.

## Test plan
- [ ] Verify home screen carousels show unread stories first
- [ ] Verify "View all" paginated screens show unread stories first
- [ ] Verify `GET /voice/preferred` returns VoiceType key (e.g., "COSMO") not UUID
- [ ] Verify voice modal shows correct display name for selected voice
- [ ] Verify free user premium badges/lock state works (lockedVoiceId matches voice.id)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stories are now consistently ordered by read status (unread → reading → done).
  * Free users can have their selected non-default free voice locked so it’s retained as their active voice.

* **Bug Fixes**
  * Improved resolution of preferred voice identifiers for more accurate voice selection and deterministic locking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->