### PR TITLE
fix(ci): use local database env during PR validation

### DIFF
--- a/.github/scripts/create-env.sh
+++ b/.github/scripts/create-env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file="${ENV_OUTPUT_FILE:-.env}"
+tmp_file="${env_file}.ci"
+
+printf '%s\n' "${ENV_FILE_CONTENT:-}" > "$env_file"
+
+override_keys=()
+if [[ -n "${DATABASE_URL_OVERRIDE:-}" ]]; then
+  override_keys+=("DATABASE_URL")
+fi
+if [[ -n "${REDIS_URL_OVERRIDE:-}" ]]; then
+  override_keys+=("REDIS_URL")
+fi
+
+if ((${#override_keys[@]} == 0)); then
+  exit 0
+fi
+
+filter_pattern="^($(IFS="|"; echo "${override_keys[*]}"))="
+grep -vE "$filter_pattern" "$env_file" > "$tmp_file" || test $? -eq 1
+mv "$tmp_file" "$env_file"
+
+{
+  if [[ -n "${DATABASE_URL_OVERRIDE:-}" ]]; then
+    printf 'DATABASE_URL=%s\n' "$DATABASE_URL_OVERRIDE"
+  fi
+  if [[ -n "${REDIS_URL_OVERRIDE:-}" ]]; then
+    printf 'REDIS_URL=%s\n' "$REDIS_URL_OVERRIDE"
+  fi
+} >> "$env_file"

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -62,6 +62,7 @@ jobs:
     environment: development
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/storytime_build
+      REDIS_URL: redis://localhost:6379
 
     services:
       postgres:
@@ -104,16 +105,11 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Create .env file
-        run: |
-          cat > .env << 'EOF'
-          ${{ secrets.ENV_FILE }}
-          EOF
-          grep -vE '^(DATABASE_URL|REDIS_URL)=' .env > .env.ci
-          mv .env.ci .env
-          {
-            echo "DATABASE_URL=${DATABASE_URL}"
-            echo "REDIS_URL=redis://localhost:6379"
-          } >> .env
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE }}
+          DATABASE_URL_OVERRIDE: ${{ env.DATABASE_URL }}
+          REDIS_URL_OVERRIDE: ${{ env.REDIS_URL }}
+        run: bash .github/scripts/create-env.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -202,16 +198,11 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Create .env file
-        run: |
-          cat > .env << 'EOF'
-          ${{ secrets.ENV_FILE }}
-          EOF
-          grep -vE '^(DATABASE_URL|REDIS_URL)=' .env > .env.ci
-          mv .env.ci .env
-          {
-            echo "DATABASE_URL=${DATABASE_URL}"
-            echo "REDIS_URL=${REDIS_URL}"
-          } >> .env
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE }}
+          DATABASE_URL_OVERRIDE: ${{ env.DATABASE_URL }}
+          REDIS_URL_OVERRIDE: ${{ env.REDIS_URL }}
+        run: bash .github/scripts/create-env.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -315,10 +306,9 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Create .env file
-        run: |
-          cat > .env << 'EOF'
-          ${{ secrets.ENV_FILE }}
-          EOF
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE }}
+        run: bash .github/scripts/create-env.sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -108,6 +108,12 @@ jobs:
           cat > .env << 'EOF'
           ${{ secrets.ENV_FILE }}
           EOF
+          grep -vE '^(DATABASE_URL|REDIS_URL)=' .env > .env.ci
+          mv .env.ci .env
+          {
+            echo "DATABASE_URL=${DATABASE_URL}"
+            echo "REDIS_URL=redis://localhost:6379"
+          } >> .env
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -200,6 +206,12 @@ jobs:
           cat > .env << 'EOF'
           ${{ secrets.ENV_FILE }}
           EOF
+          grep -vE '^(DATABASE_URL|REDIS_URL)=' .env > .env.ci
+          mv .env.ci .env
+          {
+            echo "DATABASE_URL=${DATABASE_URL}"
+            echo "REDIS_URL=${REDIS_URL}"
+          } >> .env
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,11 +1,13 @@
 const os = require('os');
 
 const cpus = os.cpus().length;
