### PR TITLE
chore: add malware-scan CI (global['!'] injector gate + weekly shai-hulud)

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -1,0 +1,56 @@
+name: malware-scan
+
+# Guards against the global['!'] JS-injector incident (2026-06):
+#  - on every push / PR: fast check for the injector marker + payloads disguised as fonts
+#  - weekly: deep scan with Cobenian/shai-hulud-detect (the Shai-Hulud npm worm)
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'   # Mondays 03:00 UTC
+
+jobs:
+  injector-check:
+    name: global['!'] injector + disguised-font check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan working tree
+        run: |
+          set -uo pipefail
+          MARK="global['!']"
+          hits=$(grep -rlF "$MARK" . \
+            --include='*.js' --include='*.mjs' --include='*.cjs' \
+            --include='*.ts' --include='*.tsx' --include='*.jsx' \
+            --include='*.json' --include='*.vue' --include='*.svelte' \
+            --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null || true)
+          fonts=$(find . -name '*.woff2' -not -path '*/node_modules/*' -not -path '*/.git/*' \
+            -exec grep -lF "$MARK" {} + 2>/dev/null || true)
+          if [ -n "${hits}${fonts}" ]; then
+            echo "::error::Malware indicators found (global['!'] injector / disguised font):"
+            [ -n "$hits" ] && printf '%s\n' "$hits"
+            [ -n "$fonts" ] && printf '%s\n' "$fonts"
+            exit 1
+          fi
+          echo "Clean — no global['!'] injector marker or disguised fonts."
+
+  shai-hulud-deep:
+    name: shai-hulud-detect (weekly)
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies (best effort, for node_modules scan)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable && (pnpm install --frozen-lockfile || pnpm install || true)
+          elif [ -f package-lock.json ]; then
+            npm ci || npm install || true
+          elif [ -f yarn.lock ]; then
+            corepack enable && (yarn install --immutable || yarn install || true)
+          fi
+      - name: Run shai-hulud-detect
+        run: |
+          git clone --depth 1 https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          bash /tmp/shd/shai-hulud-detector.sh .

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -1,5 +1,9 @@
 name: malware-scan
 
+# Least privilege: this scanner only needs to read the repo.
+permissions:
+  contents: read
+
 # Guards against the global['!'] JS-injector incident (2026-06):
 #  - on every push / PR: fast check for the injector marker + payloads disguised as fonts
 #  - weekly: deep scan with Cobenian/shai-hulud-detect (the Shai-Hulud npm worm)
@@ -15,7 +19,9 @@ jobs:
     name: global['!'] injector + disguised-font check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Scan working tree
         run: |
           set -uo pipefail
@@ -40,17 +46,20 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies (best effort, for node_modules scan)
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install dependencies (best effort, no lifecycle scripts)
         run: |
           if [ -f pnpm-lock.yaml ]; then
-            corepack enable && (pnpm install --frozen-lockfile || pnpm install || true)
+            corepack enable && (pnpm install --frozen-lockfile --ignore-scripts || pnpm install --ignore-scripts || true)
           elif [ -f package-lock.json ]; then
-            npm ci || npm install || true
+            npm ci --ignore-scripts || npm install --ignore-scripts || true
           elif [ -f yarn.lock ]; then
-            corepack enable && (yarn install --immutable || yarn install || true)
+            corepack enable && (yarn install --immutable --mode=skip-builds || yarn install --ignore-scripts || true)
           fi
-      - name: Run shai-hulud-detect
+      - name: Run shai-hulud-detect (pinned commit)
         run: |
-          git clone --depth 1 https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          git clone https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          git -C /tmp/shd checkout 353143a915d63e95e9a3ab1112d95f7692729a0e
           bash /tmp/shd/shai-hulud-detector.sh .


### PR DESCRIPTION
Adds `.github/workflows/malware-scan.yml`:
- **injector-check** on every push/PR — fails the build if the `global['!']` injector marker or a payload disguised as a `.woff2` font is present (fast, skips node_modules).
- **shai-hulud-deep** weekly (Mon 03:00 UTC) — runs Cobenian/shai-hulud-detect against installed deps.

Follow-up hardening from the 2026-06 malware incident. No functional/runtime code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated malware scanning to incoming changes and scheduled maintenance checks.
  * Expanded coverage to catch suspicious patterns in source files and font assets.
  * If indicators are found, the check now fails clearly with an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->