### PR TITLE
fix: guest feature audit fixes

### DIFF
--- a/src/guest/dto/guest.dto.ts
+++ b/src/guest/dto/guest.dto.ts
@@ -1,17 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-
-export type ReadStatus = 'done' | 'reading';
 import {
   IsNotEmpty,
   IsNumber,
   IsString,
   Max,
   Min,
-  IsOptional,
-  IsBoolean,
-  IsArray,
-  IsDate,
 } from 'class-validator';
+
+export type ReadStatus = 'done' | 'reading';
 
 export class UpdateGuestProgressDto {
   @ApiProperty({ description: 'Story ID' })
@@ -37,6 +33,20 @@ export class CreateGuestSessionResponseDto {
   expiresIn: number;
 }
 
+export class GuestStoryCategoryDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  description?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  image?: string | null;
+}
+
 export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Story ID' })
   storyId: string;
@@ -56,7 +66,7 @@ export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Story age min' })
   ageMin: number;
 
-  @ApiProperty({ description: 'Story duration in seconds' })
+  @ApiProperty({ description: 'Story duration in seconds', nullable: true })
   durationSeconds: number | null;
 
   @ApiProperty({ description: 'Story created at' })
@@ -65,13 +75,8 @@ export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Story updated at' })
   updatedAt: Date;
 
-  @ApiProperty({ description: 'Story categories' })
-  categories: Array<{
-    id: string;
-    name: string;
-    image: string | null;
-    description: string | null;
-  }>;
+  @ApiProperty({ description: 'Story categories', type: [GuestStoryCategoryDto] })
+  categories: GuestStoryCategoryDto[];
 
   @ApiProperty({ description: 'Reading progress percentage' })
   progress: number;
@@ -82,7 +87,7 @@ export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Total time spent reading' })
   totalTimeSpent: number;
 
-  @ApiProperty({ description: 'Read status: done, reading, or null' })
+  @ApiProperty({ description: 'Read status: done, reading, or null', nullable: true, enum: ['done', 'reading'] })
   readStatus: ReadStatus | null;
 }
 
