### PR TITLE
fix: align dev and staging CI/CD with prod pattern

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -309,7 +309,14 @@ jobs:
         run: pnpm db:generate && pnpm build
 
       - name: Run database migrations
+        env:
+          DATABASE_URL: ${{ secrets.MIGRATE_DATABASE_URL }}
         run: pnpm db:migrate:deploy
+
+      - name: Seed database
+        env:
+          DATABASE_URL: ${{ secrets.MIGRATE_DATABASE_URL }}
+        run: pnpm db:seed
 
       - name: Prepare deployment directory
         uses: appleboy/ssh-action@v1.0.3
@@ -325,6 +332,13 @@ jobs:
           echo "${{ secrets.EC2_SSH_KEY }}" > /tmp/ssh_key
           chmod 600 /tmp/ssh_key
 
+      - name: Add server host key
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          ssh-keyscan -H "$EC2_HOST" > /tmp/known_hosts
+          chmod 600 /tmp/known_hosts
+
       - name: Sync files to server
         run: |
           rsync -avz --delete \
@@ -334,7 +348,7 @@ jobs:
             --exclude='.env.local' \
             --exclude='coverage' \
             --exclude='.turbo' \
-            -e "ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no" \
+            -e "ssh -i /tmp/ssh_key -o UserKnownHostsFile=/tmp/known_hosts -o StrictHostKeyChecking=yes" \
             ./ ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/ubuntu/storytime/development/storytime-api/
 
       - name: Install dependencies and restart application
@@ -404,5 +418,5 @@ jobs:
       - name: Cleanup sensitive files
         if: always()
         run: |
-          rm -f /tmp/ssh_key
+          rm -f /tmp/ssh_key /tmp/known_hosts
           rm -f .env

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -5,15 +5,24 @@ on:
     branches: ['release-v*.*.*']
     types: [opened, synchronize, closed]
 
-jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
-    environment: staging
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+concurrency:
+  group: staging-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  # ===================
+  # Quality Checks (runs on all events)
+  # ===================
+  quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -21,46 +30,132 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Create .env file
-        run: echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Format and Lint
-        run: |
-          pnpm run format
-          pnpm run lint
+      - name: Format check
+        run: pnpm run format -- --check
 
-      - name: Commit formatting changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Security audit
+        continue-on-error: true
+        run: pnpm audit --audit-level=high
+
+  # ===================
+  # Build (runs on all events)
+  # ===================
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: staging
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/storytime_build
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: storytime_build
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          commit_message: "style: auto-fix formatting and linting issues"
-          branch: ${{ github.head_ref }}
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Create .env file
+        run: |
+          cat > .env << 'EOF'
+          ${{ secrets.ENV_FILE }}
+          EOF
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
 
       - name: Build
-        run: pnpm db:generate && pnpm build
-
-    # - name: Run tests
-    #   run: pnpm test
+        run: pnpm build
 
       - name: Cleanup sensitive files
         if: always()
         run: rm -f .env
 
-  deploy:
-    needs: build-and-test
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+  # ===================
+  # Test (runs on all events)
+  # ===================
+  test:
+    name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: staging
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/storytime_test
+      REDIS_URL: redis://localhost:6379
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: storytime_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -68,43 +163,249 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Create .env file
-        run: echo "${{ secrets.ENV_FILE }}" > .env
+        run: |
+          cat > .env << 'EOF'
+          ${{ secrets.ENV_FILE }}
+          EOF
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm db:generate && pnpm build && pnpm db:migrate:deploy
+      - name: Generate Prisma client
+        run: pnpm db:generate
 
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
+      - name: Run database migrations
+        run: pnpm db:migrate:deploy
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f .env
+
+  # ===================
+  # Auto-fix Formatting (only on open/sync, not on merge)
+  # ===================
+  auto-format:
+    name: Auto-fix Formatting
+    runs-on: ubuntu-latest
+    needs: [quality]
+    if: github.event.action != 'closed'
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Auto-fix formatting
+        run: |
+          pnpm run format || true
+          pnpm run lint --fix || true
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: auto-fix formatting and linting issues"
+          branch: ${{ github.head_ref }}
+
+  # ===================
+  # Deploy to Staging (only on merge, requires build/test success)
+  # ===================
+  deploy:
+    name: Deploy to Staging
+    needs: [build, test]
+    if: success() && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    environment:
+      name: staging
+      url: ${{ vars.STAGING_APP_URL }}
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Create .env file
+        run: |
+          cat > .env << 'EOF'
+          ${{ secrets.ENV_FILE }}
+          EOF
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        run: pnpm db:generate && pnpm build
+
+      - name: Run database migrations
+        env:
+          DATABASE_URL: ${{ secrets.MIGRATE_DATABASE_URL }}
+        run: pnpm db:migrate:deploy
+
+      - name: Seed database
+        env:
+          DATABASE_URL: ${{ secrets.MIGRATE_DATABASE_URL }}
+        run: pnpm db:seed
+
+      - name: Prepare deployment directory
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             mkdir -p /home/ubuntu/storytime/staging/storytime-api
-            exit 0
 
