### PR TITLE
fix: add missing mock providers to unit tests

### DIFF
--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
 import { Prisma } from '@prisma/client';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 // Type-safe mock for PrismaService
 type MockPrismaService = {
@@ -70,6 +71,7 @@ describe('PaymentService', () => {
           useValue: mockGoogleVerification,
         },
         { provide: AppleVerificationService, useValue: mockAppleVerification },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -71,7 +71,12 @@ describe('StoryService - Library & Generation', () => {
           provide: 'CACHE_MANAGER',
           useValue: { del: jest.fn(), get: jest.fn(), set: jest.fn() },
         },
-        { provide: GuestSessionService, useValue: { getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1' }) } },
+        {
+          provide: GuestSessionService,
+          useValue: {
+            getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1' }),
+          },
+        },
       ],
     }).compile();
 

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -198,8 +198,8 @@ describe('StoryService - Library & Generation', () => {
         prisma.story.count.mockResolvedValue(3);
         prisma.story.findMany.mockResolvedValue(stories);
         prisma.userStoryProgress.findMany.mockResolvedValue([
-          { storyId: 'story-1', completed: true },
-          { storyId: 'story-2', completed: false },
+          { storyId: 'story-1', progress: 100 },
+          { storyId: 'story-2', progress: 50 },
         ]);
 
         const result = await service.getStories({ userId: 'user-1' });
@@ -221,7 +221,7 @@ describe('StoryService - Library & Generation', () => {
             storyId: { in: ['story-1', 'story-2', 'story-3'] },
             isDeleted: false,
           },
-          select: { storyId: true, completed: true },
+          select: { storyId: true, progress: true },
         });
       });
     });
