### PR TITLE
Promote develop-v1.2.0 → staging (release-v1.2.0)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,11 +390,22 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
+            done
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
 
             echo "Production deployment verified successfully"
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -392,11 +392,22 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
+            done
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
 
             echo "Deployment verified successfully"
 

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -1,0 +1,65 @@
+name: malware-scan
+
+# Least privilege: this scanner only needs to read the repo.
+permissions:
+  contents: read
+
+# Guards against the global['!'] JS-injector incident (2026-06):
+#  - on every push / PR: fast check for the injector marker + payloads disguised as fonts
+#  - weekly: deep scan with Cobenian/shai-hulud-detect (the Shai-Hulud npm worm)
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'   # Mondays 03:00 UTC
+
+jobs:
+  injector-check:
+    name: global['!'] injector + disguised-font check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Scan working tree
+        run: |
+          set -uo pipefail
+          MARK="global['!']"
+          hits=$(grep -rlF "$MARK" . \
+            --include='*.js' --include='*.mjs' --include='*.cjs' \
+            --include='*.ts' --include='*.tsx' --include='*.jsx' \
+            --include='*.json' --include='*.vue' --include='*.svelte' \
+            --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null || true)
+          fonts=$(find . -name '*.woff2' -not -path '*/node_modules/*' -not -path '*/.git/*' \
+            -exec grep -lF "$MARK" {} + 2>/dev/null || true)
+          if [ -n "${hits}${fonts}" ]; then
+            echo "::error::Malware indicators found (global['!'] injector / disguised font):"
+            [ -n "$hits" ] && printf '%s\n' "$hits"
+            [ -n "$fonts" ] && printf '%s\n' "$fonts"
+            exit 1
+          fi
+          echo "Clean — no global['!'] injector marker or disguised fonts."
+
+  shai-hulud-deep:
+    name: shai-hulud-detect (weekly)
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install dependencies (best effort, no lifecycle scripts)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable && (pnpm install --frozen-lockfile --ignore-scripts || pnpm install --ignore-scripts || true)
+          elif [ -f package-lock.json ]; then
+            npm ci --ignore-scripts || npm install --ignore-scripts || true
+          elif [ -f yarn.lock ]; then
+            corepack enable && (yarn install --immutable --mode=skip-builds || yarn install --ignore-scripts || true)
+          fi
+      - name: Run shai-hulud-detect (pinned commit)
+        run: |
+          git clone https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          git -C /tmp/shd checkout 353143a915d63e95e9a3ab1112d95f7692729a0e
+          bash /tmp/shd/shai-hulud-detector.sh .

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -376,11 +376,22 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
+            done
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
 
             echo "Staging deployment verified successfully"
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -25,6 +25,12 @@ const baseConfig = {
   autorestart: true,
   watch: false,
   max_memory_restart: '1G',
+  // Stop infinite crash-loops: the app must stay up `min_uptime` to count as a
+  // successful boot; after `max_restarts` rapid failures pm2 marks the process
+  // `errored` and stops restarting it (instead of thrashing the CPU forever).
+  min_uptime: '15s',
+  max_restarts: 10,
+  restart_delay: 4000,
 };
 
 module.exports = {

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -235,13 +235,49 @@ export const RedisClientProvider: Provider = {
 
     client.on('end', () => {
       logger.warn('Redis connection ended');
+      stopKeepAlive();
     });
+
+    // Local Redis uses the default `timeout 300` (5 min); TCP-level
+    // keepAlive alone doesn't reset the idle timer on most servers. Send
+    // a Redis-protocol PING every 30 s so the server counts it as activity.
+    // ioredis 5.10 doesn't expose a `pingInterval` option, so we run a
+    // guard-checked setInterval on the client ourselves.
+    const pingIntervalMs = 30000;
+    let pingTimer: NodeJS.Timeout | null = null;
+    const stopKeepAlive = (): void => {
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
+    };
+    const startKeepAlive = (): void => {
+      stopKeepAlive();
+      pingTimer = setInterval(() => {
+        // Only ping when the client is in a usable state. Failures are
+        // tolerated — the existing error/reconnecting handlers cover
+        // reconnect cycles and the next tick will retry.
+        if (client.status === 'ready') {
+          client.ping().catch(() => undefined);
+        }
+      }, pingIntervalMs);
+      // Don't keep the event loop alive just for this ping.
+      pingTimer.unref?.();
+    };
+    startKeepAlive();
+    client.on('ready', startKeepAlive);
 
     // Test the connection
     try {
       await client.ping();
       logger.log('Redis connection test successful');
     } catch (error) {
+      // Stop the keepalive timer before disconnecting. We can't rely on the
+      // 'end' event from disconnect() to clean up the timer — it fires
+      // asynchronously and we want to drop the setInterval synchronously so the
+      // failed provider factory doesn't leave a timer scheduled against a
+      // disposed client.
+      stopKeepAlive();
       // Disconnect client to stop retry/reconnection attempts before propagating error
       try {
         client.disconnect();


### PR DESCRIPTION
Promotes the current dev line to **staging**. Brings in:
- #369 — deploy resilience: pm2 restart caps + 60s streak-based health gate
- #367 — malware-scan CI (global['!'] injector gate + weekly shai-hulud)
- #364 — redis idle-disconnect fix

Merging triggers the Staging CI/CD Pipeline → deploy to staging. No conflicts with release-v1.2.0.