### PR TITLE
feat: enable interactive story mode — backend

### DIFF
--- a/prisma/migrations/20260314011049_make_question_answer_kid_optional/migration.sql
+++ b/prisma/migrations/20260314011049_make_question_answer_kid_optional/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "question_answers" ADD COLUMN     "userId" TEXT,
+ALTER COLUMN "kidId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "question_answers_userId_idx" ON "question_answers"("userId");
+
+-- AddForeignKey
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260314120000_add_question_answer_owner_check_and_unique/migration.sql
+++ b/prisma/migrations/20260314120000_add_question_answer_owner_check_and_unique/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "question_answers_userId_questionId_key" ON "question_answers"("userId", "questionId");
+
+-- AddCheckConstraint
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_owner_check" CHECK ("kidId" IS NOT NULL OR "userId" IS NOT NULL);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model User {
   couponRedemptions     CouponRedemption[]
   // Coupon-granted premium access expiry date
   premiumAccessUntil    DateTime?
+  questionAnswers       QuestionAnswer[]
 
   @@index([isDeleted])
   @@index([email, isDeleted])
@@ -495,6 +496,7 @@ model Subscription {
 
   @@index([userId, status])
   @@index([status, isDeleted])
+  @@index([purchaseToken])
   @@index([isDeleted])
   @@map("subscriptions")
 }
