### PR TITLE
chore(ci): make malware-scan actionable (gate on real findings)

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -4,13 +4,24 @@ name: malware-scan
 permissions:
   contents: read
 
-# Guards against the global['!'] JS-injector incident (2026-06):
-#  - on every push / PR: fast check for the injector marker + payloads disguised as fonts
-#  - weekly: deep scan with Cobenian/shai-hulud-detect (the Shai-Hulud npm worm)
+# Guards against npm/PyPI supply-chain compromise:
+#  - on every push / PR: fast check for the global['!'] JS-injector marker + payloads disguised as fonts
+#  - weekly (and on demand): deep scan with Cobenian/shai-hulud-detect
+#
+# The deep scan exits non-zero on ANY finding, and many of its broad content
+# heuristics false-positive on legitimate AI / crypto / analytics SDKs (e.g.
+# elevenlabs' /v1/models path matching a "durabletask C2" string). So we run the
+# scanner for its data (--json), then gate ourselves: a curated allowlist drops
+# verified known-good false positives, the build fails only on UNRESOLVED HIGH
+# findings, and medium/low are reported as advisory. Suppression requires BOTH a
+# package-path AND the exact benign reason to match, so a genuinely malicious
+# package (hash match, compromised-package list, or real IOC string) is never
+# silenced and will still fail the build.
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1'   # Mondays 03:00 UTC
 
@@ -43,7 +54,7 @@ jobs:
 
   shai-hulud-deep:
     name: shai-hulud-detect (weekly)
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -60,6 +71,83 @@ jobs:
           fi
       - name: Run shai-hulud-detect (pinned commit)
         run: |
