### PR TITLE
fix: stable pagination, readStatus-aware shuffle, redundant slice

### DIFF
--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -260,11 +260,12 @@ export class StoryController {
       cursor !== undefined &&
       topPicksFromUs !== 'true' &&
       isMostLiked !== 'true' &&
-      recommended !== 'true';
+      recommended !== 'true' &&
+      shuffle !== 'true';
 
     if (cursor !== undefined && !useCursorMode) {
       this.logger.warn(
-        `Cursor pagination ignored: cursor="${cursor}" bypassed because topPicksFromUs=${topPicksFromUs}, isMostLiked=${isMostLiked}, recommended=${recommended}. Falling back to offset pagination.`,
+        `Cursor pagination ignored: cursor="${cursor}" bypassed because topPicksFromUs=${topPicksFromUs}, isMostLiked=${isMostLiked}, recommended=${recommended}, shuffle=${shuffle}. Falling back to offset pagination.`,
       );
     }
 

--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -159,6 +159,12 @@ export class StoryController {
     type: Number,
     description: 'Maximum number of items to return for pagination',
   })
+  @ApiQuery({
+    name: 'shuffle',
+    required: false,
+    type: String,
+    description: 'Shuffle unseen stories for variety on home screen sections',
+  })
   @ApiOkResponse({
     description: 'List of stories',
     type: CreateStoryDto,
@@ -198,6 +204,7 @@ export class StoryController {
     @Query('cursor') cursor?: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
     @Query('limit') limitParam?: string,
+    @Query('shuffle') shuffle?: string,
   ): Promise<PaginatedStoriesDto | CursorPaginatedStoriesDto> {
     // Base filter shared by both pagination modes.
     // recommended and isMostLiked are intentionally excluded here
@@ -279,6 +286,7 @@ export class StoryController {
       topPicksFromUs: topPicksFromUs === 'true',
       page: safePage,
       limit,
+      shuffle: shuffle === 'true',
     });
   }
 

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -393,8 +393,9 @@ export class StoryService {
       });
     }
 