@@ -322,8 +322,8 @@ describe('StoryService - Library & Generation', () => {
       prisma.season.findMany.mockResolvedValue([]);
 
       prisma.userStoryProgress.findMany.mockResolvedValue([
-        { storyId: 'story-1', completed: true },
-        { storyId: 'story-2', completed: false },
+        { storyId: 'story-1', progress: 100 },
+        { storyId: 'story-2', progress: 50 },
         // story-3 has no progress (unread)
       ]);
 

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -7,6 +7,7 @@ import { GeminiService } from './gemini.service';
 import { ElevenLabsService } from './elevenlabs.service';
 import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from './text-to-speech.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 
 // Mock dependencies
 const mockPrismaService = {
@@ -70,6 +71,7 @@ describe('StoryService - Library & Generation', () => {
           provide: 'CACHE_MANAGER',
           useValue: { del: jest.fn(), get: jest.fn(), set: jest.fn() },
         },
+        { provide: GuestSessionService, useValue: { getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1' }) } },
       ],
     }).compile();
 

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -122,6 +122,7 @@ describe('VoiceController', () => {
 
     it('should generate batch audio when voice access is allowed', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -145,6 +146,7 @@ describe('VoiceController', () => {
 
     it('should include usedProvider and preferredProvider in the response', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -165,6 +167,7 @@ describe('VoiceController', () => {
 
     it('should omit preferredProvider when no fallback occurred', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -184,6 +187,7 @@ describe('VoiceController', () => {
 
     it('should include providerStatus when service reports degraded', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -205,6 +209,7 @@ describe('VoiceController', () => {
 
     it('should omit providerStatus when providers are healthy', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -267,6 +272,7 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world paragraph 1. Paragraph 2. Paragraph 3.',
       });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
       mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
         ...eagerResult,
         remainingUncached: [{ index: 1, text: 'Paragraph 2' }],

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -33,7 +33,9 @@ const mockVoiceQuotaService = {
   getVoiceAccess: jest.fn(),
 };
 const mockStoryQuotaService = {
-  checkStoryAccess: jest.fn().mockResolvedValue({ canAccess: true, reason: 'premium' }),
+  checkStoryAccess: jest
+    .fn()
+    .mockResolvedValue({ canAccess: true, reason: 'premium' }),
   recordNewStoryAccess: jest.fn().mockResolvedValue(undefined),
 };
 const mockTtsBatchQueueService = {
@@ -41,7 +43,9 @@ const mockTtsBatchQueueService = {
   getBatchStatus: jest.fn().mockResolvedValue({ status: 'completed' }),
 };
 const mockGuestSessionService = {
-  getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1', userId: 'guest-1' }),
+  getGuestSession: jest
+    .fn()
+    .mockResolvedValue({ id: 'guest-1', userId: 'guest-1' }),
   recordNewStoryAccess: jest.fn().mockResolvedValue({ recorded: true }),
 };
 
@@ -105,7 +109,9 @@ describe('VoiceController', () => {
 
   describe('batchTextToSpeech', () => {
     const eagerResult = {
-      results: [{ index: 0, text: 'Hello world', audioUrl: 'https://audio.com/a.mp3' }],
+      results: [
+        { index: 0, text: 'Hello world', audioUrl: 'https://audio.com/a.mp3' },
+      ],
       totalParagraphs: 1,
       wasTruncated: false,
       usedProvider: 'deepgram',
@@ -120,7 +126,9 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(eagerResult);
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
+        eagerResult,
+      );
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -161,7 +169,9 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(eagerResult);
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(
+        eagerResult,
+      );
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -11,6 +11,9 @@ import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from '../story/text-to-speech.service';
 import { SpeechToTextService } from './speech-to-text.service';
 import { VoiceQuotaService } from './voice-quota.service';
+import { StoryQuotaService } from '@/story/story-quota.service';
+import { TtsBatchQueueService } from './queue/tts-batch-queue.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 
 const mockVoiceService = {
   listVoices: jest.fn(),
@@ -22,12 +25,24 @@ const mockStoryService = {
 };
 const mockUploadService = {};
 const mockTextToSpeechService = {
-  batchTextToSpeechCloudUrls: jest.fn(),
+  batchTextToSpeechEager: jest.fn(),
 };
 const mockSpeechToTextService = {};
 const mockVoiceQuotaService = {
   canUseVoice: jest.fn().mockResolvedValue(true),
   getVoiceAccess: jest.fn(),
+};
+const mockStoryQuotaService = {
+  checkStoryAccess: jest.fn().mockResolvedValue({ canAccess: true, reason: 'premium' }),
+  recordNewStoryAccess: jest.fn().mockResolvedValue(undefined),
+};
+const mockTtsBatchQueueService = {
+  queueBatch: jest.fn().mockResolvedValue('batch-id'),
+  getBatchStatus: jest.fn().mockResolvedValue({ status: 'completed' }),
+};
+const mockGuestSessionService = {
+  getGuestSession: jest.fn().mockResolvedValue({ id: 'guest-1', userId: 'guest-1' }),
+  recordNewStoryAccess: jest.fn().mockResolvedValue({ recorded: true }),
 };
 
 describe('VoiceController', () => {
@@ -48,6 +63,9 @@ describe('VoiceController', () => {
         { provide: TextToSpeechService, useValue: mockTextToSpeechService },
         { provide: SpeechToTextService, useValue: mockSpeechToTextService },
         { provide: VoiceQuotaService, useValue: mockVoiceQuotaService },
+        { provide: StoryQuotaService, useValue: mockStoryQuotaService },
+        { provide: TtsBatchQueueService, useValue: mockTtsBatchQueueService },
+        { provide: GuestSessionService, useValue: mockGuestSessionService },
       ],
     })
       .overrideGuard(AuthSessionGuard)
@@ -86,24 +104,23 @@ describe('VoiceController', () => {
   });
 
   describe('batchTextToSpeech', () => {
+    const eagerResult = {
+      results: [{ index: 0, text: 'Hello world', audioUrl: 'https://audio.com/a.mp3' }],
+      totalParagraphs: 1,
+      wasTruncated: false,
+      usedProvider: 'deepgram',
+      remainingUncached: [],
+      batchProvider: 'deepgram',
+      isPremium: true,
+    };
+
     it('should generate batch audio when voice access is allowed', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
-      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(eagerResult);
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -124,17 +141,8 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         preferredProvider: 'elevenlabs',
       });
 
@@ -153,18 +161,7 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
-      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue(eagerResult);
 
       const result = await controller.batchTextToSpeech(
         { storyId: 'story-1', voiceId: 'MILO' },
@@ -181,17 +178,8 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
-        usedProvider: 'deepgram',
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         preferredProvider: 'elevenlabs',
         providerStatus: 'degraded',
       });
@@ -211,16 +199,8 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world',
       });
-      mockTextToSpeechService.batchTextToSpeechCloudUrls.mockResolvedValue({
-        results: [
-          {
-            index: 0,
-            text: 'Hello world',
-            audioUrl: 'https://audio.com/a.mp3',
-          },
-        ],
-        totalParagraphs: 1,
-        wasTruncated: false,
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
         usedProvider: 'elevenlabs',
       });
 
@@ -244,8 +224,52 @@ describe('VoiceController', () => {
 
       expect(mockStoryService.getStoryById).not.toHaveBeenCalled();
       expect(
-        mockTextToSpeechService.batchTextToSpeechCloudUrls,
+        mockTextToSpeechService.batchTextToSpeechEager,
       ).not.toHaveBeenCalled();
+    });
+
+    it('should throw 403 when story quota is exceeded', async () => {
+      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryService.getStoryById.mockResolvedValue({
+        id: 'story-1',
+        textContent: 'Hello world',
+      });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: false,
+        reason: 'quota_exceeded',
+      });
+
+      await expect(
+        controller.batchTextToSpeech(
+          { storyId: 'story-1', voiceId: 'MILO' },
+          mockRequest,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(
+        mockTextToSpeechService.batchTextToSpeechEager,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should queue remaining uncached paragraphs', async () => {
+      mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
+      mockStoryService.getStoryById.mockResolvedValue({
+        id: 'story-1',
+        textContent: 'Hello world paragraph 1. Paragraph 2. Paragraph 3.',
+      });
+      mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
+        ...eagerResult,
+        remainingUncached: [{ index: 1, text: 'Paragraph 2' }],
+      });
+
+      const result = await controller.batchTextToSpeech(
+        { storyId: 'story-1', voiceId: 'MILO' },
+        mockRequest,
+      );
+
+      expect(mockTtsBatchQueueService.queueBatch).toHaveBeenCalled();
+      expect(result.batchJobId).toBe('batch-id');
+      expect(result.pendingParagraphs).toBe(1);
     });
   });
 });

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -122,7 +122,10 @@ describe('VoiceController', () => {
 
     it('should generate batch audio when voice access is allowed', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -146,7 +149,10 @@ describe('VoiceController', () => {
 
     it('should include usedProvider and preferredProvider in the response', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -167,7 +173,10 @@ describe('VoiceController', () => {
 
     it('should omit preferredProvider when no fallback occurred', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -187,7 +196,10 @@ describe('VoiceController', () => {
 
     it('should include providerStatus when service reports degraded', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -209,7 +221,10 @@ describe('VoiceController', () => {
 
     it('should omit providerStatus when providers are healthy', async () => {
       mockVoiceQuotaService.canUseVoice.mockResolvedValue(true);
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockStoryService.getStoryById.mockResolvedValue({
         id: 'story-1',
         textContent: 'Hello world',
@@ -272,7 +287,10 @@ describe('VoiceController', () => {
         id: 'story-1',
         textContent: 'Hello world paragraph 1. Paragraph 2. Paragraph 3.',
       });
-      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({ canAccess: true, reason: 'premium' });
+      mockStoryQuotaService.checkStoryAccess.mockResolvedValue({
+        canAccess: true,
+        reason: 'premium',
+      });
       mockTextToSpeechService.batchTextToSpeechEager.mockResolvedValue({
         ...eagerResult,
         remainingUncached: [{ index: 1, text: 'Paragraph 2' }],


### PR DESCRIPTION
## Summary
- Fixes 3 test suites that were failing due to missing mock providers after recent feature refactors
- `voice.controller.spec` — added `StoryQuotaService`, `TtsBatchQueueService`, `GuestSessionService` mocks; updated `batchTextToSpeechCloudUrls` → `batchTextToSpeechEager`; added tests for story quota and batch queue behavior
- `payment.service.spec` — added `EventEmitter2` mock provider
- `story.service.spec` — added `GuestSessionService` mock provider

## Test plan
- [x] All 22 test suites pass locally (197 tests, 1 skipped)
- [ ] CI pipeline passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for payment, story, and voice areas with added mocked services to simulate event emission and guest sessions.
  * Updated story tests to validate read-status handling using progress fields.
  * Enhanced voice TTS tests to cover eager processing, provider-related response behavior, partial uncached handling (enqueueing background batches), and access-denial when quota prevents processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->