@@ -858,8 +860,10 @@ model ScreenTimeSession {
 
 model QuestionAnswer {
   id             String        @id @default(uuid())
-  kidId          String
-  kid            Kid           @relation(fields: [kidId], references: [id], onDelete: Cascade)
+  kidId          String?
+  kid            Kid?          @relation(fields: [kidId], references: [id], onDelete: Cascade)
+  userId         String?
+  user           User?         @relation(fields: [userId], references: [id], onDelete: Cascade)
   questionId     String
   question       StoryQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
   storyId        String
@@ -871,6 +875,7 @@ model QuestionAnswer {
   deletedAt      DateTime?
 
   @@index([kidId])
+  @@index([userId])
   @@index([questionId])
   @@index([storyId])
   @@index([kidId, answeredAt])
@@ -1177,4 +1182,25 @@ model CouponRedemption {
   @@index([couponId])
   @@index([userId])
   @@map("coupon_redemptions")
+}
+
+// -------------------------
+// WEBHOOK EVENTS
+// -------------------------
+model WebhookEvent {
+  id              String    @id @default(uuid())
+  platform        String // "apple" | "google"
+  eventType       String // e.g. "DID_RENEW", "SUBSCRIPTION_RENEWED"
+  externalEventId String // Apple: notificationUUID, Google: messageId
+  payload         Json // Full decoded payload for debugging
+  status          String    @default("received") // received | processed | skipped | failed
+  errorMessage    String?
+  processedAt     DateTime?
+  createdAt       DateTime  @default(now())
+
+  @@unique([platform, externalEventId])
+  @@index([platform, eventType])
+  @@index([status, createdAt])
+  @@index([createdAt])
+  @@map("webhook_events")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -878,6 +878,7 @@ model QuestionAnswer {
   @@index([userId])
   @@index([questionId])
   @@index([storyId])
+  @@unique([userId, questionId], name: "userId_questionId_unique")
   @@index([kidId, answeredAt])
   @@index([isDeleted])
   @@map("question_answers")

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -14,7 +22,11 @@ import {
   EndScreenTimeSessionDto,
   DailyLimitDto,
 } from './dto/reports.dto';
-import { QuestionAnswerDto } from '../story/dto/story.dto';
+import { SubmitQuestionAnswerDto } from '../story/dto/story.dto';
+import {
+  AuthSessionGuard,
+  AuthenticatedRequest,
+} from '../shared/guards/auth.guard';
 
 @ApiTags('reports')
 @Controller('reports')
@@ -66,10 +78,14 @@ export class ReportsController {
 
   // ============== QUIZ TRACKING ==============
   @Post('answer')
+  @UseGuards(AuthSessionGuard)
   @ApiOperation({ summary: 'Record a question answer' })
-  @ApiBody({ type: QuestionAnswerDto })
+  @ApiBody({ type: SubmitQuestionAnswerDto })
   @ApiResponse({ status: 201, description: 'Returns if answer is correct' })
-  async recordAnswer(@Body() dto: QuestionAnswerDto) {
-    return this.reportsService.recordAnswer(dto);
+  async recordAnswer(
+    @Body() dto: SubmitQuestionAnswerDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.reportsService.recordAnswer(dto, req.authUserData.userId);
   }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -7,7 +7,7 @@ import {
   DailyLimitDto,
 } from './dto/reports.dto';
 // import { SetDailyLimitDto } from '@/control/control.dto';
-import { QuestionAnswerDto } from '../story/dto/story.dto'; // Import from story module
+import { SubmitQuestionAnswerDto } from '../story/dto/story.dto';
 import { BadgeProgressEngine } from '../achievement-progress/badge-progress.engine';
 
 @Injectable()
@@ -73,11 +73,12 @@ export class ReportsService {
   /**
    * Record a question answer
    */
-  async recordAnswer(dto: QuestionAnswerDto) {
+  async recordAnswer(dto: SubmitQuestionAnswerDto, userId: string) {
     const question = await this.prisma.storyQuestion.findUnique({
       where: { id: dto.questionId },
       select: {
         id: true,
+        storyId: true,
         options: true,
         correctOption: true,
       },
@@ -85,6 +86,10 @@ export class ReportsService {
 
     if (!question) {
       throw new BadRequestException('Question not found');
+    }
+
+    if (question.storyId !== dto.storyId) {
+      throw new BadRequestException('Question does not belong to this story');
     }
 
     if (
@@ -96,9 +101,40 @@ export class ReportsService {
 
     const isCorrect = question.correctOption === dto.selectedOption;
 
+    // Check for existing answer to prevent duplicates
+    const existing = await this.prisma.questionAnswer.findFirst({
+      where: {
+        userId,
+        questionId: dto.questionId,
+        isDeleted: false,
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      // Update existing answer instead of creating duplicate
+      const answer = await this.prisma.questionAnswer.update({
+        where: { id: existing.id },
+        data: {
+          selectedOption: dto.selectedOption,
+          isCorrect,
+          answeredAt: new Date(),
+        },
+        select: {
+          id: true,
+          isCorrect: true,
+        },
+      });
+
+      return {
+        answerId: answer.id,
+        isCorrect,
+      };
+    }
+
     const answer = await this.prisma.questionAnswer.create({
       data: {
-        kidId: dto.kidId,
+        userId,
         questionId: dto.questionId,
         storyId: dto.storyId,
         selectedOption: dto.selectedOption,
@@ -110,20 +146,12 @@ export class ReportsService {
       },
     });
 
-    // Trigger badge progress for quiz answered
-    const kid = await this.prisma.kid.findUnique({
-      where: { id: dto.kidId },
-      select: { parentId: true },
-    });
-
-    if (kid?.parentId) {
-      await this.badgeProgressEngine.recordActivity(
-        kid.parentId,
-        'quiz_answered',
-        dto.kidId,
-        { questionId: dto.questionId, isCorrect },
-      );
-    }
+    await this.badgeProgressEngine.recordActivity(
+      userId,
+      'quiz_answered',
+      undefined,
+      { questionId: dto.questionId, isCorrect },
+    );
 
     return {
       answerId: answer.id,
@@ -478,6 +506,8 @@ export class ReportsService {
     });
 
     // Quiz performance this week
+    // TODO: Also query by userId (via kid.parentId) once kid profiles are implemented.
+    // Currently, interactive mode answers are recorded against userId, not kidId.
     const answers = await this.prisma.questionAnswer.findMany({
       where: {
         kidId,

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -101,51 +101,30 @@ export class ReportsService {
 
     const isCorrect = question.correctOption === dto.selectedOption;
 
-    // Check for existing answer to prevent duplicates
-    const existing = await this.prisma.questionAnswer.findFirst({
+    const answer = await this.prisma.questionAnswer.upsert({
       where: {
-        userId,
-        questionId: dto.questionId,
+        userId_questionId_unique: {
+          userId,
+          questionId: dto.questionId,
+        },
+      },
+      update: {
+        selectedOption: dto.selectedOption,
+        isCorrect,
+        answeredAt: new Date(),
         isDeleted: false,
       },
-      select: { id: true },
-    });
-
-    if (existing) {
-      // Update existing answer instead of creating duplicate
-      const answer = await this.prisma.questionAnswer.update({
-        where: { id: existing.id },
-        data: {
-          selectedOption: dto.selectedOption,
-          isCorrect,
-          answeredAt: new Date(),
-        },
-        select: {
-          id: true,
-          isCorrect: true,
-        },
-      });
-
-      return {
-        answerId: answer.id,
-        isCorrect,
-      };
-    }
-
-    const answer = await this.prisma.questionAnswer.create({
-      data: {
+      create: {
         userId,
         questionId: dto.questionId,
         storyId: dto.storyId,
         selectedOption: dto.selectedOption,
         isCorrect,
       },
-      select: {
-        id: true,
-        isCorrect: true,
-      },
+      select: { id: true, isCorrect: true },
     });
 
+    // Badge progress is idempotent — safe to call on both create and update
     await this.badgeProgressEngine.recordActivity(
       userId,
       'quiz_answered',
@@ -153,10 +132,7 @@ export class ReportsService {
       { questionId: dto.questionId, isCorrect },
     );
 
-    return {
-      answerId: answer.id,
-      isCorrect,
-    };
+    return { answerId: answer.id, isCorrect };
   }
 
   /**

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -101,6 +101,17 @@ export class ReportsService {
 
     const isCorrect = question.correctOption === dto.selectedOption;
 
+    // Check existence before upsert to know if this is a new answer
+    const existing = await this.prisma.questionAnswer.findUnique({
+      where: {
+        userId_questionId_unique: {
+          userId,
+          questionId: dto.questionId,
+        },
+      },
+      select: { id: true },
+    });
+
     const answer = await this.prisma.questionAnswer.upsert({
       where: {
         userId_questionId_unique: {
@@ -124,13 +135,15 @@ export class ReportsService {
       select: { id: true, isCorrect: true },
     });
 
-    // Badge progress is idempotent — safe to call on both create and update
-    await this.badgeProgressEngine.recordActivity(
-      userId,
-      'quiz_answered',
-      undefined,
-      { questionId: dto.questionId, isCorrect },
-    );
+    // Only record badge progress for new answers to avoid inflating counts
+    if (!existing) {
+      await this.badgeProgressEngine.recordActivity(
+        userId,
+        'quiz_answered',
+        undefined,
+        { questionId: dto.questionId, isCorrect },
+      );
+    }
 
     return { answerId: answer.id, isCorrect };
   }


### PR DESCRIPTION
## Description

Backend changes to support interactive story mode. Makes `kidId` optional on `QuestionAnswer`, adds `userId` field, and updates `POST /reports/answer` to use `AuthSessionGuard` with `SubmitQuestionAnswerDto`. Answers are now recorded against the authenticated user's `userId` instead of requiring a `kidId`.

**Companion mobile PR**: https://github.com/Bolt-Silverfox/storytime-mobile/pull/203

## Type of change

- [x] New feature

## How Has This Been Tested?

- [x] Local development
- [x] `pnpm lint` and `pnpm format` clean
- [x] `pnpm test` passes (no reports-related failures)

**Manual verification plan:**
1. `npx prisma migrate dev` succeeds
2. `POST /reports/answer` with `{ questionId, storyId, selectedOption }` + auth token → records answer with userId

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Changes

| File | Change |
|------|--------|
| `prisma/schema.prisma` | Make `kidId` optional, add `userId` + relation + index on `QuestionAnswer`; add `questionAnswers` to `User` |
| `prisma/migrations/...` | Migration: make-question-answer-kid-optional |
| `src/reports/reports.controller.ts` | Use `SubmitQuestionAnswerDto` + `AuthSessionGuard`, extract `userId` from JWT |
| `src/reports/reports.service.ts` | Validate storyId, prevent duplicate answers via upsert, use `userId` for badge progress |

## Additional context

- **Kid profiles skipped** — `kidId` optional, answers recorded against `userId`. TODO added for future kid profile integration.
- **Duplicate prevention**: `findFirst` by `(userId, questionId)` → update existing if found, else create.
- **storyId validation**: Verifies `question.storyId === dto.storyId` to prevent cross-story answer injection.
- Badge progress uses `userId` directly instead of `kid.parentId` lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-based quiz answer tracking replaces kid-only approach; answers now optionally link to a user.
  * Webhook event storage added for platform integrations with relevant indexes.

* **Bug Fixes**
  * Ownership/consistency validation to ensure answers belong to the same story.
  * Enforced uniqueness for user+question answers; added check to require either kid or user on answers.

* **Security**
  * Authentication required for recording quiz answers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->