-      - name: Sync files and restart app
+      - name: Setup SSH key
         run: |
           echo "${{ secrets.EC2_SSH_KEY }}" > /tmp/ssh_key
           chmod 600 /tmp/ssh_key
 
-          rsync -avz --exclude='.git' --exclude='.github' --exclude='node_modules' \
-            -e "ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no" \
+      - name: Add server host key
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          ssh-keyscan -H "$EC2_HOST" > /tmp/known_hosts
+          chmod 600 /tmp/known_hosts
+
+      - name: Sync files to server
+        run: |
+          rsync -avz --delete \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='node_modules' \
+            --exclude='.env.local' \
+            --exclude='coverage' \
+            --exclude='.turbo' \
+            -e "ssh -i /tmp/ssh_key -o UserKnownHostsFile=/tmp/known_hosts -o StrictHostKeyChecking=yes" \
             ./ ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/ubuntu/storytime/staging/storytime-api/
 
-          ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no \
-            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
-            'bash -l -c "source ~/.nvm/nvm.sh && cd /home/ubuntu/storytime/staging/storytime-api && pnpm install --frozen-lockfile && cd scripts && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt && cd .. && pnpm deploy:staging"'
+      - name: Install dependencies and restart application
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            source ~/.nvm/nvm.sh
+            cd /home/ubuntu/storytime/staging/storytime-api
+            [ -f .env ] && chmod 600 .env
+
+            # Install Node dependencies
+            pnpm install --frozen-lockfile
+
+            # Setup Python virtual environment for scripts
+            cd scripts
+            python3 -m venv .venv
+            .venv/bin/pip install -q -r requirements.txt
+            cd ..
+
+            # Restart application
+            pnpm deploy:staging
+
+      - name: Verify deployment
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            # Wait for app to start
+            sleep 10
+
+            # Health check
+            curl -sf http://localhost:3500/api/v1/health || exit 1
+
+            echo "Staging deployment verified successfully"
+
+      - name: Comment deployment status
+        if: success()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Deployed to Staging**\n\nCommit: \`${context.sha.substring(0, 7)}\`\nTime: ${new Date().toISOString()}`
+            });
+
+      - name: Comment deployment failure
+        if: failure()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Staging Deployment Failed**\n\nCommit: \`${context.sha.substring(0, 7)}\`\nCheck the [workflow logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+            });
 
       - name: Cleanup sensitive files
         if: always()
         run: |
-          rm -f /tmp/ssh_key
+          rm -f /tmp/ssh_key /tmp/known_hosts
           rm -f .env


### PR DESCRIPTION
# Pull Request

## Description
Aligns dev and staging workflows with the production workflow pattern for consistency and security.

**Dev changes:**
- Migrations now use `MIGRATE_DATABASE_URL` (step-level env override)
- Added seed step after migrations
- SSH key handling uses `ssh-keyscan` + `StrictHostKeyChecking=yes` instead of `StrictHostKeyChecking=no`

**Staging changes (full rewrite):**
- Split single job into quality, build, test, auto-format, deploy (matches prod structure)
- Build and test use CI postgres/redis containers (no longer hits real staging DB)
- Migrations and seeding use `MIGRATE_DATABASE_URL`
- Added deployment verification health check
- Added PR deployment status comments
- Added concurrency group to prevent overlapping deploys
- SSH hardened with `ssh-keyscan` + `StrictHostKeyChecking=yes`

**Required secrets per environment:**
- `DATABASE_URL` — runtime connection string
- `MIGRATE_DATABASE_URL` — migration/seed connection string
- `ENV_FILE` — full .env contents
- `EC2_HOST`, `EC2_USERNAME`, `EC2_SSH_KEY` — server access

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI/CD workflow alignment

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [x] Other (describe): YAML syntax validated, compared against working prod workflow

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
Each environment (development, staging, production) now needs `MIGRATE_DATABASE_URL` set in GitHub secrets. Can be the same as `DATABASE_URL` if using the postgres superuser.