### PR TITLE
fix: log field name on P2003 foreign key errors

### DIFF
--- a/src/shared/filters/prisma-exception.filter.ts
+++ b/src/shared/filters/prisma-exception.filter.ts
@@ -54,6 +54,10 @@ export class PrismaExceptionFilter
       }
       // P2003: Foreign key constraint failed
       case 'P2003': {
+        const field = (exception.meta?.field_name as string) || 'unknown';
+        this.logger.error(
+          `P2003 Foreign key constraint failed on field: ${field}`,
+        );
         statusCode = HttpStatus.BAD_REQUEST;
         message = 'The provided foreign key is invalid or does not exist.';
         error = 'Invalid Foreign Key';


### PR DESCRIPTION
# Pull Request

## Description
Adds the failing `field_name` from Prisma's `exception.meta` to the log output when a P2003 (foreign key constraint) error occurs. This helps diagnose which FK relationship is causing the constraint violation (e.g. `preferredVoiceId` vs `selectedSecondVoiceId`).

Voice selection is currently returning "The provided foreign key is invalid or does not exist" for paid users, but we can't tell which field is failing from current logs.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context
No change to the client-facing error message — only adds server-side logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for foreign key constraint violations by logging detailed field information when such violations occur, improving troubleshooting and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->