@@ -96,172 +101,112 @@ export class GuestHistoryResponseDto {
 
 export class GuestStoryImageDto {
   @ApiProperty()
-  @IsString()
   url: string;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   caption?: string | null;
 }
 
 export class GuestStoryBranchDto {
   @ApiProperty()
-  @IsString()
   prompt: string;
 
   @ApiProperty()
-  @IsString()
   optionA: string;
 
   @ApiProperty()
-  @IsString()
   optionB: string;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   nextA?: string | null;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   nextB?: string | null;
-}
-
-export class GuestStoryCategoryDto {
-  @ApiProperty()
-  @IsString()
-  id: string;
-
-  @ApiProperty()
-  @IsString()
-  name: string;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
-  description?: string | null;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
-  image?: string | null;
 }
 
 export class GuestStoryThemeDto {
   @ApiProperty()
-  @IsString()
   id: string;
 
   @ApiProperty()
-  @IsString()
   name: string;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   description?: string | null;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   image?: string | null;
 }
 
 export class GuestStoryResponseDto {
   @ApiProperty()
-  @IsString()
   id: string;
 
   @ApiProperty()
-  @IsString()
   title: string;
 
   @ApiProperty()
-  @IsString()
   description: string;
 
   @ApiProperty()
-  @IsString()
   language: string;
 
   @ApiProperty({ type: [GuestStoryCategoryDto] })
-  @IsArray()
   categories: GuestStoryCategoryDto[];
 
   @ApiProperty({ type: [GuestStoryThemeDto] })
-  @IsArray()
   themes: GuestStoryThemeDto[];
 
   @ApiProperty({ type: [String], required: false })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
   seasonIds?: string[];
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   coverImageUrl?: string | null;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   audioUrl?: string | null;
 
-  @ApiProperty({ required: false })
-  @IsOptional()
+  @ApiProperty({ required: false, nullable: true })
   textContent?: string | null;
 
   @ApiProperty({ required: false })
-  @IsOptional()
-  @IsBoolean()
   isInteractive?: boolean;
 
   @ApiProperty({ required: false })
-  @IsOptional()
-  @IsNumber()
   ageMin?: number;
 
   @ApiProperty({ required: false })
-  @IsOptional()
-  @IsNumber()
   ageMax?: number;
 
   @ApiProperty({ type: [GuestStoryImageDto], required: false })
-  @IsOptional()
-  @IsArray()
   images?: GuestStoryImageDto[];
 
   @ApiProperty({ type: [GuestStoryBranchDto], required: false })
-  @IsOptional()
-  @IsArray()
   branches?: GuestStoryBranchDto[];
 
   @ApiProperty()
-  @IsDate()
   createdAt: Date;
 
   @ApiProperty()
-  @IsDate()
   updatedAt: Date;
 }
 
 export class StoryAccessCheckDto {
   @ApiProperty({ description: 'Whether the story can be accessed' })
-  @IsBoolean()
   canAccess: boolean;
 
   @ApiPropertyOptional({ description: 'Reason for denial if access is denied' })
-  @IsOptional()
-  @IsString()
   reason?: string;
 
   @ApiProperty({ description: 'Number of stories read in this session' })
-  @IsNumber()
   storiesRead: number;
 
   @ApiProperty({ description: 'Number stories remaining' })
-  @IsNumber()
   remaining: number;
 
   @ApiProperty({ description: 'Total stories allowed' })
-  @IsNumber()
   totalAllowed: number;
 
   @ApiProperty({ description: 'Whether this story has already been read' })
-  @IsBoolean()
   alreadyRead: boolean;
 }

--- a/src/guest/dto/guest.dto.ts
+++ b/src/guest/dto/guest.dto.ts
@@ -1,11 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsNotEmpty,
-  IsNumber,
-  IsString,
-  Max,
-  Min,
-} from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, Max, Min } from 'class-validator';
 
 export type ReadStatus = 'done' | 'reading';
 
@@ -75,7 +69,10 @@ export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Story updated at' })
   updatedAt: Date;
 
-  @ApiProperty({ description: 'Story categories', type: [GuestStoryCategoryDto] })
+  @ApiProperty({
+    description: 'Story categories',
+    type: [GuestStoryCategoryDto],
+  })
   categories: GuestStoryCategoryDto[];
 
   @ApiProperty({ description: 'Reading progress percentage' })
@@ -87,7 +84,11 @@ export class GuestProgressResponseDto {
   @ApiProperty({ description: 'Total time spent reading' })
   totalTimeSpent: number;
 
-  @ApiProperty({ description: 'Read status: done, reading, or null', nullable: true, enum: ['done', 'reading'] })
+  @ApiProperty({
+    description: 'Read status: done, reading, or null',
+    nullable: true,
+    enum: ['done', 'reading'],
+  })
   readStatus: ReadStatus | null;
 }
 