-const prodInstances = Math.max(2, cpus - 1);
+const devInstances = Number(process.env.PM2_DEV_INSTANCES || 1);
+const stagingInstances = Number(process.env.PM2_STAGING_INSTANCES || 1);
+const prodInstances = Number(process.env.PM2_PROD_INSTANCES || Math.max(2, cpus - 1));
 
 const baseConfig = {
   script: 'dist/src/main.js',
-  instances: 'max',
+  instances: 1,
   exec_mode: 'cluster',
   autorestart: true,
   watch: false,
@@ -17,6 +19,7 @@ module.exports = {
     {
       ...baseConfig,
       name: 'storytime-api-development',
+      instances: devInstances,
       env: {
         NODE_ENV: 'development',
       },
@@ -24,6 +27,7 @@ module.exports = {
     {
       ...baseConfig,
       name: 'storytime-api-staging',
+      instances: stagingInstances,
       env: {
         NODE_ENV: 'staging',
       },

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,10 +1,24 @@
 const os = require('os');
 
 const cpus = os.cpus().length;
-const devInstances = Number(process.env.PM2_DEV_INSTANCES) || 1;
-const stagingInstances = Number(process.env.PM2_STAGING_INSTANCES) || 1;
-const prodInstances =
-  Number(process.env.PM2_PROD_INSTANCES) || Math.max(2, cpus - 1);
+const parseInstanceCount = (rawValue, fallback) => {
+  if (rawValue == null || rawValue === '') {
+    return fallback;
+  }
+
+  const parsedValue = parseInt(rawValue, 10);
+  return Number.isFinite(parsedValue) ? parsedValue : fallback;
+};
+
+const devInstances = parseInstanceCount(process.env.PM2_DEV_INSTANCES, 1);
+const stagingInstances = parseInstanceCount(
+  process.env.PM2_STAGING_INSTANCES,
+  1,
+);
+const prodInstances = parseInstanceCount(
+  process.env.PM2_PROD_INSTANCES,
+  Math.max(2, cpus - 1),
+);
 
 const baseConfig = {
   script: 'dist/src/main.js',

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,9 +1,10 @@
 const os = require('os');
 
 const cpus = os.cpus().length;
-const devInstances = Number(process.env.PM2_DEV_INSTANCES || 1);
-const stagingInstances = Number(process.env.PM2_STAGING_INSTANCES || 1);
-const prodInstances = Number(process.env.PM2_PROD_INSTANCES || Math.max(2, cpus - 1));
+const devInstances = Number(process.env.PM2_DEV_INSTANCES) || 1;
+const stagingInstances = Number(process.env.PM2_STAGING_INSTANCES) || 1;
+const prodInstances =
+  Number(process.env.PM2_PROD_INSTANCES) || Math.max(2, cpus - 1);
 
 const baseConfig = {
   script: 'dist/src/main.js',


### PR DESCRIPTION
# Pull Request

## Description

Fixes two sources of dev database connection pressure:

1. PR validation jobs no longer run Prisma migrations against the shared development RDS database. The workflow still writes the environment secret for other required values, then removes `DATABASE_URL`/`REDIS_URL` and appends the job-local CI service URLs.
2. Development and staging PM2 deployments now run one API worker by default instead of `instances: max`, preventing one Prisma pool per CPU from connecting to the shared database. Production remains configurable with `PM2_PROD_INSTANCES`, and dev/staging can be explicitly increased with `PM2_DEV_INSTANCES` / `PM2_STAGING_INSTANCES` when the database can support it.

This addresses the failing `pnpm db:migrate:deploy` step that connected to `storytime_dev` on the shared RDS host and failed with `FATAL: too many connections for database "storytime_dev"`, and reduces the live dev app connection footprint after deployment.

Fixes: N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Local development
- [ ] Unit tests
- [ ] E2E tests
- [x] Other (describe): YAML parse check with Ruby `YAML.load_file`; `node -c ecosystem.config.js`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional context

Deploy-on-merge still uses the real development database secrets for the migration/seed/deploy stage. The PR validation build/test jobs use local GitHub Actions services. The runtime PM2 cap reduces persistent dev/staging connections after deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized environment-file creation across CI build, test, and deploy jobs; supports job-level DATABASE_URL and REDIS_URL overrides so CI runs use consistent, environment-specific values.
  * Made application instance counts configurable via environment variables for dev, staging, and production, with sensible defaults to allow flexible scaling per environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bolt-Silverfox/storytime_be/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->