### PR TITLE
fix: prevent duplicate Prisma query-engine processes

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -22,8 +22,6 @@ const prodInstances = parseInstanceCount(
 
 const baseConfig = {
   script: 'dist/src/main.js',
-  instances: 1,
-  exec_mode: 'cluster',
   autorestart: true,
   watch: false,
   max_memory_restart: '1G',
@@ -35,6 +33,7 @@ module.exports = {
       ...baseConfig,
       name: 'storytime-api-development',
       instances: devInstances,
+      exec_mode: devInstances > 1 ? 'cluster' : 'fork',
       env: {
         NODE_ENV: 'development',
       },
@@ -43,6 +42,7 @@ module.exports = {
       ...baseConfig,
       name: 'storytime-api-staging',
       instances: stagingInstances,
+      exec_mode: 'cluster',
       env: {
         NODE_ENV: 'staging',
       },
@@ -51,6 +51,7 @@ module.exports = {
       ...baseConfig,
       name: 'storytime-api-production',
       instances: prodInstances,
+      exec_mode: 'cluster',
       env: {
         NODE_ENV: 'production',
       },

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,9 +1,26 @@
 import { Global, Module } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 
+// Prevent hot-reload (HMR / watch mode) from spawning duplicate query-engine processes.
+// Each `new PrismaClient()` starts a child query-engine binary; without this guard,
+// every HMR cycle leaks one.
+const globalForPrisma = globalThis as unknown as {
+  __prismaService?: PrismaService;
+};
+
 @Global()
 @Module({
-  providers: [PrismaService],
+  providers: [
+    {
+      provide: PrismaService,
+      useFactory: () => {
+        if (!globalForPrisma.__prismaService) {
+          globalForPrisma.__prismaService = new PrismaService();
+        }
+        return globalForPrisma.__prismaService;
+      },
+    },
+  ],
   exports: [PrismaService],
 })
 export class PrismaModule {}

--- a/src/story-buddy/story-buddy.seeder.ts
+++ b/src/story-buddy/story-buddy.seeder.ts
@@ -1,24 +1,13 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
 import { storyBuddiesData } from '../../prisma/data';
 
 @Injectable()
 export class StoryBuddySeederService implements OnModuleInit {
   private readonly logger = new Logger(StoryBuddySeederService.name);
-  private prisma: PrismaClient | null = null;
 
-  private getPrisma(): PrismaClient | null {
-    if (this.prisma) return this.prisma;
-
-    const url = process.env.DATABASE_URL;
-    if (!url) {
-      this.logger.warn('DATABASE_URL not set — skipping story buddy seeding');
-      return null;
-    }
-
-    this.prisma = new PrismaClient({ datasourceUrl: url });
-    return this.prisma;
-  }
+  constructor(private readonly prisma: PrismaService) {}
 
   async onModuleInit() {
     this.logger.log('Checking for story buddies seeding...');
@@ -32,14 +21,11 @@ export class StoryBuddySeederService implements OnModuleInit {
   }
 
   async seedStoryBuddies() {
-    const prisma = this.getPrisma();
-    if (!prisma) return;
-
     this.logger.log('🌟 Seeding story buddies...');
 
     try {
       // Get existing buddies to avoid duplicates
-      const existingBuddies = await prisma.storyBuddy.findMany({
+      const existingBuddies = await this.prisma.storyBuddy.findMany({
         select: { name: true },
       });
 
@@ -64,7 +50,7 @@ export class StoryBuddySeederService implements OnModuleInit {
 
       for (const buddyData of buddiesToCreate) {
         try {
-          const buddy = await prisma.storyBuddy.create({
+          const buddy = await this.prisma.storyBuddy.create({
             data: buddyData,
           });
           this.logger.log(`✅ Created buddy: ${buddy.displayName}`);
@@ -77,11 +63,67 @@ export class StoryBuddySeederService implements OnModuleInit {
       }
 
       this.logger.log(
-        `✅ Story buddy seeding complete. Created ${buddiesToCreate.length} buddies.`,
+        `✨ Story buddies seeding completed! Created ${buddiesToCreate.length} new buddies.`,
       );
-    } finally {
-      await prisma.$disconnect();
-      this.prisma = null;
+    } catch (error) {
+      this.logger.error('❌ Error during story buddies seeding:', error);
+      throw error;
     }
   }
+}
+
+// Standalone function for manual seeding (optional)
+export async function seedStoryBuddies() {
+  const prisma = new PrismaClient();
+  const logger = new Logger('StoryBuddySeeder');
+  logger.log('🌟 Seeding story buddies...');
+
+  try {
+    const existingBuddies = await prisma.storyBuddy.findMany({
+      select: { name: true },
+    });
+
+    const existingBuddyNames = new Set(
+      existingBuddies.map((buddy) => buddy.name),
+    );
+
+    const buddiesToCreate = storyBuddiesData.filter(
+      (buddyData) => !existingBuddyNames.has(buddyData.name),
+    );
+
+    if (buddiesToCreate.length === 0) {
+      logger.log('✅ All story buddies already exist, skipping creation.');
+      return;
+    }
+
+    logger.log(`📝 Creating ${buddiesToCreate.length} new story buddies...`);
+
+    for (const buddyData of buddiesToCreate) {
+      try {
+        const buddy = await prisma.storyBuddy.create({
+          data: buddyData,
+        });
+        logger.log(`✅ Created buddy: ${buddy.displayName}`);
+      } catch (error) {
+        logger.error(`❌ Error creating buddy ${buddyData.name}:`, error);
+      }
+    }
+
+    logger.log(
+      `✨ Story buddies seeding completed! Created ${buddiesToCreate.length} new buddies.`,
+    );
+  } catch (error) {
+    logger.error('❌ Error during story buddies seeding:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run seeder if executed directly
+if (require.main === module) {
+  seedStoryBuddies().catch((error) => {
+    console.error('Error seeding story buddies:', error);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Summary

- **PrismaModule**: Add `globalThis` singleton guard via factory provider to prevent HMR/watch mode from spawning a new `query-engine-de` process on each hot reload
- **StoryBuddySeederService**: Inject `PrismaService` via DI instead of creating a separate `PrismaClient` at module scope (which spawned an extra engine process on every app boot)
- **ecosystem.config.js**: Use `fork` mode for dev when running a single instance (default), keep upstream env-var-driven instance counts

## Root cause

Each `new PrismaClient()` spawns a child `query-engine-de` binary. Three things were multiplying these:
1. HMR reloads created new `PrismaService` instances without the old engine being cleaned up
2. `StoryBuddySeederService` had `const prisma = new PrismaClient()` at module scope — an extra engine per PM2 worker
3. PM2 dev/staging previously used `instances: 'max'` (all CPU cores), each with its own engine

## Test plan

- [x] `pnpm build` — exit code 0
- [x] `pnpm lint` — exit code 0, no new errors
- [x] Rebased on latest `develop-v1.2.0`, conflicts resolved
- [ ] Deploy to dev, verify only 1 `query-engine-de` process per PM2 worker: `ps -o pid,rss,command -C query-engine-de`
- [ ] Kill existing zombies before restart: `pkill -f query-engine-de && pm2 restart storytime-api-development`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Prisma process instances during development hot-reload mode

* **Chores**
  * Updated PM2 configuration to dynamically determine execution mode based on environment instance counts
  * Refactored database seeder to use centralized service injection pattern

<!-- end of auto-generated comment: release notes by coderabbit.ai -->