-    // Slice over-fetched results back to requested limit
-    if (filter.topPicksFromUs || (filter.isMostLiked && shouldShuffle)) {
+    // Slice over-fetched results back to requested limit (only needed when
+    // we over-fetched during shuffle; deterministic paths already return exact limit)
+    if (shouldShuffle && (filter.topPicksFromUs || filter.isMostLiked)) {
       sortedStories = sortedStories.slice(0, limit);
     }
 

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -310,10 +310,9 @@ export class StoryService {
     // Handle topPicksFromUs filter - get random stories using shared helper
     if (filter.topPicksFromUs) {
       const overFetchLimit = shouldShuffle ? Math.min(limit * 3, 150) : limit;
-      const randomStoryIds = await this.getRandomStoryIds(
-        overFetchLimit,
-        shouldShuffle ? 0 : skip,
-      );
+      const randomStoryIds = shouldShuffle
+        ? await this.getRandomStoryIds(overFetchLimit)
+        : await this.getDeterministicStoryIds(limit, skip);
 
       if (randomStoryIds.length === 0) {
         return {
@@ -382,13 +381,16 @@ export class StoryService {
     });
 
     // For mostLiked with shuffle, randomize tiebreakers within same like count
+    // and readStatus so that unread-first ordering from sortByReadStatus is preserved.
     if (filter.isMostLiked && shouldShuffle) {
-      sortedStories = this.shuffleTiedStories(
-        sortedStories,
-        (s) =>
+      sortedStories = this.shuffleTiedStories(sortedStories, (s) => {
+        const favCount =
           (s as unknown as { _count?: { parentFavorites?: number } })._count
-            ?.parentFavorites ?? 0,
-      );
+            ?.parentFavorites ?? 0;
+        const readStatus =
+          (s as unknown as { readStatus?: string }).readStatus ?? 'unseen';
+        return `${readStatus}:${favCount}`;
+      });
     }
 
     // Slice over-fetched results back to requested limit
@@ -505,22 +507,28 @@ export class StoryService {
   }
 
   /**
-   * Shuffle stories that share the same score (e.g. equal like counts)
-   * while preserving the relative order between different score groups.
+   * Shuffle stories that share the same grouping key (e.g. equal like counts
+   * and readStatus) while preserving the relative order between different groups.
+   * The key function should return a string that encodes all ordering-relevant
+   * dimensions so that, e.g., unseen and done stories with the same favourite
+   * count are never mixed.
    */
-  private shuffleTiedStories<T>(stories: T[], getScore: (s: T) => number): T[] {
-    const groups = new Map<number, T[]>();
+  private shuffleTiedStories<T>(
+    stories: T[],
+    getKey: (s: T) => string,
+  ): T[] {
+    const groups = new Map<string, T[]>();
     for (const s of stories) {
-      const score = getScore(s);
-      if (!groups.has(score)) groups.set(score, []);
-      groups.get(score)!.push(s);
+      const key = getKey(s);
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(s);
     }
     for (const group of groups.values()) {
       this.fisherYatesShuffle(group);
     }
-    return [...groups.entries()]
-      .sort(([a], [b]) => b - a)
-      .flatMap(([, g]) => g);
+    // Preserve insertion order — callers feed already-sorted input so the
+    // first occurrence of each key reflects the correct group ordering.
+    return [...groups.values()].flatMap((g) => g);
   }
 
   private async enrichWithReadStatus<T extends { id: string }>(
@@ -2184,23 +2192,42 @@ export class StoryService {
 
   /**
    * Get random story IDs using raw SQL for efficiency.
+   * Only suitable for single-page results (page 1) because ORDER BY RANDOM()
+   * produces a different ordering on each call, causing overlapping pages.
    * @param limit - Maximum number of IDs to return
-   * @param offset - Number of results to skip (for pagination)
    * @returns Array of random story IDs
    */
-  private async getRandomStoryIds(
-    limit: number,
-    offset: number = 0,
-  ): Promise<string[]> {
+  private async getRandomStoryIds(limit: number): Promise<string[]> {
     const randomIds = await this.prisma.$queryRaw<{ id: string }[]>`
       SELECT id FROM "stories"
       WHERE "isDeleted" = false
       ORDER BY RANDOM()
       LIMIT ${limit}
-      OFFSET ${offset}
     `;
 
     return randomIds.map((r) => r.id);
+  }
+
+  /**
+   * Get story IDs using a deterministic (createdAt DESC) ordering.
+   * Safe for paginated requests beyond page 1 where stable ordering is required.
+   * @param limit - Maximum number of IDs to return
+   * @param offset - Number of results to skip (for pagination)
+   * @returns Array of story IDs in stable order
+   */
+  private async getDeterministicStoryIds(
+    limit: number,
+    offset: number = 0,
+  ): Promise<string[]> {
+    const ids = await this.prisma.$queryRaw<{ id: string }[]>`
+      SELECT id FROM "stories"
+      WHERE "isDeleted" = false
+      ORDER BY "createdAt" DESC, id ASC
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `;
+
+    return ids.map((r) => r.id);
   }
 
   /**

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -295,6 +295,7 @@ export class StoryService {
     kidId?: string;
     page?: number;
     limit?: number;
+    shuffle?: boolean;
   }): Promise<PaginatedStoriesDto> {
     const page = filter.page || 1;
     const limit = filter.limit || 12;
@@ -302,9 +303,17 @@ export class StoryService {
 
     const { where } = await this.buildStoryWhereClause(filter);
 
+    // Shuffle only applies on page 1 (home screen carousels).
+    // Beyond page 1 (paginated "See All"), disable shuffle to avoid overlapping pages.
+    const shouldShuffle = filter.shuffle === true && page === 1;
+
     // Handle topPicksFromUs filter - get random stories using shared helper
     if (filter.topPicksFromUs) {
-      const randomStoryIds = await this.getRandomStoryIds(limit, skip);
+      const overFetchLimit = shouldShuffle ? Math.min(limit * 3, 150) : limit;
+      const randomStoryIds = await this.getRandomStoryIds(
+        overFetchLimit,
+        shouldShuffle ? 0 : skip,
+      );
 
       if (randomStoryIds.length === 0) {
         return {
@@ -338,7 +347,15 @@ export class StoryService {
         : this.prisma.story.count({ where }),
       this.prisma.story.findMany({
         where,
-        ...(filter.topPicksFromUs ? {} : { skip, take: limit }),
+        ...(filter.topPicksFromUs
+          ? {}
+          : {
+              skip,
+              take:
+                filter.isMostLiked && shouldShuffle
+                  ? Math.min(limit * 2, 100)
+                  : limit,
+            }),
         orderBy,
         include: {
           images: true,
@@ -347,6 +364,9 @@ export class StoryService {
           themes: true,
           seasons: true,
           questions: true,
+          ...(filter.isMostLiked && shouldShuffle
+            ? { _count: { select: { parentFavorites: true } } }
+            : {}),
         },
       }),
     ]);
@@ -357,8 +377,37 @@ export class StoryService {
       stories,
     );
 
+    let sortedStories = this.sortByReadStatus(enrichedStories, {
+      shuffleUnseen: shouldShuffle,
+    });
+
+    // For mostLiked with shuffle, randomize tiebreakers within same like count
+    if (filter.isMostLiked && shouldShuffle) {
+      sortedStories = this.shuffleTiedStories(
+        sortedStories,
+        (s) =>
+          (s as unknown as { _count?: { parentFavorites?: number } })._count
+            ?.parentFavorites ?? 0,
+      );
+    }
+
+    // Slice over-fetched results back to requested limit
+    if (filter.topPicksFromUs || (filter.isMostLiked && shouldShuffle)) {
+      sortedStories = sortedStories.slice(0, limit);
+    }
+
+    // Strip _count from response to avoid leaking internal fields
+    const cleanedStories =
+      shouldShuffle && filter.isMostLiked
+        ? (sortedStories.map((s) => {
+            const { _count, ...rest } = s as Record<string, unknown>;
+            void _count;
+            return rest;
+          }) as typeof sortedStories)
+        : sortedStories;
+
     return {
-      data: this.sortByReadStatus(enrichedStories),
+      data: cleanedStories,
       pagination: {
         currentPage: page,
         totalPages,
@@ -430,16 +479,48 @@ export class StoryService {
 
   // Sort stories so unread appear first, then reading, then done.
   // Preserves original order within each group (stable sort).
-  // Applied post-fetch: pagination cursors use DB order (createdAt/id),
-  // so items may shift within a page if readStatus changes between requests.
+  // When shuffleUnseen is true, Fisher-Yates shuffle the unseen bucket
+  // so home screen sections show varied stories on each request.
   private sortByReadStatus<T extends { readStatus: 'done' | 'reading' | null }>(
     stories: T[],
+    options?: { shuffleUnseen?: boolean },
   ): T[] {
-    const order: Record<string, number> = { done: 2, reading: 1 };
-    return [...stories].sort(
-      (a, b) =>
-        (order[a.readStatus ?? ''] ?? 0) - (order[b.readStatus ?? ''] ?? 0),
-    );
+    const unseen = stories.filter((s) => s.readStatus === null);
+    const reading = stories.filter((s) => s.readStatus === 'reading');
+    const done = stories.filter((s) => s.readStatus === 'done');
+
+    if (options?.shuffleUnseen) {
+      this.fisherYatesShuffle(unseen);
+    }
+
+    return [...unseen, ...reading, ...done];
+  }
+
+  /** In-place Fisher-Yates shuffle. */
+  private fisherYatesShuffle<T>(arr: T[]): void {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  }
+
+  /**
+   * Shuffle stories that share the same score (e.g. equal like counts)
+   * while preserving the relative order between different score groups.
+   */
+  private shuffleTiedStories<T>(stories: T[], getScore: (s: T) => number): T[] {
+    const groups = new Map<number, T[]>();
+    for (const s of stories) {
+      const score = getScore(s);
+      if (!groups.has(score)) groups.set(score, []);
+      groups.get(score)!.push(s);
+    }
+    for (const group of groups.values()) {
+      this.fisherYatesShuffle(group);
+    }
+    return [...groups.entries()]
+      .sort(([a], [b]) => b - a)
+      .flatMap(([, g]) => g);
   }
 
   private async enrichWithReadStatus<T extends { id: string }>(


### PR DESCRIPTION
## Description

Follow-up fixes from CodeRabbit review on #324 (already merged):

1. **Stable pagination (major)** — `ORDER BY RANDOM()` with OFFSET re-randomized each request, causing overlapping pages. Now uses `getDeterministicStoryIds()` with `ORDER BY "createdAt" DESC, id ASC` for pages > 1.

2. **ReadStatus-aware shuffle (major)** — `shuffleTiedStories()` grouped only by favorite count, breaking unread-first ordering from `sortByReadStatus()`. Now includes readStatus in the grouping key so unseen/reading/done stories are never mixed.

3. **Cursor/shuffle conflict (minor)** — Added `shuffle !== 'true'` to `useCursorMode` condition to prevent silent shuffle drops.

4. **Redundant slice (nitpick)** — Only slice over-fetched results when `shouldShuffle` is true; deterministic paths already return exact limit.

## Type of change
- [x] Bug fix

## How Has This Been Tested?
- [x] Local development
- [x] Unit tests (admin and story tests pass)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings