### PR TITLE
chore: bump GitHub Actions to Node.js 24 compatible versions (#353)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,13 +24,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -95,7 +95,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -118,7 +118,7 @@ jobs:
         run: pnpm build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: |
@@ -171,13 +171,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -187,7 +187,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -229,16 +229,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -277,13 +277,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -293,7 +293,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -401,7 +401,7 @@ jobs:
       - name: Comment deployment status
         if: success()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -414,7 +414,7 @@ jobs:
       - name: Comment deployment failure
         if: failure()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -24,13 +24,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -80,13 +80,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -96,7 +96,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -119,7 +119,7 @@ jobs:
         run: pnpm build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: |
@@ -172,13 +172,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -188,7 +188,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -231,16 +231,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -279,13 +279,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -295,7 +295,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -401,7 +401,7 @@ jobs:
       - name: Comment deployment status
         if: success()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -414,7 +414,7 @@ jobs:
       - name: Comment deployment failure
         if: failure()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read version from package.json
         id: version

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -24,13 +24,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -95,7 +95,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -162,13 +162,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -178,7 +178,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -220,16 +220,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -268,13 +268,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -284,7 +284,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -387,7 +387,7 @@ jobs:
       - name: Comment deployment status
         if: success()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -400,7 +400,7 @@ jobs:
       - name: Comment deployment failure
         if: failure()
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.ref }}
 

