### PR TITLE
fix: version bump workflow creates PR instead of direct push

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -57,7 +57,9 @@ jobs:
           BRANCH_REF: ${{ github.event.ref }}
           TARGET_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          BUMP_BRANCH="chore/bump-v${TARGET_VERSION}"
+          # Include sanitized source branch to avoid collisions between develop-v* and hotfix/v*
+          SAFE_REF=$(echo "$BRANCH_REF" | tr '/' '-')
+          BUMP_BRANCH="chore/bump-v${TARGET_VERSION}-${SAFE_REF}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BUMP_BRANCH"


### PR DESCRIPTION
## Summary
- Branch protection rules reject direct pushes from GitHub Actions bot
- Changed version-bump workflow to create a PR with the bump instead of pushing directly
- Sanitized `github.event.ref` into env variables per GitHub Actions security best practices
- Added `pull-requests: write` permission

## Context
Failed run: https://github.com/Bolt-Silverfox/storytime_be/actions/runs/22516938985

## Test plan
- [ ] Delete and recreate `develop-v1.1.0` (or create a test `develop-v99.0.0`) to trigger the workflow
- [ ] Verify a PR is created with the version bump instead of a direct push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated version-bump workflow now creates pull requests for review instead of directly updating releases.
  * Version is derived from the branch and compared to the target before bumping; bump changes are pushed on a descriptive branch.
  * Workflow adds the needed permissions, environment usage, and clearer logging for traceability and safer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->