### PR TITLE
refactor: Remove Prisma Accelerate dependency and switch to DATABASE_URL

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -273,7 +273,7 @@ jobs:
       name: production
       url: ${{ vars.PROD_APP_URL }}
     env:
-      DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -275,7 +275,7 @@ jobs:
       name: development
       url: ${{ vars.DEV_APP_URL }}
     env:
-      DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout
@@ -316,12 +316,12 @@ jobs:
 
       - name: Run database migrations
         env:
-          DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm db:migrate:deploy
 
       - name: Seed database
         env:
-          DIRECT_DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm db:seed
 
       - name: Prepare deployment directory

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -264,7 +264,7 @@ jobs:
       name: staging
       url: ${{ vars.STAGING_APP_URL }}
     env:
-      DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout
@@ -307,7 +307,7 @@ jobs:
         run: pnpm db:migrate:deploy
 
       - name: Seed database
-        run: DIRECT_DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL }}" pnpm db:seed
+        run: DATABASE_URL="${{ secrets.DATABASE_URL }}" pnpm db:seed
 
       - name: Prepare deployment directory
         uses: appleboy/ssh-action@v1.0.3

--- a/prisma/prisma.config.ts
+++ b/prisma/prisma.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     seed: 'npx ts-node prisma/seeds/index.ts',
   },
   datasource: {
-    url: env('DIRECT_DATABASE_URL'),
+    url: env('DATABASE_URL'),
   },
 });

--- a/prisma/seeds/index.ts
+++ b/prisma/seeds/index.ts
@@ -12,16 +12,14 @@ import { seedAvatars } from './avatars.seed';
 import { seedStoryBuddies } from './story-buddies.seed';
 import { seedStories } from './stories.seed';
 
-if (!process.env.DIRECT_DATABASE_URL) {
-if (!process.env.DIRECT_DATABASE_URL) {
+if (!process.env.DATABASE_URL) {
   throw new Error(
-    'DIRECT_DATABASE_URL environment variable is required for seeding',
+    'DATABASE_URL environment variable is required for seeding',
   );
-}
 }
 
 const prisma = new PrismaClient({
-  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+  datasourceUrl: process.env.DATABASE_URL,
 });
 
 /**

--- a/prisma/seeds/migrate-pollinations-to-cloudinary.ts
+++ b/prisma/seeds/migrate-pollinations-to-cloudinary.ts
@@ -9,14 +9,14 @@
  *   npx ts-node prisma/seeds/migrate-pollinations-to-cloudinary.ts
  *
  * Requires these env vars (from .env):
- *   DIRECT_DATABASE_URL, HF_TOKEN, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
+ *   DATABASE_URL, HF_TOKEN, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
  */
 import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import { v2 as cloudinary } from 'cloudinary';
 
 const requiredEnvVars = [
-  'DIRECT_DATABASE_URL',
+  'DATABASE_URL',
   'HF_TOKEN',
   'CLOUDINARY_CLOUD_NAME',
   'CLOUDINARY_API_KEY',
@@ -38,7 +38,7 @@ cloudinary.config({
 });
 
 const prisma = new PrismaClient({
-  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+  datasourceUrl: process.env.DATABASE_URL,
 });
 
 const HF_API_URL =

--- a/prisma/seeds/prod-content-reset.seed.ts
+++ b/prisma/seeds/prod-content-reset.seed.ts
@@ -112,12 +112,12 @@ export async function prodContentReset(prisma: PrismaClient) {
 
 // Allow running directly if main module
 if (require.main === module) {
-  if (!process.env.DIRECT_DATABASE_URL) {
-    console.error('DIRECT_DATABASE_URL environment variable is required');
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL environment variable is required');
     process.exit(1);
   }
   const prisma = new PrismaClient({
-    datasourceUrl: process.env.DIRECT_DATABASE_URL,
+    datasourceUrl: process.env.DATABASE_URL,
   });
   prodContentReset(prisma)
     .catch((e) => {

--- a/prisma/seeds/seed-notifications.ts
+++ b/prisma/seeds/seed-notifications.ts
@@ -9,14 +9,14 @@
  */
 import { PrismaClient, NotificationCategory } from '@prisma/client';
 
-if (!process.env.DIRECT_DATABASE_URL) {
+if (!process.env.DATABASE_URL) {
   throw new Error(
-    'DIRECT_DATABASE_URL environment variable is required for seeding',
+    'DATABASE_URL environment variable is required for seeding',
   );
 }
 
 const prisma = new PrismaClient({
-  datasourceUrl: process.env.DIRECT_DATABASE_URL,
+  datasourceUrl: process.env.DATABASE_URL,
 });
 
 const testNotifications = [

--- a/src/story-buddy/story-buddy.seeder.ts
+++ b/src/story-buddy/story-buddy.seeder.ts
@@ -12,9 +12,7 @@ export class StoryBuddySeederService implements OnModuleInit {
 
     const url = process.env.DATABASE_URL;
     if (!url) {
-      this.logger.warn(
-        'DATABASE_URL not set — skipping story buddy seeding',
-      );
+      this.logger.warn('DATABASE_URL not set — skipping story buddy seeding');
       return null;
     }
 

--- a/src/story-buddy/story-buddy.seeder.ts
+++ b/src/story-buddy/story-buddy.seeder.ts
@@ -10,10 +10,10 @@ export class StoryBuddySeederService implements OnModuleInit {
   private getPrisma(): PrismaClient | null {
     if (this.prisma) return this.prisma;
 
-    const url = process.env.DIRECT_DATABASE_URL;
+    const url = process.env.DATABASE_URL;
     if (!url) {
       this.logger.warn(
-        'DIRECT_DATABASE_URL not set — skipping story buddy seeding',
+        'DATABASE_URL not set — skipping story buddy seeding',
       );
       return null;
     }


### PR DESCRIPTION
## Summary
Removes the Prisma Accelerate dependency and switches all database connections to use the standard `DATABASE_URL` environment variable.

## Changes
- Updated `prisma/prisma.config.ts` to use `DATABASE_URL` instead of `DIRECT_DATABASE_URL`
- Updated all seed scripts to use `DATABASE_URL`
- Updated GitHub Actions workflows to use `DATABASE_URL`

## Files Changed
- `prisma/prisma.config.ts`
- `src/story-buddy/story-buddy.seeder.ts`
- `prisma/seeds/index.ts`
- `prisma/seeds/seed-notifications.ts`
- `prisma/seeds/migrate-pollinations-to-cloudinary.ts`
- `prisma/seeds/prod-content-reset.seed.ts`
- `.github/workflows/dev-deploy.yml`
- `.github/workflows/staging-deploy.yml`
- `.github/workflows/deploy-prod.yml`

## Motivation
Prisma Accelerate pricing is too expensive for our current needs. This change allows us to use a standard PostgreSQL connection without the additional cost.

## Testing
- Build passes successfully
- TypeScript type checking passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection configuration across deployment pipelines and seeding processes to use standardized environment variable naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->