### PR TITLE
fix(prisma): limit direct database connections

### DIFF
--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -1,6 +1,17 @@
-import { resolvePrismaDatasourceUrl } from './prisma.service';
+import {
+  parseConnectionLimit,
+  resolvePrismaDatasourceUrl,
+} from './prisma.service';
 
 describe('resolvePrismaDatasourceUrl', () => {
+  it('returns undefined when resolvePrismaDatasourceUrl receives undefined', () => {
+    expect(resolvePrismaDatasourceUrl(undefined, 3)).toBeUndefined();
+  });
+
+  it('returns an empty string when resolvePrismaDatasourceUrl receives an empty string', () => {
+    expect(resolvePrismaDatasourceUrl('', 3)).toBe('');
+  });
+
   it('adds a default connection limit to direct postgres URLs', () => {
     expect(
       resolvePrismaDatasourceUrl(
@@ -31,5 +42,27 @@ describe('resolvePrismaDatasourceUrl', () => {
 
   it('returns the original URL when parsing fails', () => {
     expect(resolvePrismaDatasourceUrl('not-a-url', 3)).toBe('not-a-url');
+  });
+});
+
+describe('parseConnectionLimit', () => {
+  it('returns the fallback when parseConnectionLimit receives an empty string', () => {
+    expect(parseConnectionLimit('')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives a non-numeric string', () => {
+    expect(parseConnectionLimit('not-a-number')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives a negative number', () => {
+    expect(parseConnectionLimit('-1')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives zero', () => {
+    expect(parseConnectionLimit('0')).toBe(3);
+  });
+
+  it('returns the parsed value when parseConnectionLimit receives a valid integer', () => {
+    expect(parseConnectionLimit('7')).toBe(7);
   });
 });

--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -43,11 +43,25 @@ describe('resolvePrismaDatasourceUrl', () => {
   it('returns the original URL when parsing fails', () => {
     expect(resolvePrismaDatasourceUrl('not-a-url', 3)).toBe('not-a-url');
   });
+
+  it('does not add a connection limit to non-postgres URLs', () => {
+    expect(resolvePrismaDatasourceUrl('mysql://localhost/storytime', 3)).toBe(
+      'mysql://localhost/storytime',
+    );
+  });
 });
 
 describe('parseConnectionLimit', () => {
+  it('returns the fallback when parseConnectionLimit receives undefined', () => {
+    expect(parseConnectionLimit(undefined)).toBe(3);
+  });
+
   it('returns the fallback when parseConnectionLimit receives an empty string', () => {
     expect(parseConnectionLimit('')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives whitespace only', () => {
+    expect(parseConnectionLimit('   ')).toBe(3);
   });
 
   it('returns the fallback when parseConnectionLimit receives a non-numeric string', () => {

--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,35 @@
+import { resolvePrismaDatasourceUrl } from './prisma.service';
+
+describe('resolvePrismaDatasourceUrl', () => {
+  it('adds a default connection limit to direct postgres URLs', () => {
+    expect(
+      resolvePrismaDatasourceUrl(
+        'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime',
+        3,
+      ),
+    ).toBe(
+      'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=3',
+    );
+  });
+
+  it('preserves an existing connection limit', () => {
+    expect(
+      resolvePrismaDatasourceUrl(
+        'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=7',
+        3,
+      ),
+    ).toBe(
+      'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=7',
+    );
+  });
+
+  it('leaves prisma accelerate URLs unchanged', () => {
+    expect(
+      resolvePrismaDatasourceUrl('prisma://accelerate.example.com', 3),
+    ).toBe('prisma://accelerate.example.com');
+  });
+
+  it('returns the original URL when parsing fails', () => {
+    expect(resolvePrismaDatasourceUrl('not-a-url', 3)).toBe('not-a-url');
+  });
+});

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -7,22 +7,26 @@ import {
 import { PrismaClient } from '@prisma/client';
 import IHealth, { HealthResponse } from '@/health/Ihealth.interfaces';
 
-const DEFAULT_DATABASE_CONNECTION_LIMIT = 3;
+const FALLBACK_DATABASE_CONNECTION_LIMIT = 3;
 
-const parseConnectionLimit = (value: string | undefined): number => {
+export const parseConnectionLimit = (value: string | undefined): number => {
   if (value === undefined || value.trim() === '') {
-    return DEFAULT_DATABASE_CONNECTION_LIMIT;
+    return FALLBACK_DATABASE_CONNECTION_LIMIT;
   }
 
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0
     ? parsed
-    : DEFAULT_DATABASE_CONNECTION_LIMIT;
+    : FALLBACK_DATABASE_CONNECTION_LIMIT;
 };
+
+const DEFAULT_DATABASE_CONNECTION_LIMIT = parseConnectionLimit(
+  process.env.DATABASE_CONNECTION_LIMIT,
+);
 
 export const resolvePrismaDatasourceUrl = (
   databaseUrl: string | undefined,
-  connectionLimit = parseConnectionLimit(process.env.DATABASE_CONNECTION_LIMIT),
+  connectionLimit = DEFAULT_DATABASE_CONNECTION_LIMIT,
 ): string | undefined => {
   if (!databaseUrl || databaseUrl.startsWith('prisma://')) {
     return databaseUrl;
@@ -47,8 +51,9 @@ export class PrismaService
   private readonly logger = new Logger(PrismaService.name);
 
   constructor() {
-    // Use Prisma Accelerate for connection pooling
-    // The DATABASE_URL should be a prisma:// URL for Accelerate
+    // Supports Prisma Accelerate URLs (prisma://) or direct database URLs
+    // (for example, postgresql://). Accelerate is used when provided;
+    // otherwise direct URLs get a bounded connection pool by default.
     super({
       datasources: {
         db: {

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -7,6 +7,38 @@ import {
 import { PrismaClient } from '@prisma/client';
 import IHealth, { HealthResponse } from '@/health/Ihealth.interfaces';
 
+const DEFAULT_DATABASE_CONNECTION_LIMIT = 3;
+
+const parseConnectionLimit = (value: string | undefined): number => {
+  if (value === undefined || value.trim() === '') {
+    return DEFAULT_DATABASE_CONNECTION_LIMIT;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_DATABASE_CONNECTION_LIMIT;
+};
+
+export const resolvePrismaDatasourceUrl = (
+  databaseUrl: string | undefined,
+  connectionLimit = parseConnectionLimit(process.env.DATABASE_CONNECTION_LIMIT),
+): string | undefined => {
+  if (!databaseUrl || databaseUrl.startsWith('prisma://')) {
+    return databaseUrl;
+  }
+
+  try {
+    const url = new URL(databaseUrl);
+    if (!url.searchParams.has('connection_limit')) {
+      url.searchParams.set('connection_limit', String(connectionLimit));
+    }
+    return url.toString();
+  } catch {
+    return databaseUrl;
+  }
+};
+
 @Injectable()
 export class PrismaService
   extends PrismaClient
@@ -20,7 +52,7 @@ export class PrismaService
     super({
       datasources: {
         db: {
-          url: process.env.DATABASE_URL,
+          url: resolvePrismaDatasourceUrl(process.env.DATABASE_URL),
         },
       },
       log:

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -34,7 +34,10 @@ export const resolvePrismaDatasourceUrl = (
 
   try {
     const url = new URL(databaseUrl);
-    if (!url.searchParams.has('connection_limit')) {
+    const isPostgresUrl =
+      url.protocol === 'postgres:' || url.protocol === 'postgresql:';
+
+    if (isPostgresUrl && !url.searchParams.has('connection_limit')) {
       url.searchParams.set('connection_limit', String(connectionLimit));
     }
     return url.toString();


### PR DESCRIPTION
# Pull Request

## Description

Caps Prisma direct PostgreSQL runtime connections by appending `connection_limit=3` to datasource URLs when no limit is already present. The resolver preserves existing `connection_limit` values, leaves Prisma Accelerate `prisma://` URLs unchanged, and falls back to the original URL if parsing fails.

Fixes: N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Local development
- [x] Unit tests
- [ ] E2E tests
- [x] Other (describe): `pnpm exec tsc --noEmit`; `pnpm exec prettier --check src/prisma/prisma.service.ts src/prisma/prisma.service.spec.ts`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional context

This complements PR #360 by reducing runtime app-side connection pressure. It does not alter Prisma CLI migration behavior, and it does not terminate existing idle sessions already held by running app processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering datasource URL handling and connection limit parsing to ensure robust behavior across URL formats and edge cases.

* **Chores**
  * Standardized datasource URL handling to ensure a sensible default connection limit and preserve existing settings, improving reliability of database connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bolt-Silverfox/storytime_be/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->