### PR TITLE
fix(redis): prevent idle-disconnect cycle every 5 minutes (#364)

### DIFF
--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -235,13 +235,49 @@ export const RedisClientProvider: Provider = {
 
     client.on('end', () => {
       logger.warn('Redis connection ended');
+      stopKeepAlive();
     });
+
+    // Local Redis uses the default `timeout 300` (5 min); TCP-level
+    // keepAlive alone doesn't reset the idle timer on most servers. Send
+    // a Redis-protocol PING every 30 s so the server counts it as activity.
+    // ioredis 5.10 doesn't expose a `pingInterval` option, so we run a
+    // guard-checked setInterval on the client ourselves.
+    const pingIntervalMs = 30000;
+    let pingTimer: NodeJS.Timeout | null = null;
+    const stopKeepAlive = (): void => {
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
+    };
+    const startKeepAlive = (): void => {
+      stopKeepAlive();
+      pingTimer = setInterval(() => {
+        // Only ping when the client is in a usable state. Failures are
+        // tolerated — the existing error/reconnecting handlers cover
+        // reconnect cycles and the next tick will retry.
+        if (client.status === 'ready') {
+          client.ping().catch(() => undefined);
+        }
+      }, pingIntervalMs);
+      // Don't keep the event loop alive just for this ping.
+      pingTimer.unref?.();
+    };
+    startKeepAlive();
+    client.on('ready', startKeepAlive);
 
     // Test the connection
     try {
       await client.ping();
       logger.log('Redis connection test successful');
     } catch (error) {
+      // Stop the keepalive timer before disconnecting. We can't rely on the
+      // 'end' event from disconnect() to clean up the timer — it fires
+      // asynchronously and we want to drop the setInterval synchronously so the
+      // failed provider factory doesn't leave a timer scheduled against a
+      // disposed client.
+      stopKeepAlive();
       // Disconnect client to stop retry/reconnection attempts before propagating error
       try {
         client.disconnect();


### PR DESCRIPTION
# Pull Request

## Description

Local Redis uses the default `timeout 300` (5 min). The ioredis client in RedisProvider only set TCP-level keepAlive, which many Redis servers (and most managed providers / NLB / NAT gateways) ignore for purposes of resetting the idle timer. The result: every 5 minutes of low traffic, the connection is dropped by the server and the client logs:

  Redis connection closed
  Reconnecting to Redis (attempt 1), delay: 2000ms
  Redis client connecting...
  Redis client connected and ready

ioredis 5.10 does not expose `pingInterval` in its option types. Run a guard-checked setInterval on the client that sends a Redis-protocol PING every 30 seconds — that's what the server counts as activity and resets its idle timer. The timer is cleared on `end` (which includes the graceful `quit()` from `RedisService.onModuleDestroy`). Cost: ~2 commands/min on the wire.

* fix(redis): stop keepalive timer deterministically on failed connection test

The keepalive setInterval started by startKeepAlive() before the connection test was only cleaned up via the client's 'end' event after client.disconnect() — which fires asynchronously. If the ping threw during provider construction, the timer could remain scheduled against the (about-to-be-disposed) client until the event loop next fired.

Call stopKeepAlive() explicitly at the top of the catch block so the cleanup is synchronous and deterministic, mirroring what 'end' would have done on connection teardown.
Fixes #(issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Local development
- [ ] Unit tests
- [ ] E2E tests
- [ ] Other (describe):

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional context 