### PR TITLE
fix: use DIRECT_DATABASE_URL for Prisma operations

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -315,7 +315,7 @@ jobs:
         run: pnpm db:generate && pnpm build
 
       - name: Run database migrations
-        run: pnpm db:migrate:deploy
+        run: DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL }}" pnpm db:migrate:deploy
 
       - name: Seed database
         run: pnpm db:seed

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -315,7 +315,7 @@ jobs:
         run: pnpm db:generate && pnpm build
 
       - name: Run database migrations
-        run: DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL }}" pnpm db:migrate:deploy
+        run: pnpm db:migrate:deploy
 
       - name: Seed database
         run: pnpm db:seed

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -307,7 +307,7 @@ jobs:
         run: pnpm db:migrate:deploy
 
       - name: Seed database
-        run: pnpm db:seed
+        run: DIRECT_DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL }}" pnpm db:seed
 
       - name: Prepare deployment directory
         uses: appleboy/ssh-action@v1.0.3

--- a/prisma/prisma.config.ts
+++ b/prisma/prisma.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     seed: 'npx ts-node prisma/seeds/index.ts',
   },
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL'),
   },
 });

--- a/prisma/seeds/index.ts
+++ b/prisma/seeds/index.ts
@@ -13,7 +13,11 @@ import { seedStoryBuddies } from './story-buddies.seed';
 import { seedStories } from './stories.seed';
 
 if (!process.env.DIRECT_DATABASE_URL) {
-  throw new Error('DIRECT_DATABASE_URL environment variable is required for seeding');
+if (!process.env.DIRECT_DATABASE_URL) {
+  throw new Error(
+    'DIRECT_DATABASE_URL environment variable is required for seeding',
+  );
+}
 }
 
 const prisma = new PrismaClient({

--- a/prisma/seeds/index.ts
+++ b/prisma/seeds/index.ts
@@ -12,7 +12,9 @@ import { seedAvatars } from './avatars.seed';
 import { seedStoryBuddies } from './story-buddies.seed';
 import { seedStories } from './stories.seed';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+});
 
 /**
  * Main seed orchestrator

--- a/prisma/seeds/index.ts
+++ b/prisma/seeds/index.ts
@@ -12,6 +12,10 @@ import { seedAvatars } from './avatars.seed';
 import { seedStoryBuddies } from './story-buddies.seed';
 import { seedStories } from './stories.seed';
 
+if (!process.env.DIRECT_DATABASE_URL) {
+  throw new Error('DIRECT_DATABASE_URL environment variable is required for seeding');
+}
+
 const prisma = new PrismaClient({
   datasourceUrl: process.env.DIRECT_DATABASE_URL,
 });

--- a/prisma/seeds/migrate-pollinations-to-cloudinary.ts
+++ b/prisma/seeds/migrate-pollinations-to-cloudinary.ts
@@ -9,13 +9,14 @@
  *   npx ts-node prisma/seeds/migrate-pollinations-to-cloudinary.ts
  *
  * Requires these env vars (from .env):
- *   HF_TOKEN, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
+ *   DIRECT_DATABASE_URL, HF_TOKEN, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
  */
 import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { v2 as cloudinary } from 'cloudinary';
 
 const requiredEnvVars = [
+  'DIRECT_DATABASE_URL',
   'HF_TOKEN',
   'CLOUDINARY_CLOUD_NAME',
   'CLOUDINARY_API_KEY',

--- a/prisma/seeds/migrate-pollinations-to-cloudinary.ts
+++ b/prisma/seeds/migrate-pollinations-to-cloudinary.ts
@@ -36,7 +36,9 @@ cloudinary.config({
   secure: true,
 });
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+});
 
 const HF_API_URL =
   'https://router.huggingface.co/hf-inference/models/black-forest-labs/FLUX.1-schnell';

