### PR TITLE
fix: restore process error handlers and enable shutdown hooks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,18 @@ import { requestLogger } from './shared/middleware/request-logger.middleware';
 
 async function bootstrap() {
   const logger = new Logger('Main');
+
+  process.on('unhandledRejection', (reason) => {
+    logger.error('Unhandled Rejection', reason);
+    // Exit to avoid running in a potentially corrupt state
+    setTimeout(() => process.exit(1), 1000);
+  });
+
+  process.on('uncaughtException', (error) => {
+    logger.error('Uncaught Exception', error);
+    process.exit(1);
+  });
+
   const app = await NestFactory.create(AppModule, {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });
@@ -98,6 +110,9 @@ async function bootstrap() {
       persistAuthorization: true,
     },
   });
+
+  // Graceful shutdown
+  app.enableShutdownHooks();
 
   // ==========================================================
   // 6. START APPLICATION


### PR DESCRIPTION
# Pull Request

## Description

Restores process-level error handlers that were lost during the `develop-v1.0.0` → `develop-v1.1.0` branch migration.

**Changes to `src/main.ts`:**
- `process.on('unhandledRejection')` — logs and exits after 1s delay (prevents running in corrupt state)
- `process.on('uncaughtException')` — logs and exits immediately
- `app.enableShutdownHooks()` — ensures NestJS `OnModuleDestroy` lifecycle hooks fire on SIGTERM/SIGINT (Prisma disconnect, Redis cleanup, SSE interval teardown)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [x] Other (describe): ESLint (0 errors), Prettier, TypeScript type-check

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional context

These handlers existed in `develop-v1.0.0` (commit `a25a607`) but were dropped when `develop-v1.1.0` was cut. Without them, unhandled errors crash silently and container signals don't trigger graceful shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application error handling and logging for unhandled exceptions and rejections.
  * Improved graceful shutdown process for better application lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->