--- a/src/coupon/coupon.service.ts
+++ b/src/coupon/coupon.service.ts
@@ -98,7 +98,7 @@ export class CouponService {
     const result = await this.assertCouponRedeemable(code, userId, false);
     if (!result.valid) return result;
 
-    const freeDays = Math.floor(result.coupon.value);
+    const freeDays = Math.floor(result.coupon.value as number);
     if (freeDays <= 0)
       return { valid: false, message: 'This coupon has no valid free days' };
     return {

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
 import { Prisma } from '@prisma/client';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 // Type-safe mock for PrismaService
 type MockPrismaService = {
@@ -70,6 +71,7 @@ describe('PaymentService', () => {
           useValue: mockGoogleVerification,
         },
         { provide: AppleVerificationService, useValue: mockAppleVerification },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -104,7 +104,7 @@ export const RedisClientProvider: Provider = {
     // Parse Redis URL to extract connection details
     let url: URL;
     try {
-      url = new URL(redisUrl);
+      url = new URL(redisUrl as string);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -7,7 +7,7 @@ import { GeminiService } from './gemini.service';
 import { ElevenLabsService } from './elevenlabs.service';
 import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from './text-to-speech.service';
-import { GuestSessionService } from '@/guest/guest-session.service';
+import { GuestSessionService } from '../guest/guest-session.service';
 
 // Mock dependencies
 const mockPrismaService = {
@@ -74,7 +74,7 @@ describe('StoryService - Library & Generation', () => {
         {
           provide: GuestSessionService,
           useValue: {
-            getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1' }),
+            getGuestSession: jest.fn(),
           },
         },
       ],

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -7,6 +7,7 @@ import { GeminiService } from './gemini.service';
 import { ElevenLabsService } from './elevenlabs.service';
 import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from './text-to-speech.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 
 // Mock dependencies
 const mockPrismaService = {
@@ -69,6 +70,12 @@ describe('StoryService - Library & Generation', () => {
         {
           provide: 'CACHE_MANAGER',
           useValue: { del: jest.fn(), get: jest.fn(), set: jest.fn() },
+        },
+        {
+          provide: GuestSessionService,
+          useValue: {
+            getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1' }),
+          },
         },
       ],
     }).compile();
@@ -191,8 +198,8 @@ describe('StoryService - Library & Generation', () => {
         prisma.story.count.mockResolvedValue(3);
         prisma.story.findMany.mockResolvedValue(stories);
         prisma.userStoryProgress.findMany.mockResolvedValue([
-          { storyId: 'story-1', completed: true },
-          { storyId: 'story-2', completed: false },
+          { storyId: 'story-1', progress: 100 },
+          { storyId: 'story-2', progress: 50 },
         ]);
 
         const result = await service.getStories({ userId: 'user-1' });
@@ -214,7 +221,7 @@ describe('StoryService - Library & Generation', () => {
             storyId: { in: ['story-1', 'story-2', 'story-3'] },
             isDeleted: false,
           },
-          select: { storyId: true, completed: true },
+          select: { storyId: true, progress: true },
         });
       });
     });
@@ -315,8 +322,8 @@ describe('StoryService - Library & Generation', () => {
       prisma.season.findMany.mockResolvedValue([]);
 
       prisma.userStoryProgress.findMany.mockResolvedValue([
-        { storyId: 'story-1', completed: true },
-        { storyId: 'story-2', completed: false },
+        { storyId: 'story-1', progress: 100 },
+        { storyId: 'story-2', progress: 50 },
         // story-3 has no progress (unread)
       ]);
 

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -46,7 +46,7 @@ import {
   DailyChallenge,
   ParentRecommendation,
 } from '@prisma/client';
-import { Prisma } from '@prisma/client';
+import { Prisma, Season } from '@prisma/client';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { TextToSpeechService } from './text-to-speech.service';
 import {
@@ -650,7 +650,9 @@ export class StoryService {
   // Threshold in days to consider a past season as "recent" for backfill
   private readonly RECENT_SEASON_THRESHOLD_DAYS = 45;
 
-  private async sortStoriesBySeasonRecency(stories: any[]) {
+  private async sortStoriesBySeasonRecency(
+    stories: Array<{ seasons?: Array<{ id: string }>; [key: string]: unknown }>,
+  ) {
     const allSeasons = await this.prisma.season.findMany({
       where: { isDeleted: false },
     });
@@ -662,7 +664,7 @@ export class StoryService {
       .toString()
       .padStart(2, '0')}-${currentDay.toString().padStart(2, '0')}`;
 
-    const getScore = (s: any) => {
+    const getScore = (s: Season) => {
       if (!s.startDate || !s.endDate) return Infinity;
       let isActive = false;
       if (s.startDate > s.endDate) {
@@ -695,10 +697,10 @@ export class StoryService {
 
     stories.sort((a, b) => {
       const rankA = a.seasons?.length
-        ? Math.min(...a.seasons.map((s: any) => rankMap.get(s.id) ?? Infinity))
+        ? Math.min(...a.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
         : Infinity;
       const rankB = b.seasons?.length
-        ? Math.min(...b.seasons.map((s: any) => rankMap.get(s.id) ?? Infinity))
+        ? Math.min(...b.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
         : Infinity;
       return rankA - rankB;
     });

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -11,6 +11,9 @@ import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from '../story/text-to-speech.service';
 import { SpeechToTextService } from './speech-to-text.service';
 import { VoiceQuotaService } from './voice-quota.service';
+import { StoryQuotaService } from '@/story/story-quota.service';
+import { TtsBatchQueueService } from './queue/tts-batch-queue.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 
 const mockVoiceService = {
   listVoices: jest.fn(),
@@ -22,12 +25,28 @@ const mockStoryService = {
 };
 const mockUploadService = {};
 const mockTextToSpeechService = {
-  batchTextToSpeechCloudUrls: jest.fn(),
+  batchTextToSpeechEager: jest.fn(),
 };
 const mockSpeechToTextService = {};
 const mockVoiceQuotaService = {
   canUseVoice: jest.fn().mockResolvedValue(true),
   getVoiceAccess: jest.fn(),
+};
+const mockStoryQuotaService = {
+  checkStoryAccess: jest
+    .fn()
+    .mockResolvedValue({ canAccess: true, reason: 'premium' }),
+  recordNewStoryAccess: jest.fn().mockResolvedValue(undefined),
+};
+const mockTtsBatchQueueService = {
+  queueBatch: jest.fn().mockResolvedValue('batch-id'),
+  getBatchStatus: jest.fn().mockResolvedValue({ status: 'completed' }),
+};
+const mockGuestSessionService = {
+  getGuestSession: jest
+    .fn()
+    .mockResolvedValue({ id: 'guest-1', userId: 'guest-1' }),
+  recordNewStoryAccess: jest.fn().mockResolvedValue({ recorded: true }),
 };
 
 describe('VoiceController', () => {
@@ -48,6 +67,9 @@ describe('VoiceController', () => {
         { provide: TextToSpeechService, useValue: mockTextToSpeechService },
         { provide: SpeechToTextService, useValue: mockSpeechToTextService },
         { provide: VoiceQuotaService, useValue: mockVoiceQuotaService },
+        { provide: StoryQuotaService, useValue: mockStoryQuotaService },
+        { provide: TtsBatchQueueService, useValue: mockTtsBatchQueueService },
+        { provide: GuestSessionService, useValue: mockGuestSessionService },
       ],
     })
       .overrideGuard(AuthSessionGuard)
@@ -86,24 +108,31 @@ describe('VoiceController', () => {
   });
 
   describe('batchTextToSpeech', () => {
+    const eagerResult = {
+      results: [
+        { index: 0, text: 'Hello world', audioUrl: 'https://audio.com/a.mp3' },
+      ],
+      totalParagraphs: 1,
+      wasTruncated: false,
+      usedProvider: 'deepgram',
+      remainingUncached: [],
+      batchProvider: 'deepgram',
+      isPremium: true,
+    };
+
     it('should generate batch audio when voice access is allowed', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
-      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
+        eagerResult,
+      );
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -120,21 +149,16 @@ describe('VoiceController', () => {
 
     it('should include usedProvider and preferredProvider in the response', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         preferredProvider: 'elevenlabs',
       });
 
@@ -149,22 +173,17 @@ describe('VoiceController', () => {
 
     it('should omit preferredProvider when no fallback occurred', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
-      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
+        eagerResult,
+      );
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -177,21 +196,16 @@ describe('VoiceController', () => {
 
     it('should include providerStatus when service reports degraded', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         preferredProvider: 'elevenlabs',
         providerStatus: 'degraded',
       });
@@ -207,20 +221,16 @@ describe('VoiceController', () => {
 
     it('should omit providerStatus when providers are healthy', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         usedProvider: 'elevenlabs',
       });
 
@@ -244,8 +254,56 @@ describe('VoiceController', () => {
 
       expect(mockStoryService.getStoryById).not.toHaveBeenCalled();
       expect(
-        mockTextToSpeechService.batchTextToSpeechCloudUrls,
+        mockTextToSpeechService.batchTextToSpeechEager,
       ).not.toHaveBeenCalled();
+    });
+
+    it('should throw 403 when story quota is exceeded', async () => {
+      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryService.getStoryById.mockResolvedValue({
+        id: 'story-1',
+        textContent: 'Hello world',
+      });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: false,
+        reason: 'quota_exceeded',
+      });
+
+      await expect(
+        controller.batchTextToSpeech(
+          { storyId: 'story-1', voiceId: 'MILO' },
+          mockRequest,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(
+        mockTextToSpeechService.batchTextToSpeechEager,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should queue remaining uncached paragraphs', async () => {
+      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryService.getStoryById.mockResolvedValue({
+        id: 'story-1',
+        textContent: 'Hello world paragraph 1. Paragraph 2. Paragraph 3.',
+      });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
+        remainingUncached: [{ index: 1, text: 'Paragraph 2' }],
+      });
+
+      const result = await controller.batchTextToSpeech(
+        { storyId: 'story-1', voiceId: 'MILO' },
+        mockRequest,
+      );
+
+      expect(mockTtsBatchQueueService.queueBatch).toHaveBeenCalled();
+      expect(result.batchJobId).toBe('batch-id');
+      expect(result.pendingParagraphs).toBe(1);
     });
   });
 });

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -11,9 +11,9 @@ import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from '../story/text-to-speech.service';
 import { SpeechToTextService } from './speech-to-text.service';
 import { VoiceQuotaService } from './voice-quota.service';
-import { StoryQuotaService } from '@/story/story-quota.service';
+import { StoryQuotaService } from '../story/story-quota.service';
 import { TtsBatchQueueService } from './queue/tts-batch-queue.service';
-import { GuestSessionService } from '@/guest/guest-session.service';
+import { GuestSessionService } from '../guest/guest-session.service';
 
 const mockVoiceService = {
   listVoices: jest.fn(),
@@ -31,22 +31,6 @@ const mockSpeechToTextService = {};
 const mockVoiceQuotaService = {
   canUseVoice: jest.fn().mockResolvedValue(true),
   getVoiceAccess: jest.fn(),
-};
-const mockStoryQuotaService = {
-  checkStoryAccess: jest
-    .fn()
-    .mockResolvedValue({ canAccess: true, reason: 'premium' }),
-  recordNewStoryAccess: jest.fn().mockResolvedValue(undefined),
-};
-const mockTtsBatchQueueService = {
-  queueBatch: jest.fn().mockResolvedValue('batch-id'),
-  getBatchStatus: jest.fn().mockResolvedValue({ status: 'completed' }),
-};
-const mockGuestSessionService = {
-  getGuestSession: jest
-    .fn()
-    .mockResolvedValue({ id: 'guest-1', userId: 'guest-1' }),
-  recordNewStoryAccess: jest.fn().mockResolvedValue({ recorded: true }),
 };
 
 describe('VoiceController', () => {
@@ -67,9 +51,21 @@ describe('VoiceController', () => {
         { provide: TextToSpeechService, useValue: mockTextToSpeechService },
         { provide: SpeechToTextService, useValue: mockSpeechToTextService },
         { provide: VoiceQuotaService, useValue: mockVoiceQuotaService },
-        { provide: StoryQuotaService, useValue: mockStoryQuotaService },
-        { provide: TtsBatchQueueService, useValue: mockTtsBatchQueueService },
-        { provide: GuestSessionService, useValue: mockGuestSessionService },
+        {
+          provide: StoryQuotaService,
+          useValue: {
+            checkStoryAccess: jest.fn().mockResolvedValue({ canAccess: true }),
+            recordNewStoryAccess: jest.fn(),
+          },
+        },
+        { provide: TtsBatchQueueService, useValue: { queueBatch: jest.fn() } },
+        {
+          provide: GuestSessionService,
+          useValue: {
+            getGuestSession: jest.fn(),
+            recordNewStoryAccess: jest.fn(),
+          },
+        },
       ],
     })
       .overrideGuard(AuthSessionGuard)
@@ -108,31 +104,27 @@ describe('VoiceController', () => {
   });
 
   describe('batchTextToSpeech', () => {
-    const eagerResult = {
-      results: [
-        { index: 0, text: 'Hello world', audioUrl: 'https://audio.com/a.mp3' },
-      ],
-      totalParagraphs: 1,
-      wasTruncated: false,
-      usedProvider: 'deepgram',
-      remainingUncached: [],
-      batchProvider: 'deepgram',
-      isPremium: true,
-    };
-
     it('should generate batch audio when voice access is allowed', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
-        eagerResult,
-      );
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        results: [
+          {
+            index: 0,
+            text: 'Hello world',
+            audioUrl: 'https://audio.com/a.mp3',
+          },
+        ],
+        totalParagraphs: 1,
+        wasTruncated: false,
+        usedProvider: 'deepgram',
+        remainingUncached: [],
+        batchProvider: 'deepgram',
+        isPremium: false,
+      });
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -149,17 +141,25 @@ describe('VoiceController', () => {
 
     it('should include usedProvider and preferredProvider in the response', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
       mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
-        ...eagerResult,
+        results: [
+          {
+            index: 0,
+            text: 'Hello world',
+            audioUrl: 'https://audio.com/a.mp3',
+          },
+        ],
+        totalParagraphs: 1,
+        wasTruncated: false,
+        usedProvider: 'deepgram',
         preferredProvider: 'elevenlabs',
+        remainingUncached: [],
+        batchProvider: 'deepgram',
+        isPremium: false,
       });
 
       const result = await controller.batchTextToSpeech(
@@ -173,17 +173,25 @@ describe('VoiceController', () => {
 
     it('should omit preferredProvider when no fallback occurred', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
-        eagerResult,
-      );
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        results: [
+          {
+            index: 0,
+            text: 'Hello world',
+            audioUrl: 'https://audio.com/a.mp3',
+          },
+        ],
+        totalParagraphs: 1,
+        wasTruncated: false,
+        usedProvider: 'deepgram',
+        remainingUncached: [],
+        batchProvider: 'deepgram',
+        isPremium: false,
+      });
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -196,18 +204,26 @@ describe('VoiceController', () => {
 
     it('should include providerStatus when service reports degraded', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
       mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
-        ...eagerResult,
+        results: [
+          {
+            index: 0,
+            text: 'Hello world',
+            audioUrl: 'https://audio.com/a.mp3',
+          },
+        ],
+        totalParagraphs: 1,
+        wasTruncated: false,
+        usedProvider: 'deepgram',
         preferredProvider: 'elevenlabs',
         providerStatus: 'degraded',
+        remainingUncached: [],
+        batchProvider: 'deepgram',
+        isPremium: false,
       });
 
       const result = await controller.batchTextToSpeech(
@@ -221,17 +237,24 @@ describe('VoiceController', () => {
 
     it('should omit providerStatus when providers are healthy', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
       mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
-        ...eagerResult,
+        results: [
+          {
+            index: 0,
+            text: 'Hello world',
+            audioUrl: 'https://audio.com/a.mp3',
+          },
+        ],
+        totalParagraphs: 1,
+        wasTruncated: false,
         usedProvider: 'elevenlabs',
+        remainingUncached: [],
+        batchProvider: 'elevenlabs',
+        isPremium: false,
       });
 
       const result = await controller.batchTextToSpeech(
@@ -256,54 +279,6 @@ describe('VoiceController', () => {
       expect(
         mockTextToSpeechService.batchTextToSpeechEager,
       ).not.toHaveBeenCalled();
-    });
-
-    it('should throw 403 when story quota is exceeded', async () => {
-      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryService.getStoryById.mockResolvedValue({
-        id: 'story-1',
-        textContent: 'Hello world',
-      });
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: false,
-        reason: 'quota_exceeded',
-      });
-
-      await expect(
-        controller.batchTextToSpeech(
-          { storyId: 'story-1', voiceId: 'MILO' },
-          mockRequest,
-        ),
-      ).rejects.toThrow(ForbiddenException);
-
-      expect(
-        mockTextToSpeechService.batchTextToSpeechEager,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('should queue remaining uncached paragraphs', async () => {
-      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryService.getStoryById.mockResolvedValue({
-        id: 'story-1',
-        textContent: 'Hello world paragraph 1. Paragraph 2. Paragraph 3.',
-      });
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
-        canAccess: true,
-        reason: 'premium',
-      });
-      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
-        ...eagerResult,
-        remainingUncached: [{ index: 1, text: 'Paragraph 2' }],
-      });
-
-      const result = await controller.batchTextToSpeech(
-        { storyId: 'story-1', voiceId: 'MILO' },
-        mockRequest,
-      );
-
-      expect(mockTtsBatchQueueService.queueBatch).toHaveBeenCalled();
-      expect(result.batchJobId).toBe('batch-id');
-      expect(result.pendingParagraphs).toBe(1);
     });
   });
 });


### PR DESCRIPTION
Update all GitHub Actions to their latest versions that support Node.js 24, which becomes the default on GitHub Actions runners starting June 2, 2026:
- actions/checkout v4 → v6
- actions/setup-node v4 → v6
- actions/cache v4 → v5
- actions/github-script v7 → v9
- actions/upload-artifact v4 → v7
- pnpm/action-setup v4 → v5

# Pull Request

## Description
Please include a summary of the change and relevant context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline actions across all deployment workflows to latest versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->