### PR TITLE
feat: add OptionalAuth decorator and public story endpoints for guest mode

### DIFF
--- a/src/shared/decorators/optional-auth.decorator.ts
+++ b/src/shared/decorators/optional-auth.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_OPTIONAL_AUTH_KEY = 'isOptionalAuth';
+export const OptionalAuth = () => SetMetadata(IS_OPTIONAL_AUTH_KEY, true);

--- a/src/shared/guards/auth.guard.ts
+++ b/src/shared/guards/auth.guard.ts
@@ -9,6 +9,7 @@ import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { JwtService } from '@nestjs/jwt';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { IS_OPTIONAL_AUTH_KEY } from '../decorators/optional-auth.decorator';
 import { PrismaService } from '@/prisma/prisma.service';
 
 export interface JwtPayload {
@@ -43,7 +44,22 @@ export class AuthSessionGuard implements CanActivate {
       return true;
     }
 
+    const isOptionalAuth = this.reflector.getAllAndOverride<boolean>(
+      IS_OPTIONAL_AUTH_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
     const request = context.switchToHttp().getRequest<Request>();
+
+    if (isOptionalAuth) {
+      try {
+        await this.validateRequest(request);
+      } catch {
+        // Optional auth: allow through without user data
+      }
+      return true;
+    }
+
     return this.validateRequest(request);
   }
 

--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -236,8 +236,7 @@ export class StoryController {
     }
 
     const authenticatedUserId = req.authUserData?.userId;
-    const resolvedKidId =
-      kidId && authenticatedUserId ? kidId : undefined;
+    const resolvedKidId = kidId && authenticatedUserId ? kidId : undefined;
 
     if (resolvedKidId && authenticatedUserId) {
       await this.verifyKidOwnership(resolvedKidId, authenticatedUserId);

--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -81,6 +81,8 @@ import {
 } from '@/shared/constants/cache-keys.constants';
 import { StoryQuotaService } from './story-quota.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
+import { Public } from '@/shared/decorators/public.decorator';
 
 @ApiTags('stories')
 @UseGuards(AuthSessionGuard)
@@ -185,6 +187,7 @@ export class StoryController {
     description: 'Not Found',
     type: ErrorResponseDto,
   })
+  @OptionalAuth()
   @Throttle({
     long: { limit: THROTTLE_LIMITS.LONG.LIMIT, ttl: THROTTLE_LIMITS.LONG.TTL },
   }) // 100 per minute
@@ -232,12 +235,12 @@ export class StoryController {
       throw new BadRequestException('maxAge must be a non-negative number');
     }
 
-    if (kidId) {
+    if (kidId && req.authUserData?.userId) {
       await this.verifyKidOwnership(kidId, req.authUserData.userId);
     }
 
     const baseFilter = {
-      userId: req.authUserData.userId,
+      userId: req.authUserData?.userId,
       theme,
       category,
       season,
@@ -292,6 +295,7 @@ export class StoryController {
   }
 
   @Get('homepage/parent')
+  @OptionalAuth()
   @ApiOperation({
     summary: 'Get parent homepage stories (Recommended, Seasonal, Top Liked)',
   })
@@ -315,7 +319,7 @@ export class StoryController {
     const safeLimitSeasonal = Math.max(1, Math.min(limitSeasonal, 50));
     const safeLimitTopLiked = Math.max(1, Math.min(limitTopLiked, 50));
     return this.storyService.getHomePageStories(
-      req.authUserData.userId,
+      req.authUserData?.userId,
       safeLimitRecommended,
       safeLimitSeasonal,
       safeLimitTopLiked,
@@ -323,6 +327,7 @@ export class StoryController {
   }
 
   @Get('categories')
+  @Public()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('categories:all')
   @CacheTTL(4 * 60 * 60 * 1000)
@@ -352,6 +357,7 @@ export class StoryController {
   }
 
   @Get('themes')
+  @Public()
   @ApiOperation({ summary: 'Get all themes' })
   @ApiOkResponse({
     description: 'List of themes',
@@ -378,6 +384,7 @@ export class StoryController {
   }
 
   @Get('seasons')
+  @Public()
   @ApiOperation({ summary: 'Get all seasons' })
   @ApiOkResponse({
     description: 'List of seasons',
@@ -1224,6 +1231,7 @@ export class StoryController {
   }
 
   @Get(':id')
+  @OptionalAuth()
   @UseGuards(StoryAccessGuard)
   @CheckStoryQuota()
   @ApiOperation({ summary: 'Get a story by id' })

--- a/src/story/story.controller.ts
+++ b/src/story/story.controller.ts
@@ -235,17 +235,21 @@ export class StoryController {
       throw new BadRequestException('maxAge must be a non-negative number');
     }
 
-    if (kidId && req.authUserData?.userId) {
-      await this.verifyKidOwnership(kidId, req.authUserData.userId);
+    const authenticatedUserId = req.authUserData?.userId;
+    const resolvedKidId =
+      kidId && authenticatedUserId ? kidId : undefined;
+
+    if (resolvedKidId && authenticatedUserId) {
+      await this.verifyKidOwnership(resolvedKidId, authenticatedUserId);
     }
 
     const baseFilter = {
-      userId: req.authUserData?.userId,
+      userId: authenticatedUserId,
       theme,
       category,
       season,
       isSeasonal: isSeasonal === 'true',
-      kidId,
+      kidId: resolvedKidId,
       age: parsedAge,
       minAge: parsedMinAge,
       maxAge: parsedMaxAge,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -281,7 +281,7 @@ export class StoryService {
   }
 
   async getStories(filter: {
-    userId: string;
+    userId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -371,10 +371,9 @@ export class StoryService {
     ]);
 
     const totalPages = Math.ceil(totalCount / limit);
-    const enrichedStories = await this.enrichWithReadStatus(
-      filter.userId,
-      stories,
-    );
+    const enrichedStories = filter.userId
+      ? await this.enrichWithReadStatus(filter.userId, stories)
+      : stories.map((s) => ({ ...s, readStatus: null }));
 
     let sortedStories = this.sortByReadStatus(enrichedStories, {
       shuffleUnseen: shouldShuffle,
@@ -420,7 +419,7 @@ export class StoryService {
   }
 
   async getStoriesCursor(filter: {
-    userId: string;
+    userId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -458,7 +457,9 @@ export class StoryService {
       stories,
       limit,
     );
-    const enriched = await this.enrichWithReadStatus(filter.userId, data);
+    const enriched = filter.userId
+      ? await this.enrichWithReadStatus(filter.userId, data)
+      : data.map((s) => ({ ...s, readStatus: null }));
 
     return { data: this.sortByReadStatus(enriched), pagination };
   }
@@ -621,30 +622,33 @@ export class StoryService {
   }
 
   async getHomePageStories(
-    userId: string,
+    userId: string | undefined,
     limitRecommended: number = 5,
     limitSeasonal: number = 5,
     limitTopLiked: number = 5,
   ) {
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId, isDeleted: false },
-      include: { preferredCategories: true },
-    });
+    const user = userId
+      ? await this.prisma.user.findUnique({
+          where: { id: userId, isDeleted: false },
+          include: { preferredCategories: true },
+        })
+      : null;
 
-    if (!user) {
+    if (userId && !user) {
       throw new NotFoundException('User not found');
     }
 
     // 1. Recommended Stories (based on preferred categories)
     let recommended: Awaited<ReturnType<typeof this.prisma.story.findMany>> =
       [];
-    if (user.preferredCategories.length > 0) {
+    const preferredCategories = user?.preferredCategories ?? [];
+    if (preferredCategories.length > 0) {
       recommended = await this.prisma.story.findMany({
         where: {
           isDeleted: false,
           categories: {
             some: {
-              id: { in: user.preferredCategories.map((c: Category) => c.id) },
+              id: { in: preferredCategories.map((c: Category) => c.id) },
             },
           },
         },
@@ -721,7 +725,9 @@ export class StoryService {
 
     // Enrich all stories with readStatus in a single DB query
     const allStories = [...recommended, ...seasonal, ...topLiked];
-    const enriched = await this.enrichWithReadStatus(userId, allStories);
+    const enriched = userId
+      ? await this.enrichWithReadStatus(userId, allStories)
+      : allStories.map((s) => ({ ...s, readStatus: null }));
 
     const recLen = recommended.length;
     const seaLen = seasonal.length;


### PR DESCRIPTION
# Pull Request

## Description

Enables guest mode by making story browsing endpoints accessible without authentication. Companion to mobile PR storytime-mobile#210.

### Changes:
- **`@OptionalAuth()` decorator**: New decorator that attempts auth but allows through if no token present (sets `authUserData` to undefined)
- **AuthSessionGuard**: Updated to support `isOptionalAuth` metadata — tries to validate, catches failure silently
- **Story controller**: Added `@OptionalAuth()` to `GET /stories`, `GET /stories/homepage/parent`, `GET /stories/:id`; added `@Public()` to `GET /stories/categories`, `GET /stories/themes`, `GET /stories/seasons`
- **Story service**: `getStories()`, `getStoriesCursor()`, `getHomePageStories()` accept optional `userId` — skip `enrichWithReadStatus()` when absent, use fallback recommendations

### Security:
- Only read-only browsing endpoints are affected — all write/mutation/payment endpoints remain fully authenticated
- StoryAccessGuard already handles missing userId gracefully (skips quota check)
- IP-based throttling still applies to unauthenticated requests

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Local development
- [x] Other (describe): ESLint (0 errors), TypeScript type-check

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story endpoints (list, homepage, details) now support optional authentication—accessible to all users while providing personalized data when logged in.
  * Story metadata endpoints (categories, themes, seasons) are publicly accessible without authentication.

* **Bug Fixes / Improvements**
  * Stories and homepage now safely handle unauthenticated requests, returning neutral read-status and avoiding authentication errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->