### PR TITLE
feat: cursor pagination for parent favorites

### DIFF
--- a/src/parent-favorites/parent-favorites.controller.ts
+++ b/src/parent-favorites/parent-favorites.controller.ts
@@ -96,8 +96,22 @@ export class ParentFavoritesController {
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiOkResponse({
     description: 'Paginated list of parent favorites',
-    type: ParentFavoriteResponseDto,
-    isArray: true,
+    schema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/ParentFavoriteResponseDto' },
+        },
+        pagination: {
+          type: 'object',
+          properties: {
+            nextCursor: { type: 'string', nullable: true },
+            hasNextPage: { type: 'boolean' },
+          },
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 401,

--- a/src/parent-favorites/parent-favorites.service.ts
+++ b/src/parent-favorites/parent-favorites.service.ts
@@ -66,7 +66,7 @@ export class ParentFavoritesService {
           },
         },
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
     });
 
     const mapped = favorites.map((fav) => ({


### PR DESCRIPTION
## Summary
- Adds cursor-based pagination to `GET /parent-favorites` endpoint
- Accepts optional `cursor` and `limit` query params (default limit: 20)
- Uses existing `PaginationUtil.buildCursorResponse` for consistent pagination format
- Response shape changes from `FavouriteStory[]` to `{ data: FavouriteStory[], pagination: { nextCursor, hasNextPage } }`

## Test plan
- [ ] `GET /parent-favorites` returns paginated response with `data` and `pagination`
- [ ] `GET /parent-favorites?limit=2` returns max 2 items with `hasNextPage: true` if more exist
- [ ] `GET /parent-favorites?cursor=<id>&limit=2` returns next page
- [ ] Empty favorites returns `{ data: [], pagination: { nextCursor: null, hasNextPage: false } }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to the parent favorites endpoint, enabling users to navigate through results efficiently using cursor and limit parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->