### PR TITLE
fix(tts): fall back after elevenlabs quota exhaustion

### DIFF
--- a/src/story/text-to-speech.service.spec.ts
+++ b/src/story/text-to-speech.service.spec.ts
@@ -16,6 +16,7 @@ import { MAX_TTS_TEXT_LENGTH } from '../voice/voice.config';
 import { CircuitBreakerService } from '@/shared/services/circuit-breaker.service';
 import { TTS_CIRCUIT_BREAKER_CONFIG } from '@/shared/constants/circuit-breaker.constants';
 import { VOICE_CONFIG } from '../voice/voice.constants';
+import { QuotaExhaustedError } from '../voice/errors/quota-exhausted.error';
 
 describe('TextToSpeechService', () => {
   let service: TextToSpeechService;
@@ -706,6 +707,26 @@ describe('TextToSpeechService', () => {
       expect(result.results.every((r) => r.audioUrl !== null)).toBe(true);
       expect(result.usedProvider).toBe('deepgram');
       expect(result.preferredProvider).toBe('elevenlabs');
+    });
+
+    it('should throw QuotaExhaustedError for overridden ElevenLabs when quota is denied', async () => {
+      mockPrisma.paragraphAudioCache.findFirst.mockResolvedValue(null);
+      mockIsPremiumUser.mockResolvedValue(false);
+      mockCanFreeUserUseElevenLabs.mockResolvedValue(false);
+
+      await expect(
+        service.generateSingleParagraphTTS(
+          storyId,
+          'A single paragraph for retry fallback.',
+          VoiceType.MILO,
+          userId,
+          { isPremium: false, providerOverride: 'elevenlabs' },
+        ),
+      ).rejects.toBeInstanceOf(QuotaExhaustedError);
+
+      expect(mockElevenLabsGenerate).not.toHaveBeenCalled();
+      expect(mockDeepgramGenerate).not.toHaveBeenCalled();
+      expect(mockEdgeTtsGenerate).not.toHaveBeenCalled();
     });
 
     it('should cap paragraphs at MAX_BATCH_PARAGRAPHS (50)', async () => {

--- a/src/story/text-to-speech.service.ts
+++ b/src/story/text-to-speech.service.ts
@@ -19,6 +19,7 @@ import { PrismaService } from '../prisma/prisma.service';
 
 import { VoiceQuotaService } from '../voice/voice-quota.service';
 import { SubscriptionService } from '../subscription/subscription.service';
+import { QuotaExhaustedError } from '../voice/errors/quota-exhausted.error';
 import {
   CircuitBreakerService,
   CircuitBreaker,
@@ -379,9 +380,7 @@ export class TextToSpeechService {
     // Honour the quota decision: if ElevenLabs was denied, don't bypass via override.
     if (override) {
       if (override === 'elevenlabs' && !useElevenLabs) {
-        throw new InternalServerErrorException(
-          'ElevenLabs quota exhausted for this request',
-        );
+        throw new QuotaExhaustedError('ElevenLabs');
       }
       return this.attemptSingleProvider(
         override,


### PR DESCRIPTION
# Pull Request

## Description
Use a fallback when ElevenLabs is done

Fixes #(issue)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development
- [x] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context 