### PR TITLE
fix: batch story seeding to prevent transaction timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storytime_be",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "packageManager": "pnpm@10.15.1",
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
## Summary
- Production seed with 302 stories was timing out at 30s in a single Prisma interactive transaction
- Stories are now processed in batches of 50 with 60s timeout per batch
- Prevents `Transaction already closed: A query cannot be executed on an expired transaction` errors
- Bumps version to v1.0.2

## Root Cause
The `stories.production.json` file contains 302 stories. Creating each story involves `connectOrCreate` for categories, themes, and seasons, plus creating questions — resulting in multiple DB queries per story. A single transaction wrapping all 302 stories exceeded the 30s timeout.

## Test plan
- [ ] Verify prod deploy succeeds after merge
- [ ] Confirm all 302 stories are seeded
- [ ] Check seed logs show batch progress (e.g. "Batch 1/7 (50 stories)")