### PR TITLE
fix: SSE guard soft-delete check and initial health event

### DIFF
--- a/src/admin/sse/admin-sse.service.ts
+++ b/src/admin/sse/admin-sse.service.ts
@@ -5,7 +5,7 @@ import {
   OnModuleDestroy,
 } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, defer, from, concat } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AdminService } from '../admin.service';
 
@@ -43,7 +43,14 @@ export class AdminSseService implements OnModuleInit, OnModuleDestroy {
   }
 
   getEventStream(): Observable<MessageEvent> {
-    return this.events$.asObservable().pipe(
+    const initialHealth$ = defer(() =>
+      from(this.adminService.getSystemHealth().then((health) => ({
+        type: 'dashboard.health' as const,
+        data: health,
+      }))),
+    );
+
+    return concat(initialHealth$, this.events$.asObservable()).pipe(
       map(
         (event) =>
           ({

--- a/src/admin/sse/admin-sse.service.ts
+++ b/src/admin/sse/admin-sse.service.ts
@@ -44,10 +44,12 @@ export class AdminSseService implements OnModuleInit, OnModuleDestroy {
 
   getEventStream(): Observable<MessageEvent> {
     const initialHealth$ = defer(() =>
-      from(this.adminService.getSystemHealth().then((health) => ({
-        type: 'dashboard.health' as const,
-        data: health,
-      }))),
+      from(
+        this.adminService.getSystemHealth().then((health) => ({
+          type: 'dashboard.health' as const,
+          data: health,
+        })),
+      ),
     );
 
     return concat(initialHealth$, this.events$.asObservable()).pipe(

--- a/src/admin/sse/sse-auth.guard.ts
+++ b/src/admin/sse/sse-auth.guard.ts
@@ -25,8 +25,8 @@ export class SseAuthGuard implements CanActivate {
 
     try {
       const payload = await this.jwtService.verifyAsync(token);
-      const user = await this.prisma.user.findUnique({
-        where: { id: payload.sub },
+      const user = await this.prisma.user.findFirst({
+        where: { id: payload.sub, isDeleted: false },
       });
 
       if (!user || user.role !== Role.admin) {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -304,7 +304,7 @@ export class PaymentService {
       timestamp: new Date().toISOString(),
     });
     this.eventEmitter.emit('admin.sse.stats', {
-      trigger: 'subscription_created',
+      trigger: existingSub ? 'subscription_renewed' : 'subscription_created',
     });
 
     return {

--- a/src/voice/providers/eleven-labs-tts.provider.ts
+++ b/src/voice/providers/eleven-labs-tts.provider.ts
@@ -194,9 +194,7 @@ export class ElevenLabsTTSProvider
         const err = error as Record<string, unknown>;
         const status = (err.status || err.statusCode) as number | undefined;
         if (status === 401 || status === 403) {
-          throw new BadGatewayException(
-            'ElevenLabs API authentication error',
-          );
+          throw new BadGatewayException('ElevenLabs API authentication error');
         }
       }
 


### PR DESCRIPTION
# Pull Request

## Description
Addresses CodeRabbit findings on the admin SSE module (PR #317):

- **Security fix**: Add `isDeleted: false` check in `sse-auth.guard.ts` to prevent soft-deleted admin users from subscribing to the SSE stream
- **Subscription events**: Differentiate `subscription_created` vs `subscription_renewed` in `payment.service.ts` for accurate analytics
- **UX improvement**: Push initial health event immediately to new SSE subscribers instead of waiting up to 30s

## Type of change
- [x] Bug fix
- [x] New feature

## How Has This Been Tested?
- [x] Local development
- [x] Other: `pnpm build` — no errors in SSE files

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional context
Only actionable CodeRabbit findings were addressed — Swagger decorators and type assertion nitpicks were skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted user accounts are now properly prevented from accessing admin features.

* **Improvements**
  * Subscription renewal events are now tracked separately from new subscription events for improved analytics visibility.
  * System health monitoring enhancements improve dashboard data delivery.

* **Refactoring**
  * Code formatting improvements in error handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->