--- a/src/guest/guest-session.service.ts
+++ b/src/guest/guest-session.service.ts
@@ -217,9 +217,6 @@ export class GuestSessionService {
     // Validate progress is between 0 and 100
     const clampedProgress = Math.max(0, Math.min(100, progress));
 
-    // Check if this is a new story (not previously in readingHistory)
-    const isNewStory = !session.readingHistory[storyId];
-
     // Update reading history only when clampedProgress > 0
     if (clampedProgress > 0 || session.readingHistory[storyId]) {
       session.readingHistory[storyId] = {
@@ -228,10 +225,6 @@ export class GuestSessionService {
       };
     }
 
-    // If this is a new story, increment uniqueStoriesRead to keep quota in sync
-    if (isNewStory && session.readingHistory[storyId]) {
-      session.uniqueStoriesRead += 1;
-    }
     // Update last active timestamp
     session.lastActiveAt = new Date();
 

--- a/src/guest/guest.controller.ts
+++ b/src/guest/guest.controller.ts
@@ -10,6 +10,7 @@ import {
   Logger,
   Req,
   ForbiddenException,
+  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -23,7 +24,7 @@ import { Throttle } from '@nestjs/throttler';
 import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
 import { Public } from '@/shared/decorators/public.decorator';
 import {
-  AuthenticatedRequest,
+  OptionalAuthRequest,
   AuthSessionGuard,
 } from '@/shared/guards/auth.guard';
 import {
@@ -48,11 +49,20 @@ import {
 export class GuestController {
   private readonly logger = new Logger(GuestController.name);
 
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
   constructor(
     private readonly guestSessionService: GuestSessionService,
     private readonly prisma: PrismaService,
     private readonly storyService: StoryService,
   ) {}
+
+  private validateSessionId(guestSessionId: string): void {
+    if (!GuestController.UUID_REGEX.test(guestSessionId)) {
+      throw new BadRequestException('Invalid session ID format');
+    }
+  }
 
   /**
    * Create a new guest session
@@ -98,6 +108,11 @@ export class GuestController {
     type: GuestStoryResponseDto,
   })
   @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - missing or invalid x-guest-session-id header',
+  })
+  @ApiResponse({
     status: 401,
     description: 'Unauthorized - invalid or expired guest session',
   })
@@ -117,6 +132,8 @@ export class GuestController {
       throw new BadRequestException('x-guest-session-id header is required');
     }
 
+    this.validateSessionId(guestSessionId);
+
     // Validate guest session
     const session =
       await this.guestSessionService.getGuestSession(guestSessionId);
@@ -124,7 +141,7 @@ export class GuestController {
       this.logger.warn(
         `Guest session not found: ${this.guestSessionService.maskSessionId(guestSessionId)}`,
       );
-      throw new BadRequestException(
+      throw new UnauthorizedException(
         'Your guest session has expired. Please refresh the page to continue.',
       );
     }
@@ -208,6 +225,11 @@ export class GuestController {
     },
   })
   @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - missing or invalid x-guest-session-id header',
+  })
+  @ApiResponse({
     status: 401,
     description: 'Unauthorized - invalid or expired guest session',
   })
@@ -222,6 +244,8 @@ export class GuestController {
       throw new BadRequestException('x-guest-session-id header is required');
     }
 
+    this.validateSessionId(guestSessionId);
+
     const quotaStatus =
       await this.guestSessionService.getGuestQuotaStatus(guestSessionId);
 
@@ -229,7 +253,7 @@ export class GuestController {
       this.logger.warn(
         `Guest quota status not found for sessionId: ${this.guestSessionService.maskSessionId(guestSessionId)}`,
       );
-      throw new BadRequestException(
+      throw new UnauthorizedException(
         'Your guest session has expired. Please refresh the page to continue.',
       );
     }
@@ -259,8 +283,12 @@ export class GuestController {
     description:
       'Bad Request - missing guest session ID for unauthenticated users',
   })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - invalid or expired guest session',
+  })
   async updateProgress(
-    @Req() req: AuthenticatedRequest,
+    @Req() req: OptionalAuthRequest,
     @Body() dto: UpdateGuestProgressDto,
     @Headers('x-guest-session-id') guestSessionId?: string,
   ): Promise<{ success: boolean }> {
@@ -276,7 +304,10 @@ export class GuestController {
       );
     }
 
-    // Clamp progress between 0 and 100
+    if (!userId && guestSessionId) {
+      this.validateSessionId(guestSessionId);
+    }
+
     const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     if (userId) {
@@ -313,7 +344,7 @@ export class GuestController {
         this.logger.warn(
           `Failed to update guest progress for session: ${this.guestSessionService.maskSessionId(guestSessionId)}`,
         );
-        throw new BadRequestException(
+        throw new UnauthorizedException(
           'Your guest session has expired. Please refresh the page to continue.',
         );
       }
@@ -343,8 +374,17 @@ export class GuestController {
     description: 'Progress retrieved successfully',
     type: GuestProgressResponseDto,
   })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - missing guest session ID for unauthenticated users',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - invalid or expired guest session',
+  })
   async getProgress(
-    @Req() req: AuthenticatedRequest,
+    @Req() req: OptionalAuthRequest,
     @Param('storyId') storyId: string,
     @Headers('x-guest-session-id') guestSessionId?: string,
   ): Promise<GuestProgressResponseDto | null> {
@@ -354,6 +394,10 @@ export class GuestController {
       throw new BadRequestException(
         'Either authentication or x-guest-session-id header is required',
       );
+    }
+
+    if (!userId && guestSessionId) {
+      this.validateSessionId(guestSessionId);
     }
 
     let progressData: { progress: number; lastAccessed: Date } | null = null;
@@ -386,7 +430,7 @@ export class GuestController {
         await this.guestSessionService.getGuestSession(guestSessionId);
 
       if (!session) {
-        throw new BadRequestException(
+        throw new UnauthorizedException(
           'Your guest session has expired. Please refresh the page to continue.',
         );
       }
@@ -436,6 +480,7 @@ export class GuestController {
     }
 
     const isDone = progressData.progress >= 100;
+    const readStatus: ReadStatus = isDone ? 'done' : 'reading';
 
     return {
       storyId,
@@ -451,11 +496,8 @@ export class GuestController {
       progress: progressData.progress,
       lastAccessed: progressData.lastAccessed,
       totalTimeSpent: 0,
-      readStatus: (isDone ? 'done' : 'reading') as ReadStatus,
+      readStatus,
     };
-
-    // This should never be reached due to the validation above
-    return null;
   }
 
   /**
@@ -476,8 +518,17 @@ export class GuestController {
     description: 'History retrieved successfully',
     type: GuestHistoryResponseDto,
   })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - missing guest session ID for unauthenticated users',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - invalid or expired guest session',
+  })
   async getHistory(
-    @Req() req: AuthenticatedRequest,
+    @Req() req: OptionalAuthRequest,
     @Headers('x-guest-session-id') guestSessionId?: string,
   ): Promise<GuestHistoryResponseDto> {
     const userId = req.authUserData?.userId;
@@ -486,6 +537,10 @@ export class GuestController {
       throw new BadRequestException(
         'Either authentication or x-guest-session-id header is required',
       );
+    }
+
+    if (!userId && guestSessionId) {
+      this.validateSessionId(guestSessionId);
     }
 
     if (userId) {
@@ -524,6 +579,7 @@ export class GuestController {
       return {
         stories: progressRecords.map((record) => {
           const isDone = record.progress >= 100;
+          const readStatus: ReadStatus = isDone ? 'done' : 'reading';
           return {
             storyId: record.storyId,
             title: record.story.title,
@@ -538,7 +594,7 @@ export class GuestController {
             progress: record.progress,
             lastAccessed: record.lastAccessed,
             totalTimeSpent: 0,
-            readStatus: (isDone ? 'done' : 'reading') as ReadStatus,
+            readStatus,
           };
         }),
       };
@@ -548,7 +604,7 @@ export class GuestController {
         await this.guestSessionService.getGuestSession(guestSessionId);
 
       if (!session) {
-        throw new BadRequestException(
+        throw new UnauthorizedException(
           'Your guest session has expired. Please refresh the page to continue.',
         );
       }
@@ -591,6 +647,7 @@ export class GuestController {
       const storiesWithProgress = stories.map((story) => {
         const progress = history[story.id];
         const isDone = progress.progress >= 100;
+        const readStatus: ReadStatus = isDone ? 'done' : 'reading';
         return {
           storyId: story.id,
           title: story.title,
@@ -605,7 +662,7 @@ export class GuestController {
           progress: progress.progress,
           lastAccessed: progress.lastReadAt,
           totalTimeSpent: 0, // Not tracked for guests
-          readStatus: (isDone ? 'done' : 'reading') as ReadStatus,
+          readStatus,
         };
       });
 
@@ -643,6 +700,11 @@ export class GuestController {
     description: 'Access check completed',
     type: StoryAccessCheckDto,
   })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - invalid x-guest-session-id header format',
+  })
   async checkStoryAccess(
     @Param('storyId') storyId: string,
     @Headers('x-guest-session-id') guestSessionId?: string,
@@ -657,6 +719,8 @@ export class GuestController {
         alreadyRead: false,
       };
     }
+
+    this.validateSessionId(guestSessionId);
 
     const session =
       await this.guestSessionService.getGuestSession(guestSessionId);

--- a/src/guest/guest.controller.ts
+++ b/src/guest/guest.controller.ts
@@ -109,8 +109,7 @@ export class GuestController {
   })
   @ApiResponse({
     status: 400,
-    description:
-      'Bad Request - missing or invalid x-guest-session-id header',
+    description: 'Bad Request - missing or invalid x-guest-session-id header',
   })
   @ApiResponse({
     status: 401,
@@ -226,8 +225,7 @@ export class GuestController {
   })
   @ApiResponse({
     status: 400,
-    description:
-      'Bad Request - missing or invalid x-guest-session-id header',
+    description: 'Bad Request - missing or invalid x-guest-session-id header',
   })
   @ApiResponse({
     status: 401,
@@ -702,8 +700,7 @@ export class GuestController {
   })
   @ApiResponse({
     status: 400,
-    description:
-      'Bad Request - invalid x-guest-session-id header format',
+    description: 'Bad Request - invalid x-guest-session-id header format',
   })
   async checkStoryAccess(
     @Param('storyId') storyId: string,

--- a/src/shared/guards/auth.guard.ts
+++ b/src/shared/guards/auth.guard.ts
@@ -25,6 +25,10 @@ export interface AuthenticatedRequest extends Request {
   authUserData: JwtPayload;
 }
 
+export interface OptionalAuthRequest extends Request {
+  authUserData?: JwtPayload;
+}
+
 @Injectable()
 export class AuthSessionGuard implements CanActivate {
   private readonly logger = new Logger(AuthSessionGuard.name);

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -629,12 +629,13 @@ export class StoryService {
     const readingHistory = session.readingHistory;
     return stories.map((story) => {
       const progress = readingHistory[story.id];
+      const progressValue = progress?.progress;
       return {
         ...story,
         readStatus:
-          progress === undefined
+          progressValue == null
             ? null
-            : progress.progress >= 100
+            : progressValue >= 100
               ? 'done'
               : 'reading',
       };


### PR DESCRIPTION
## Summary
- Add UUID validation on `x-guest-session-id` header to prevent key-space pollution
- Use `UnauthorizedException` (401) for expired/invalid guest sessions instead of `BadRequestException` (400)
- Remove quota increment from `updateGuestProgress` — only `recordNewStoryAccess` manages quota
- Add `OptionalAuthRequest` type for `@OptionalAuth()` endpoints
- Add `nullable: true` to Swagger decorators for nullable fields
- Use `GuestStoryCategoryDto` for categories array Swagger type
- Use typed `ReadStatus` variable instead of `as` cast
- Add defensive null check in `enrichWithGuestReadStatus`
- Re-add progress clamping in controller for authenticated path
- Remove class-validator decorators from response-only DTOs

## Test plan
- [ ] `pnpm build` passes
- [ ] Guest session creation returns valid UUID
- [ ] Invalid session ID header returns 400
- [ ] Expired session returns 401 (not 400)
- [ ] Guest progress updates don't increment quota
- [ ] Swagger docs reflect nullable fields correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized unauthorized responses for missing/invalid guest sessions (401).
  * Fixed session progress handling so story-read counts and session activity update more reliably.

* **Refactor**
  * Introduced a dedicated category representation for guest stories.
  * Enforced stricter session ID validation and adjusted request typing for guest endpoints.

* **Documentation**
  * API docs updated: several fields marked nullable and progress status enum tightened to 'done'/'reading'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->