### PR TITLE
chore(deploy): stop silent crash-loops (pm2 restart caps + 60s health gate)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,16 +390,21 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for the app to start AND stay healthy for ~60s.
-            # A single instant check passes a crash-loop that dies seconds later,
-            # so re-check every 5s and require it to still be healthy at the end.
-            ok=0
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
             for i in $(seq 1 12); do
               sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
             done
-            if [ "$ok" != "1" ]; then
-              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
             fi
 
             echo "Production deployment verified successfully"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,11 +390,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Production deployment verified successfully"
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -392,11 +392,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Deployment verified successfully"
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -392,16 +392,21 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for the app to start AND stay healthy for ~60s.
-            # A single instant check passes a crash-loop that dies seconds later,
-            # so re-check every 5s and require it to still be healthy at the end.
-            ok=0
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
             for i in $(seq 1 12); do
               sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
             done
-            if [ "$ok" != "1" ]; then
-              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
             fi
 
             echo "Deployment verified successfully"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -376,11 +376,17 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Wait for the app to start AND stay healthy for ~60s.
+            # A single instant check passes a crash-loop that dies seconds later,
+            # so re-check every 5s and require it to still be healthy at the end.
+            ok=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+            done
+            if [ "$ok" != "1" ]; then
+              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            fi
 
             echo "Staging deployment verified successfully"
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -376,16 +376,21 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for the app to start AND stay healthy for ~60s.
-            # A single instant check passes a crash-loop that dies seconds later,
-            # so re-check every 5s and require it to still be healthy at the end.
-            ok=0
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
             for i in $(seq 1 12); do
               sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then ok=1; else ok=0; fi
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
             done
-            if [ "$ok" != "1" ]; then
-              echo "App not healthy after 60s (possible crash-loop)"; exit 1
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
             fi
 
             echo "Staging deployment verified successfully"

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -25,6 +25,12 @@ const baseConfig = {
   autorestart: true,
   watch: false,
   max_memory_restart: '1G',
+  // Stop infinite crash-loops: the app must stay up `min_uptime` to count as a
+  // successful boot; after `max_restarts` rapid failures pm2 marks the process
+  // `errored` and stops restarting it (instead of thrashing the CPU forever).
+  min_uptime: '15s',
+  max_restarts: 10,
+  restart_delay: 4000,
 };
 
 module.exports = {


### PR DESCRIPTION
Follow-up after staging sat crash-looping (~1.77M restarts) for days unnoticed.

**1. pm2 restart caps (`ecosystem.config.js`)** — `min_uptime: '15s'`, `max_restarts: 10`, `restart_delay: 4000` on shared `baseConfig`. pm2 marks a fast-crashing app `errored` and stops thrashing instead of restarting forever.

**2. Deploy health gate (dev/staging/prod workflows)** — post-deploy check now verifies the app **stays** healthy ~60s (re-check every 5s) instead of one instant curl, so a boot-then-crash deploy fails.

No app/runtime code changed. Targets `develop-v1.2.0` to flow dev → staging → prod (supersedes #368, which incorrectly targeted main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment verification to poll health checks over time, reducing false positives from short-lived startup crashes.
  * Added restart limits and delays to help prevent rapid crash-loop thrashing in running services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->