### PR TITLE
fix(redis): prevent idle-disconnect cycle every 5 minutes

### DIFF
--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -272,6 +272,12 @@ export const RedisClientProvider: Provider = {
       await client.ping();
       logger.log('Redis connection test successful');
     } catch (error) {
+      // Stop the keepalive timer before disconnecting. We can't rely on the
+      // 'end' event from disconnect() to clean up the timer — it fires
+      // asynchronously and we want to drop the setInterval synchronously so the
+      // failed provider factory doesn't leave a timer scheduled against a
+      // disposed client.
+      stopKeepAlive();
       // Disconnect client to stop retry/reconnection attempts before propagating error
       try {
         client.disconnect();

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -235,7 +235,37 @@ export const RedisClientProvider: Provider = {
 
     client.on('end', () => {
       logger.warn('Redis connection ended');
+      stopKeepAlive();
     });
+
+    // Local Redis uses the default `timeout 300` (5 min); TCP-level
+    // keepAlive alone doesn't reset the idle timer on most servers. Send
+    // a Redis-protocol PING every 30 s so the server counts it as activity.
+    // ioredis 5.10 doesn't expose a `pingInterval` option, so we run a
+    // guard-checked setInterval on the client ourselves.
+    const pingIntervalMs = 30000;
+    let pingTimer: NodeJS.Timeout | null = null;
+    const stopKeepAlive = (): void => {
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
+    };
+    const startKeepAlive = (): void => {
+      stopKeepAlive();
+      pingTimer = setInterval(() => {
+        // Only ping when the client is in a usable state. Failures are
+        // tolerated — the existing error/reconnecting handlers cover
+        // reconnect cycles and the next tick will retry.
+        if (client.status === 'ready') {
+          client.ping().catch(() => undefined);
+        }
+      }, pingIntervalMs);
+      // Don't keep the event loop alive just for this ping.
+      pingTimer.unref?.();
+    };
+    startKeepAlive();
+    client.on('ready', startKeepAlive);
 
     // Test the connection
     try {


### PR DESCRIPTION
## Description

Local Redis uses the default `timeout 300` (5 min). The ioredis client in `src/redis/redis.provider.ts` only set TCP-level `keepAlive`, which most Redis servers (and L4 proxies / NLB / NAT gateways) ignore for purposes of resetting the idle timer. The result: every 5 minutes of low traffic, the server drops the connection and PM2 logs cycle:

```
WARN [RedisProvider] Redis connection closed
WARN [RedisProvider] Reconnecting to Redis (attempt 1), delay: 2000ms
LOG  [RedisProvider] Redis client connecting...
LOG  [RedisProvider] Redis client connected and ready
```

Any requests landing in the 2-3 sec reconnect window queue against `enableOfflineQueue: true`, producing latency blips that aren't visible in error counts but are visible in tail latency.

### Fix

`ioredis@5.10` does not expose a `pingInterval` option in its types or runtime, so we run a guard-checked `setInterval` on the client. Every 30 s, when `client.status === 'ready'`, we send a Redis-protocol `PING`. The server counts that as activity and resets its idle timer.

The timer is created once and re-armed on every `'ready'` event; cleared on `'end'` (which fires from the graceful `quit()` in `RedisService.onModuleDestroy`). `timer.unref()` is used so the ping doesn't keep the event loop alive on its own.

```ts
const pingTimer = setInterval(() => {
  if (client.status === 'ready') {
    client.ping().catch(() => undefined);
  }
}, 30_000);
pingTimer.unref?.();
```

No new dependencies. No behavior change for active callers — the `'ready'` event still fires as before, only a second listener is added.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Local development — `pnpm build` passes (the prior `pingInterval` option caused a TS2769 build failure; this version compiles clean)
- [ ] Unit tests
- [ ] E2E tests
- [x] Other (describe): Verified the 5-min WARN cycle by reading PM2 logs in production. Runtime verification needs a 6+ minute idle observation after deploy — the cycle should be gone.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a; this is runtime tuning against local Redis with the default `timeout 300`. A unit test would need a real Redis with that configuration and idle traffic to be meaningful, which current test infra doesn't support.
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context

If 30s is too slow for some proxied path (e.g., behind aggressive NLB with sub-minute idle timeouts), drop the interval to 10_000. Cost: ~2 commands/min on the wire — negligible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Redis connection stability through periodic keepalive mechanism.
  * Resolved potential resource leak during failed connection initialization.

* **Performance**
  * Optimized background timers to prevent blocking application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->