### PR TITLE
chore(deploy): stop silent crash-loops (pm2 restart caps + 60s health gate)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,11 +390,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Production deployment verified successfully"
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -392,11 +392,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Deployment verified successfully"
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -376,11 +376,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Staging deployment verified successfully"
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -25,6 +25,12 @@ const baseConfig = {
   autorestart: true,
   watch: false,
   max_memory_restart: '1G',
+  // Stop infinite crash-loops: the app must stay up `min_uptime` to count as a
+  // successful boot; after `max_restarts` rapid failures pm2 marks the process
+  // `errored` and stops restarting it (instead of thrashing the CPU forever).
+  min_uptime: '15s',
+  max_restarts: 10,
+  restart_delay: 4000,
 };
 
 module.exports = {


### PR DESCRIPTION
Follow-up after staging sat crash-looping (~1.77M restarts) for days, unnoticed, until a manual fix.

### 1. pm2 restart caps — `ecosystem.config.js`
`baseConfig` had `autorestart: true` with **no limit**, so a broken app restarts forever, pinning CPU silently. Added:
- `min_uptime: '15s'` — must stay up 15s to count as a good boot
- `max_restarts: 10` — after 10 rapid failures pm2 marks it `errored` and **stops** thrashing
- `restart_delay: 4000` — backoff between restarts

Applies to dev/staging/prod (shared `baseConfig`).

### 2. Deploy health gate now catches crash-loops — dev/staging/prod workflows
The post-deploy check was a single `sleep 10; curl health` — which a crash-loop passes if it happens to be up at second 10. Now it re-checks every 5s for ~60s and requires the app to still be healthy at the end, so a boot-then-crash deploy **fails**.

No app/runtime code changed. Verified: `ecosystem.config.js` loads, all 3 workflows are valid YAML.