-          git clone https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
-          git -C /tmp/shd checkout 353143a915d63e95e9a3ab1112d95f7692729a0e
-          bash /tmp/shd/shai-hulud-detector.sh .
+          set -uo pipefail
+          git clone --quiet https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          git -C /tmp/shd checkout --quiet 353143a915d63e95e9a3ab1112d95f7692729a0e
+          # The detector exits non-zero on any finding; we gate ourselves on the
+          # JSON below, so don't let its exit code abort the step.
+          bash /tmp/shd/shai-hulud-detector.sh --json findings.json --save-log findings.log . || true
+          if [ ! -f findings.json ]; then
+            echo "::error::shai-hulud-detect produced no findings.json — the scan failed to run."
+            exit 1
+          fi
+      - name: Triage findings (allowlist verified false positives, gate on HIGH)
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Verified known-good false positives (reviewed 2026-06-29).
+          # Each rule is "<path-substring>|<message-substring>". A finding is
+          # suppressed ONLY when BOTH match, so a real compromise of the same
+          # package (different reason: hash match / compromised-package / real
+          # IOC string) is never silenced.
+          ALLOW=(
+            "/elevenlabs/|durabletask C2 reference (/v1/models)"
+            "/elevenlabs/|durabletask C2 reference (/audio.mp3)"
+            "/formdata-polyfill/|XMLHttpRequest prototype modification detected"
+            "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected"
+            "/@noble/ed25519/|Ethereum wallet address patterns"
+            "/@faker-js/faker/|Ethereum wallet address patterns"
+          )
+
+          jq -r '.findings[]? | [.severity, .file, .message] | @tsv' findings.json > all.tsv || : > all.tsv
+
+          : > remaining.tsv
+          sup=0
+          while IFS=$'\t' read -r sev file msg; do
+            [ -z "${sev:-}" ] && continue
+            matched=no
+            for rule in "${ALLOW[@]}"; do
+              p="${rule%%|*}"; m="${rule#*|}"
+              if [[ "$file" == *"$p"* && "$msg" == *"$m"* ]]; then matched=yes; break; fi
+            done
+            if [ "$matched" = yes ]; then
+              sup=$((sup+1))
+            else
+              printf '%s\t%s\t%s\n' "$sev" "$file" "$msg" >> remaining.tsv
+            fi
+          done < all.tsv
+
+          high=$(awk -F'\t' 'tolower($1)=="high"{c++} END{print c+0}' remaining.tsv)
+          med=$(awk -F'\t'  'tolower($1)=="medium"{c++} END{print c+0}' remaining.tsv)
+          low=$(awk -F'\t'  'tolower($1)=="low"{c++} END{print c+0}' remaining.tsv)
+
+          {
+            echo "## Malware scan (shai-hulud-detect)"
+            echo ""
+            echo "| Severity | Count (after allowlist) |"
+            echo "|---|---|"
+            echo "| 🔴 High (blocking) | $high |"
+            echo "| 🟡 Medium (advisory) | $med |"
+            echo "| ⚪ Low (advisory) | $low |"
+            echo "| ✅ Suppressed (verified false positives) | $sup |"
+            echo ""
+            if [ "$high" -gt 0 ]; then
+              echo "### 🔴 Unresolved HIGH findings — build failed"
+              echo '```'
+              awk -F'\t' 'tolower($1)=="high"{print $2" — "$3}' remaining.tsv
+              echo '```'
+            fi
+            if [ "$med" -gt 0 ] || [ "$low" -gt 0 ]; then
+              echo "### Advisory (non-blocking)"
+              echo '```'
+              awk -F'\t' 'tolower($1)=="medium"||tolower($1)=="low"{print toupper($1)": "$2" — "$3}' remaining.tsv
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+          if [ "$high" -gt 0 ]; then
+            echo "::error::$high unresolved HIGH-risk malware indicator(s) — review the job summary."
+            exit 1
+          fi
+          echo "OK — no unresolved high-risk indicators (medium=$med low=$low suppressed=$sup)."

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -71,12 +71,18 @@ jobs:
           fi
       - name: Run shai-hulud-detect (pinned commit)
         run: |
-          set -uo pipefail
+          set -euo pipefail
+          # Fail closed: a stale findings.json must never satisfy the check below.
+          rm -f findings.json findings.log
+          # With set -e a failed clone/checkout aborts the step (good — we must not
+          # silently skip the scan).
           git clone --quiet https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
           git -C /tmp/shd checkout --quiet 353143a915d63e95e9a3ab1112d95f7692729a0e
           # The detector exits non-zero on any finding; we gate ourselves on the
-          # JSON below, so don't let its exit code abort the step.
-          bash /tmp/shd/shai-hulud-detector.sh --json findings.json --save-log findings.log . || true
+          # JSON below, so its exit code alone must not abort the step.
+          if ! bash /tmp/shd/shai-hulud-detector.sh --json findings.json --save-log findings.log .; then
+            echo "shai-hulud-detect exited non-zero (findings present); continuing to triage its JSON."
+          fi
           if [ ! -f findings.json ]; then
             echo "::error::shai-hulud-detect produced no findings.json — the scan failed to run."
             exit 1
@@ -87,20 +93,28 @@ jobs:
           set -uo pipefail
 
           # Verified known-good false positives (reviewed 2026-06-29).
-          # Each rule is "<path-substring>|<message-substring>". A finding is
-          # suppressed ONLY when BOTH match, so a real compromise of the same
-          # package (different reason: hash match / compromised-package / real
-          # IOC string) is never silenced.
+          # Each rule is "<path-substring>|<exact-reason>". A finding is suppressed
+          # ONLY when the file path contains <path-substring> AND the message equals
+          # <exact-reason> exactly. The reason is the FP signature itself, so a real
+          # compromise of the same package (hash match / compromised-package / a
+          # different IOC string) has a different message and is never silenced —
+          # even when it shares the package and the HIGH severity.
           ALLOW=(
             "/elevenlabs/|durabletask C2 reference (/v1/models)"
             "/elevenlabs/|durabletask C2 reference (/audio.mp3)"
-            "/formdata-polyfill/|XMLHttpRequest prototype modification detected"
-            "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected"
-            "/@noble/ed25519/|Ethereum wallet address patterns"
-            "/@faker-js/faker/|Ethereum wallet address patterns"
+            "/formdata-polyfill/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
+            "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
+            "/@noble/ed25519/|Ethereum wallet address patterns detected"
+            "/@faker-js/faker/|Ethereum wallet address patterns detected"
           )
 
-          jq -r '.findings[]? | [.severity, .file, .message] | @tsv' findings.json > all.tsv || : > all.tsv
+          # Fail closed if the detector JSON is missing/malformed — never treat a
+          # broken scan as "no findings".
+          if ! jq -e 'type=="object" and (.findings|type=="array")' findings.json >/dev/null 2>&1; then
+            echo "::error::shai-hulud-detect JSON has no top-level findings array — failing closed."
+            exit 1
+          fi
+          jq -r '.findings[] | [(.severity // ""), (.file // ""), (.message // "")] | @tsv' findings.json > all.tsv
 
           : > remaining.tsv
           sup=0
@@ -109,7 +123,7 @@ jobs:
             matched=no
             for rule in "${ALLOW[@]}"; do
               p="${rule%%|*}"; m="${rule#*|}"
-              if [[ "$file" == *"$p"* && "$msg" == *"$m"* ]]; then matched=yes; break; fi
+              if [[ "$file" == *"$p"* && "$msg" == "$m" ]]; then matched=yes; break; fi
             done
             if [ "$matched" = yes ]; then
               sup=$((sup+1))


### PR DESCRIPTION
## What

Makes the weekly `malware-scan` (Cobenian/shai-hulud-detect) job actionable instead of permanently red.

## Why

The detector exits non-zero on **any** finding, and several of its broad content heuristics false-positive on legitimate dependencies — e.g. the ElevenLabs SDK's `/v1/models` path matched a "durabletask C2 reference", and `formdata-polyfill` / `@amplitude/analytics-core` / `@noble/ed25519` / `@faker-js/faker` tripped crypto-pattern checks. Result: the Monday scheduled run failed across most repos with **zero actual malware present** (the unique, high-confidence IOCs — known hashes, compromised-package list, real C2 strings — all matched nothing).

A permanently-failing security scan trains everyone to ignore it, which is the real risk.

## How

Instead of trusting the detector's exit code, we run it with `--json` and gate ourselves:

- A curated allowlist suppresses **verified** false positives, matched by **both** package path **and** the exact benign reason. A real compromise of the same package (hash match / compromised-package / different IOC) has a different message and is therefore **never** silenced.
- The build fails only on **unresolved HIGH** findings (the genuine-compromise tier).
- Medium/low are reported as **advisory** in the job summary, not blocking.
- Added `workflow_dispatch` so the deep scan can be run on demand.
- The fast push/PR `injector-check` job is unchanged.

Validated locally against the actual findings from this week's runs (all suppressed → green) and against simulated genuine indicators — including an escalated HIGH finding inside an allowlisted package — which correctly still fail the build.

The allowlist is inline and commented; add a `path|reason` line to extend it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded malware scanning coverage with clearer run modes, including push/PR checks, scheduled deep scans, and manual runs.
  * Improved scan reporting with a structured findings summary, severity counts (HIGH/medium/low), and controlled suppression for approved items.
  * Workflow behavior updated so unresolved HIGH findings block the workflow, while medium/low findings remain advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->