--- a/prisma/seeds/prod-content-reset.seed.ts
+++ b/prisma/seeds/prod-content-reset.seed.ts
@@ -112,7 +112,9 @@ export async function prodContentReset(prisma: PrismaClient) {
 
 // Allow running directly if main module
 if (require.main === module) {
-  const prisma = new PrismaClient();
+  const prisma = new PrismaClient({
+    datasourceUrl: process.env.DIRECT_DATABASE_URL,
+  });
   prodContentReset(prisma)
     .catch((e) => {
       console.error(e);

--- a/prisma/seeds/prod-content-reset.seed.ts
+++ b/prisma/seeds/prod-content-reset.seed.ts
@@ -112,6 +112,10 @@ export async function prodContentReset(prisma: PrismaClient) {
 
 // Allow running directly if main module
 if (require.main === module) {
+  if (!process.env.DIRECT_DATABASE_URL) {
+    console.error('DIRECT_DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
   const prisma = new PrismaClient({
     datasourceUrl: process.env.DIRECT_DATABASE_URL,
   });

--- a/prisma/seeds/seed-notifications.ts
+++ b/prisma/seeds/seed-notifications.ts
@@ -9,6 +9,10 @@
  */
 import { PrismaClient, NotificationCategory } from '@prisma/client';
 
+if (!process.env.DIRECT_DATABASE_URL) {
+  throw new Error('DIRECT_DATABASE_URL environment variable is required for seeding');
+}
+
 const prisma = new PrismaClient({
   datasourceUrl: process.env.DIRECT_DATABASE_URL,
 });

--- a/prisma/seeds/seed-notifications.ts
+++ b/prisma/seeds/seed-notifications.ts
@@ -10,7 +10,9 @@
 import { PrismaClient, NotificationCategory } from '@prisma/client';
 
 if (!process.env.DIRECT_DATABASE_URL) {
-  throw new Error('DIRECT_DATABASE_URL environment variable is required for seeding');
+  throw new Error(
+    'DIRECT_DATABASE_URL environment variable is required for seeding',
+  );
 }
 
 const prisma = new PrismaClient({

--- a/prisma/seeds/seed-notifications.ts
+++ b/prisma/seeds/seed-notifications.ts
@@ -9,7 +9,9 @@
  */
 import { PrismaClient, NotificationCategory } from '@prisma/client';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+});
 
 const testNotifications = [
   {

--- a/prisma/seeds/stories.seed.ts
+++ b/prisma/seeds/stories.seed.ts
@@ -96,7 +96,7 @@ export async function seedStories(ctx: SeedContext): Promise<SeedResult> {
       let fileSkipped = 0;
 
       // Batch stories into chunks to avoid transaction timeouts on large files
-      const BATCH_SIZE = 50;
+      const BATCH_SIZE = 10;
       for (let i = 0; i < stories.length; i += BATCH_SIZE) {
         const batch = stories.slice(i, i + BATCH_SIZE);
         const batchNum = Math.floor(i / BATCH_SIZE) + 1;
@@ -206,7 +206,7 @@ export async function seedStories(ctx: SeedContext): Promise<SeedResult> {
               batchCount++;
             }
           },
-          { timeout: 60_000 },
+          { timeout: 120_000 },
         );
 
         // Batch succeeded — update global tracking

--- a/src/story-buddy/story-buddy.seeder.ts
+++ b/src/story-buddy/story-buddy.seeder.ts
@@ -2,6 +2,12 @@ import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 import { storyBuddiesData } from '../../prisma/data';
 
+if (!process.env.DIRECT_DATABASE_URL) {
+  throw new Error(
+    'DIRECT_DATABASE_URL environment variable is required for story buddy seeding',
+  );
+}
+
 const prisma = new PrismaClient({
   datasourceUrl: process.env.DIRECT_DATABASE_URL,
 });

--- a/src/story-buddy/story-buddy.seeder.ts
+++ b/src/story-buddy/story-buddy.seeder.ts
@@ -2,7 +2,9 @@ import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 import { storyBuddiesData } from '../../prisma/data';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+});
 
 @Injectable()
 export class StoryBuddySeederService implements OnModuleInit {


### PR DESCRIPTION
# Pull Request

## Description
Fix Prisma seeding failures caused by transaction timeouts when using Prisma Accelerate. The issue was that seed operations were using the Accelerate connection which has a 15-second timeout limit for interactive transactions.

Changes:
- Use DIRECT_DATABASE_URL for database migrations in dev-deploy workflow
- Configure PrismaClient to use DIRECT_DATABASE_URL in all seed files
- Reduce story batch size from 50 to 10 to avoid transaction timeouts
- Increase transaction timeout from 60s to 120s for story seeding

Fixes #

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched seeding and local/CI database connectivity to use an explicit environment variable and updated deployment to pass it through.
  * Seed scripts now enforce that the required database connection variable is present and will error early if missing.
  * Reduced per-batch seed size and increased transaction timeout to improve reliability of seeding operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->