### PR TITLE
fix: cache double-wrapping and dev deploy migrations

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -315,10 +315,14 @@ jobs:
         run: pnpm db:generate && pnpm build
 
       - name: Run database migrations
+        env:
+          DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
         run: pnpm db:migrate:deploy
 
       - name: Seed database
-        run: DIRECT_DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL }}" pnpm db:seed
+        env:
+          DIRECT_DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+        run: pnpm db:seed
 
       - name: Prepare deployment directory
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
# Pull Request

## Description
Two clean fixes on top of develop-v1.1.0:

### 1. `fix(cache): avoid double-wrapping in IoredisStore`
The custom `IoredisStore` adapter was JSON-stringifying values that **Keyv had already serialized** before calling `store.set()`. This produced double-wrapped entries in Redis like:

```json
{"value":"{\"value\":[...categories],\"expires\":...}","expires":...}
```

When read back, Keyv would deserialize one layer and return the inner JSON string — causing the categories cache (and any other Redis-cached endpoint) to return **stringified data to the frontend** instead of properly deserialized objects.

The fix makes `IoredisStore` a thin pass-through, matching the canonical `@keyv/redis` adapter implementation. Keyv handles serialization on its side.

The cache key prefix is bumped from `cache:` → `cache:v2:` to invalidate any legacy double-wrapped entries written by the old code path on deploy. Otherwise stale entries would continue poisoning the new code path until their TTL expired (4 hours for categories).

### 2. `fix(ci): use DIRECT_DATABASE_URL for migrate and seed in dev deploy`
The dev `DATABASE_URL` points to the Prisma Accelerate proxy (`db.prisma.io:5432`), which **does not support migrations or direct SQL commands**. The `Run database migrations` step was failing with `P1001: Can't reach database server at db.prisma.io:5432`.

Override `DATABASE_URL` with `DIRECT_DATABASE_URL` for the migrate step, and pass `DIRECT_DATABASE_URL` via a step-level `env:` block to the seed step (cleaner than inline shell substitution, addresses CodeRabbit nitpick).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development (lint, format, build all green)
- [ ] Unit tests
- [ ] E2E tests
- [x] Other: traced full Keyv v5 → cache-manager v7 → CacheInterceptor data flow to verify fix correctness

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context
- Replaces the messy history on PR #349 (`fix/redis-connection-pooling`) — this is a clean 2-commit branch off `develop-v1.1.0`.
- Reviewed with CodeRabbit; only 2 nitpicks were raised, both addressed (step-level `env:` blocks, honest type cast).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for improved environment variable handling during database initialization processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->