### PR TITLE
feat(story): reliable read status + fresh-first home feed

### DIFF
--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -145,14 +145,21 @@ describe('StoryService - Library & Generation', () => {
 
         await service.getStories({ userId: 'user-1', minAge: 3, maxAge: 5 });
 
+        // Authenticated users fetch FRESH stories only: the catalog where is
+        // wrapped at the top level with the read anti-join.
         expect(prisma.story.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              // Check overlap logic: story.ageMin <= 5 AND story.ageMax >= 3
-              ageMin: { lte: 5 },
-              ageMax: { gte: 3 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  // Overlap logic: story.ageMin <= 5 AND story.ageMax >= 3
+                  ageMin: { lte: 5 },
+                  ageMax: { gte: 3 },
+                }),
+                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+              ],
+            },
           }),
         );
       });
@@ -166,10 +173,15 @@ describe('StoryService - Library & Generation', () => {
 
         expect(prisma.story.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              ageMax: { gte: 4 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  ageMax: { gte: 4 },
+                }),
+                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+              ],
+            },
           }),
         );
       });
@@ -183,10 +195,15 @@ describe('StoryService - Library & Generation', () => {
 
         expect(prisma.story.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              ageMin: { lte: 8 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  ageMin: { lte: 8 },
+                }),
+                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+              ],
+            },
           }),
         );
       });
@@ -199,10 +216,17 @@ describe('StoryService - Library & Generation', () => {
         ];
         prisma.story.count.mockResolvedValue(3);
         prisma.story.findMany.mockResolvedValue(stories);
-        prisma.userStoryProgress.findMany.mockResolvedValue([
-          { storyId: 'story-1', progress: 100 },
-          { storyId: 'story-2', progress: 50 },
-        ]);
+        // The read-status enrich query uses `select`; the fresh-first backfill
+        // query uses `include`. Return progress for the former, nothing for the
+        // latter (the page is filled by the 3 fresh stories).
+        prisma.userStoryProgress.findMany.mockImplementation((args) =>
+          args?.select
+            ? Promise.resolve([
+                { storyId: 'story-1', progress: 100, completed: true },
+                { storyId: 'story-2', progress: 50, completed: false },
+              ])
+            : Promise.resolve([]),
+        );
 
         const result = await service.getStories({ userId: 'user-1' });
 
@@ -216,14 +240,18 @@ describe('StoryService - Library & Generation', () => {
         expect(result.data[2]).toEqual(
           expect.objectContaining({ id: 'story-1', readStatus: 'done' }),
         );
-        expect(prisma.userStoryProgress.findMany).toHaveBeenCalledTimes(1);
+        // Exactly one read-status enrich query (selects progress + completed).
+        const selectCalls = prisma.userStoryProgress.findMany.mock.calls.filter(
+          (c) => c[0]?.select,
+        );
+        expect(selectCalls).toHaveLength(1);
         expect(prisma.userStoryProgress.findMany).toHaveBeenCalledWith({
           where: {
             userId: 'user-1',
             storyId: { in: ['story-1', 'story-2', 'story-3'] },
             isDeleted: false,
           },
-          select: { storyId: true, progress: true },
+          select: { storyId: true, progress: true, completed: true },
         });
       });
 
@@ -349,19 +377,29 @@ describe('StoryService - Library & Generation', () => {
         { id: 'story-3', title: 'Top Liked Unread' },
       ];
 
-      // story.findMany: 1st call = recommended, 2nd call = topLiked
-      // (no seasonal call since season.findMany returns [])
+      // story.findMany: 1st = recommended (fresh), 2nd = topLiked (fresh),
+      // 3rd = topLiked read-backfill (ranked by likes; returns [] here since the
+      // fresh stories already fill the section). No seasonal call since
+      // season.findMany returns [].
       prisma.story.findMany
         .mockResolvedValueOnce(recommended)
-        .mockResolvedValueOnce(topLiked);
+        .mockResolvedValueOnce(topLiked)
+        .mockResolvedValueOnce([]);
 
       prisma.season.findMany.mockResolvedValue([]);
 
-      prisma.userStoryProgress.findMany.mockResolvedValue([
-        { storyId: 'story-1', progress: 100 },
-        { storyId: 'story-2', progress: 50 },
-        // story-3 has no progress (unread)
-      ]);
+      // Read-status enrich uses `select`; per-section fresh-first top-up uses
+      // `include`. Return progress for enrich, nothing for the top-ups (the
+      // sections are already filled by the fresh stories above).
+      prisma.userStoryProgress.findMany.mockImplementation((args) =>
+        args?.select
+          ? Promise.resolve([
+              { storyId: 'story-1', progress: 100, completed: true },
+              { storyId: 'story-2', progress: 50, completed: false },
+              // story-3 has no progress (unread)
+            ])
+          : Promise.resolve([]),
+      );
 
       const result = await service.getHomePageStories(userId);
 
@@ -377,8 +415,12 @@ describe('StoryService - Library & Generation', () => {
         expect.objectContaining({ id: 'story-2', readStatus: 'reading' }),
       );
 
-      // Verify only 1 DB call for progress (not 1 per section)
-      expect(prisma.userStoryProgress.findMany).toHaveBeenCalledTimes(1);
+      // Verify only 1 read-status enrich query for all sections (not 1 per
+      // section); the fresh-first top-ups use separate `include` queries.
+      const selectCalls = prisma.userStoryProgress.findMany.mock.calls.filter(
+        (c) => c[0]?.select,
+      );
+      expect(selectCalls).toHaveLength(1);
     });
   });
 

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -157,7 +157,11 @@ describe('StoryService - Library & Generation', () => {
                   ageMin: { lte: 5 },
                   ageMax: { gte: 3 },
                 }),
-                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
               ],
             },
           }),
@@ -179,7 +183,11 @@ describe('StoryService - Library & Generation', () => {
                   isDeleted: false,
                   ageMax: { gte: 4 },
                 }),
-                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
               ],
             },
           }),
@@ -201,7 +209,11 @@ describe('StoryService - Library & Generation', () => {
                   isDeleted: false,
                   ageMin: { lte: 8 },
                 }),
-                { userProgress: { none: { userId: 'user-1', isDeleted: false } } },
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
               ],
             },
           }),

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -640,7 +640,9 @@ export class StoryService {
         ...(readEnriched as unknown as Record<string, unknown>[]),
       ],
       pagination: {
-        nextCursor: readHasNext ? `r:${readPage[readPage.length - 1].id}` : null,
+        nextCursor: readHasNext
+          ? `r:${readPage[readPage.length - 1].id}`
+          : null,
         hasNextPage: readHasNext,
       },
     };
@@ -779,13 +781,12 @@ export class StoryService {
       // partially read, and unseen only when there is no meaningful progress.
       return {
         ...story,
-        readStatus: (
+        readStatus:
           completed || progressValue >= 100
             ? 'done'
             : progressValue <= 0
               ? null
-              : 'reading'
-        ) as 'done' | 'reading' | null,
+              : 'reading',
       };
     });
   }
@@ -1067,7 +1068,9 @@ export class StoryService {
         ? {
             isDeleted: false,
             categories: {
-              some: { id: { in: preferredCategories.map((c: Category) => c.id) } },
+              some: {
+                id: { in: preferredCategories.map((c: Category) => c.id) },
+              },
             },
           }
         : { isDeleted: false };

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -77,6 +77,15 @@ export class StoryService {
   // Average reading speed for children: ~150 words per minute
   private readonly WORDS_PER_MINUTE = 150;
   private readonly CATEGORY_HOLIDAY_SEASONAL = 'Holiday/Seasonal';
+  /** Standard relations returned by story list endpoints (used for fresh-first read backfill). */
+  private readonly storyListInclude: Prisma.StoryInclude = {
+    images: true,
+    branches: true,
+    categories: true,
+    themes: true,
+    seasons: true,
+    questions: true,
+  };
 
   /** Wraps a Prisma query to handle invalid cursor IDs gracefully */
   private async withCursorErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
@@ -130,6 +139,7 @@ export class StoryService {
   }
 
   private async buildStoryWhereClause(filter: {
+    userId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -356,6 +366,13 @@ export class StoryService {
         ]
       : [{ createdAt: 'desc' as const }, { id: 'asc' as const }];
 
+    // Fresh-first: authenticated users fetch FRESH stories only here (no
+    // non-deleted progress row). Read stories are added afterwards as backfill.
+    // Guests get `where` unchanged (byte-for-byte identical responses).
+    // totalCount is still counted on the unfiltered `where` so it reflects the
+    // full result set (fresh + read) and pagination metadata stays correct.
+    const freshWhere = this.withUserReadFilter(where, filter.userId, 'fresh');
+
     // Run count and findMany in parallel to reduce latency by ~50%
     // For topPicksFromUs, pagination is handled in the raw SQL query
     const [totalCount, queriedStories] = await Promise.all([
@@ -363,7 +380,7 @@ export class StoryService {
         ? this.prisma.story.count({ where: { isDeleted: false } })
         : this.prisma.story.count({ where }),
       this.prisma.story.findMany({
-        where,
+        where: freshWhere,
         ...(filter.topPicksFromUs || shouldSortBySeason
           ? {}
           : {
@@ -441,8 +458,49 @@ export class StoryService {
           }) as typeof sortedStories)
         : sortedStories;
 
+    // Fresh-first backfill (authenticated users only): the page above is drawn
+    // from FRESH stories only. If the fresh pool cannot fill the requested
+    // limit, top up with already-read stories ranked last (most recently
+    // accessed first). For page 1 (and the page-1 carousels) readSkip is 0; for
+    // deeper offset pages we compute how many read rows earlier pages already
+    // consumed via `skip - freshCount` so there is no overlap or gap.
+    let pageData = cleanedStories as unknown as Record<string, unknown>[];
+    if (filter.userId) {
+      const deficit = limit - pageData.length;
+      if (deficit > 0) {
+        // For topPicksFromUs the page is already scoped by a per-page id window
+        // (where.id in randomStoryIds), so applying the global read offset would
+        // skip inside that small window and leave the page short — backfill from
+        // the start of the window instead.
+        const freshCount =
+          !filter.topPicksFromUs && skip > 0
+            ? await this.prisma.story.count({ where: freshWhere })
+            : 0;
+        const readSkip = filter.topPicksFromUs
+          ? 0
+          : Math.max(0, skip - freshCount);
+        const backfill = await this.fetchReadBackfill(
+          where,
+          filter.userId,
+          readSkip,
+          deficit,
+          this.storyListInclude,
+        );
+        if (backfill.length > 0) {
+          const enrichedBackfill = await this.enrichWithReadStatus(
+            filter.userId,
+            backfill,
+          );
+          pageData = [
+            ...pageData,
+            ...(enrichedBackfill as unknown as Record<string, unknown>[]),
+          ];
+        }
+      }
+    }
+
     return {
-      data: cleanedStories,
+      data: pageData,
       pagination: {
         currentPage: page,
         totalPages,
@@ -471,42 +529,158 @@ export class StoryService {
 
     const orderBy = [{ createdAt: 'desc' as const }, { id: 'asc' as const }];
 
-    const stories = await this.withCursorErrorHandling(() =>
+    // GUEST / PUBLIC PATH — unchanged behaviour (byte-for-byte identical).
+    if (!filter.userId) {
+      const stories = await this.withCursorErrorHandling(() =>
+        this.prisma.story.findMany({
+          where,
+          take: limit + 1,
+          ...(filter.cursor ? { cursor: { id: filter.cursor }, skip: 1 } : {}),
+          orderBy,
+          include: this.storyListInclude,
+        }),
+      );
+
+      const { data, pagination } = PaginationUtil.buildCursorResponse(
+        stories,
+        limit,
+      );
+
+      const enriched = filter.guestSessionId
+        ? await this.enrichWithGuestReadStatus(filter.guestSessionId, data)
+        : data.map((s) => ({ ...s, readStatus: null }));
+
+      return { data: this.sortByReadStatus(enriched), pagination };
+    }
+
+    // AUTHENTICATED PATH — fresh-first with read backfill across a composite
+    // cursor. Format: `r:<progressId>` continues the READ stream; anything else
+    // (a bare story id or `f:<storyId>`, incl. legacy raw cursors) continues the
+    // FRESH stream. Fresh stories are served first; once the fresh pool is
+    // exhausted we backfill with read stories ordered by lastAccessed desc.
+    // NOTE: the cursor stays a single opaque string for the client.
+    const userId = filter.userId;
+    const rawCursor = filter.cursor;
+
+    // READ stream continuation.
+    if (rawCursor?.startsWith('r:')) {
+      const progressCursor = rawCursor.slice(2) || undefined;
+      return this.fetchReadStreamPage(userId, where, progressCursor, limit);
+    }
+
+    // FRESH stream (default / start). Tolerate legacy bare story-id cursors.
+    const freshCursor = rawCursor?.startsWith('f:')
+      ? rawCursor.slice(2) || undefined
+      : rawCursor;
+    const freshWhere = this.withUserReadFilter(where, userId, 'fresh');
+
+    const freshRows = await this.withCursorErrorHandling(() =>
       this.prisma.story.findMany({
-        where,
+        where: freshWhere,
         take: limit + 1,
-        ...(filter.cursor ? { cursor: { id: filter.cursor }, skip: 1 } : {}),
+        ...(freshCursor ? { cursor: { id: freshCursor }, skip: 1 } : {}),
         orderBy,
-        include: {
-          images: true,
-          branches: true,
-          categories: true,
-          themes: true,
-          seasons: true,
-          questions: true,
-        },
+        include: this.storyListInclude,
       }),
     );
 
-    const { data, pagination } = PaginationUtil.buildCursorResponse(
-      stories,
-      limit,
-    );
+    const freshHasNext = freshRows.length > limit;
+    const freshPage = freshHasNext ? freshRows.slice(0, limit) : freshRows;
+    const freshEnriched = freshPage.map((s) => ({
+      ...s,
+      readStatus: null as 'done' | 'reading' | null,
+    }));
 
-    // Enrich with read status based on user or guest session
-    let enriched;
-    if (filter.userId) {
-      enriched = await this.enrichWithReadStatus(filter.userId, data);
-    } else if (filter.guestSessionId) {
-      enriched = await this.enrichWithGuestReadStatus(
-        filter.guestSessionId,
-        data,
-      );
-    } else {
-      enriched = data.map((s) => ({ ...s, readStatus: null }));
+    // Fresh stories still remain — keep serving fresh first.
+    if (freshHasNext) {
+      return {
+        data: freshEnriched,
+        pagination: {
+          nextCursor: `f:${freshPage[freshPage.length - 1].id}`,
+          hasNextPage: true,
+        },
+      };
     }
 
-    return { data: this.sortByReadStatus(enriched), pagination };
+    // Fresh pool exhausted on this page. Backfill the remainder of the page from
+    // the start of the READ stream; if the page is already full, signal that the
+    // read stream begins on the next request via the `r:` sentinel cursor.
+    const deficit = limit - freshPage.length;
+    if (deficit <= 0) {
+      const readProbe = await this.prisma.userStoryProgress.findFirst({
+        where: { userId, isDeleted: false, story: { ...where } },
+        orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+        select: { id: true },
+      });
+      return {
+        data: freshEnriched,
+        pagination: {
+          nextCursor: readProbe ? 'r:' : null,
+          hasNextPage: !!readProbe,
+        },
+      };
+    }
+
+    const readRows = await this.prisma.userStoryProgress.findMany({
+      where: { userId, isDeleted: false, story: { ...where } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      take: deficit + 1,
+      include: { story: { include: this.storyListInclude } },
+    });
+    const readHasNext = readRows.length > deficit;
+    const readPage = readHasNext ? readRows.slice(0, deficit) : readRows;
+    const readEnriched = await this.enrichWithReadStatus(
+      userId,
+      readPage.map((r) => r.story as unknown as { id: string }),
+    );
+
+    return {
+      data: [
+        ...(freshEnriched as unknown as Record<string, unknown>[]),
+        ...(readEnriched as unknown as Record<string, unknown>[]),
+      ],
+      pagination: {
+        nextCursor: readHasNext ? `r:${readPage[readPage.length - 1].id}` : null,
+        hasNextPage: readHasNext,
+      },
+    };
+  }
+
+  /**
+   * Serves a page of the READ stream for the fresh-first cursor pagination.
+   * Records come from the progress join table ordered by lastAccessed desc, so
+   * the cursor is the UserStoryProgress id (prefixed `r:` by the caller).
+   */
+  private async fetchReadStreamPage(
+    userId: string,
+    baseWhere: Prisma.StoryWhereInput,
+    progressCursor: string | undefined,
+    limit: number,
+  ): Promise<CursorPaginatedStoriesDto> {
+    const rows = await this.withCursorErrorHandling(() =>
+      this.prisma.userStoryProgress.findMany({
+        where: { userId, isDeleted: false, story: { ...baseWhere } },
+        orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+        take: limit + 1,
+        ...(progressCursor ? { cursor: { id: progressCursor }, skip: 1 } : {}),
+        include: { story: { include: this.storyListInclude } },
+      }),
+    );
+
+    const hasNextPage = rows.length > limit;
+    const page = hasNextPage ? rows.slice(0, limit) : rows;
+    const enriched = await this.enrichWithReadStatus(
+      userId,
+      page.map((r) => r.story as unknown as { id: string }),
+    );
+
+    return {
+      data: enriched as unknown as Record<string, unknown>[],
+      pagination: {
+        nextCursor: hasNextPage ? `r:${page[page.length - 1].id}` : null,
+        hasNextPage,
+      },
+    };
   }
 
   private mapProgressRecord(record: {
@@ -587,23 +761,31 @@ export class StoryService {
 
     const readProgress = await this.prisma.userStoryProgress.findMany({
       where: { userId, storyId: { in: storyIds }, isDeleted: false },
-      select: { storyId: true, progress: true },
+      select: { storyId: true, progress: true, completed: true },
     });
     const progressMap = new Map(
-      readProgress.map((p) => [p.storyId, { progress: p.progress }]),
+      readProgress.map((p) => [
+        p.storyId,
+        { progress: p.progress, completed: p.completed },
+      ]),
     );
 
     return stories.map((story) => {
       const progress = progressMap.get(story.id);
-      const progressValue = progress?.progress;
+      const progressValue = progress?.progress ?? 0;
+      const completed = progress?.completed === true;
+      // Align home read-status with the library's `completed` boolean: a story
+      // is "done" when explicitly completed OR at 100% progress, "reading" when
+      // partially read, and unseen only when there is no meaningful progress.
       return {
         ...story,
-        readStatus:
-          progressValue == null || progressValue <= 0
-            ? null
-            : progressValue >= 100
-              ? 'done'
-              : 'reading',
+        readStatus: (
+          completed || progressValue >= 100
+            ? 'done'
+            : progressValue <= 0
+              ? null
+              : 'reading'
+        ) as 'done' | 'reading' | null,
       };
     });
   }
@@ -645,6 +827,98 @@ export class StoryService {
               : 'reading',
       };
     });
+  }
+
+  /**
+   * Wraps a story `where` clause with a user read/fresh filter at the TOP LEVEL
+   * (AND), so it is never bypassed by the recommended-OR rewrite or the
+   * topPicks `id.in` / restricted `id.notIn` rewrites inside
+   * buildStoryWhereClause. A story counts as "read" when the user has any
+   * non-deleted UserStoryProgress row for it (in-progress OR done); "fresh"
+   * means no such row.
+   *
+   * - mode 'fresh' -> stories the user has NOT read (userProgress none)
+   * - mode 'read'  -> stories the user HAS read (userProgress some)
+   *
+   * Guests / unauthenticated callers (no userId) get the clause back unchanged,
+   * so their responses stay byte-for-byte identical.
+   */
+  private withUserReadFilter(
+    where: Prisma.StoryWhereInput,
+    userId: string | undefined,
+    mode: 'fresh' | 'read',
+  ): Prisma.StoryWhereInput {
+    if (!userId) return where;
+    const relation: Prisma.StoryWhereInput =
+      mode === 'fresh'
+        ? { userProgress: { none: { userId, isDeleted: false } } }
+        : { userProgress: { some: { userId, isDeleted: false } } };
+    return { AND: [where, relation] };
+  }
+
+  /**
+   * Fetches already-read stories for the fresh-first backfill, ranked
+   * most-recently-accessed first. Reads the progress join table so we can order
+   * by `lastAccessed` (not orderable as a Story to-many relation) and returns
+   * the underlying Story rows. `baseWhere` is the catalog filter WITHOUT any
+   * user read filter applied.
+   */
+  private async fetchReadBackfill(
+    baseWhere: Prisma.StoryWhereInput,
+    userId: string,
+    skip: number,
+    take: number,
+    include: Prisma.StoryInclude,
+  ): Promise<Array<{ id: string }>> {
+    if (take <= 0) return [];
+    const rows = await this.prisma.userStoryProgress.findMany({
+      where: { userId, isDeleted: false, story: { ...baseWhere } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      ...(skip > 0 ? { skip } : {}),
+      take,
+      include: { story: { include } },
+    });
+    return rows.map((r) => r.story as unknown as { id: string });
+  }
+
+  /**
+   * Tops a fresh section list up to `take` items with already-read stories
+   * (recent first) when there aren't enough fresh ones. Used by the home-page
+   * carousels. Guests (no userId) get the fresh list back unchanged.
+   */
+  private async topUpWithRead<T extends { id: string }>(
+    fresh: T[],
+    baseWhere: Prisma.StoryWhereInput,
+    userId: string | undefined,
+    take: number,
+    include: Prisma.StoryInclude,
+    storyOrderBy?:
+      | Prisma.StoryOrderByWithRelationInput
+      | Prisma.StoryOrderByWithRelationInput[],
+  ): Promise<T[]> {
+    if (!userId) return fresh;
+    const deficit = take - fresh.length;
+    if (deficit <= 0) return fresh;
+    // When the section has a story-level ranking (e.g. most-liked), backfill by
+    // querying read stories with that same ordering so the section's ranking
+    // contract is preserved. Otherwise backfill most-recently-read (ordered via
+    // the progress row, which is where lastAccessed lives).
+    if (storyOrderBy) {
+      const stories = await this.prisma.story.findMany({
+        where: this.withUserReadFilter(baseWhere, userId, 'read'),
+        orderBy: storyOrderBy,
+        take: deficit,
+        include,
+      });
+      return [...fresh, ...(stories as unknown as T[])];
+    }
+    const rows = await this.prisma.userStoryProgress.findMany({
+      where: { userId, isDeleted: false, story: { ...baseWhere } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      take: deficit,
+      include: { story: { include } },
+    });
+    return [...fresh, ...rows.map((r) => r.story as unknown as T)];
   }
 
   // Threshold in days to consider a past season as "recent" for backfill
@@ -787,86 +1061,132 @@ export class StoryService {
     let recommended: Awaited<ReturnType<typeof this.prisma.story.findMany>> =
       [];
     const preferredCategories = user?.preferredCategories ?? [];
-    if (preferredCategories.length > 0) {
-      recommended = await this.prisma.story.findMany({
-        where: {
-          isDeleted: false,
-          categories: {
-            some: {
-              id: { in: preferredCategories.map((c: Category) => c.id) },
+    const recInclude: Prisma.StoryInclude = { images: true, categories: true };
+    const recBaseWhere: Prisma.StoryWhereInput =
+      preferredCategories.length > 0
+        ? {
+            isDeleted: false,
+            categories: {
+              some: { id: { in: preferredCategories.map((c: Category) => c.id) } },
             },
-          },
-        },
-        take: limitRecommended,
-        include: { images: true, categories: true },
-        orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
-      });
-    } else {
-      // Fallback if no preferences: just fresh stories
-      recommended = await this.prisma.story.findMany({
-        where: { isDeleted: false },
-        orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
-        take: limitRecommended,
-        include: { images: true, categories: true },
-      });
-    }
+          }
+        : { isDeleted: false };
+    // Fresh-first: fetch unread recommendations, then top up with read ones.
+    recommended = await this.prisma.story.findMany({
+      where: this.withUserReadFilter(recBaseWhere, userId, 'fresh'),
+      take: limitRecommended,
+      include: recInclude,
+      orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
+    });
+    recommended = await this.topUpWithRead(
+      recommended,
+      recBaseWhere,
+      userId,
+      limitRecommended,
+      recInclude,
+    );
 
     // 2. Seasonal Stories (Logic: find active season based on today's date)
     const { activeSeasons, backfillSeasons } = await this.getRelevantSeasons();
 
     let seasonal: Awaited<ReturnType<typeof this.prisma.story.findMany>> = [];
     let seasonalCount = 0;
+    const seasonalInclude: Prisma.StoryInclude = {
+      images: true,
+      themes: true,
+      seasons: true,
+    };
 
     if (activeSeasons.length > 0) {
+      // Fresh-first: only unread seasonal stories in the primary fetch.
       seasonal = await this.prisma.story.findMany({
-        where: {
-          isDeleted: false,
-          seasons: {
-            some: {
-              id: { in: activeSeasons.map((s) => s.id) },
+        where: this.withUserReadFilter(
+          {
+            isDeleted: false,
+            seasons: {
+              some: {
+                id: { in: activeSeasons.map((s) => s.id) },
+              },
             },
           },
-        },
+          userId,
+          'fresh',
+        ),
         take: limitSeasonal,
-        include: { images: true, themes: true, seasons: true },
+        include: seasonalInclude,
       });
       seasonalCount = seasonal.length;
     }
 
-    // Backfill if needed
+    // Backfill with other (recent) seasons' fresh stories if needed
     if (seasonalCount < limitSeasonal && backfillSeasons.length > 0) {
       const needed = limitSeasonal - seasonalCount;
       const existingIds = new Set(seasonal.map((s) => s.id));
 
       const backfillStories = await this.prisma.story.findMany({
-        where: {
-          isDeleted: false,
-          seasons: {
-            some: {
-              id: { in: backfillSeasons.map((s) => s.id) },
+        where: this.withUserReadFilter(
+          {
+            isDeleted: false,
+            seasons: {
+              some: {
+                id: { in: backfillSeasons.map((s) => s.id) },
+              },
             },
+            id: { notIn: Array.from(existingIds) },
           },
-          id: { notIn: Array.from(existingIds) },
-        },
+          userId,
+          'fresh',
+        ),
         take: needed,
-        include: { images: true, themes: true, seasons: true },
+        include: seasonalInclude,
         orderBy: { createdAt: 'desc' },
       });
 
       seasonal = [...seasonal, ...backfillStories];
     }
 
-    // 3. Top Liked by Parents
-    const topLiked = await this.prisma.story.findMany({
-      where: { isDeleted: false },
+    // Final fresh-first top-up: if still short on fresh seasonal stories, fill
+    // with already-read seasonal stories (active or recent seasons).
+    seasonal = await this.topUpWithRead(
+      seasonal,
+      {
+        isDeleted: false,
+        seasons: {
+          some: {
+            id: {
+              in: [
+                ...activeSeasons.map((s) => s.id),
+                ...backfillSeasons.map((s) => s.id),
+              ],
+            },
+          },
+        },
+      },
+      userId,
+      limitSeasonal,
+      seasonalInclude,
+    );
+
+    // 3. Top Liked by Parents (fresh-first, then top up with read)
+    const topLikedInclude: Prisma.StoryInclude = { images: true };
+    let topLiked = await this.prisma.story.findMany({
+      where: this.withUserReadFilter({ isDeleted: false }, userId, 'fresh'),
       orderBy: {
         parentFavorites: {
           _count: 'desc',
         },
       },
       take: limitTopLiked,
-      include: { images: true },
+      include: topLikedInclude,
     });
+    topLiked = await this.topUpWithRead(
+      topLiked,
+      { isDeleted: false },
+      userId,
+      limitTopLiked,
+      topLikedInclude,
+      { parentFavorites: { _count: 'desc' } },
+    );
 
     // Enrich all stories with readStatus in a single DB query
     const allStories = [...recommended, ...seasonal, ...topLiked];
@@ -1072,29 +1392,55 @@ export class StoryService {
     if (!story) throw new NotFoundException('Story not found');
 
     const sessionTime = normalizeSessionTime(dto.sessionTime);
+    const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     const existing = await this.prisma.storyProgress.findUnique({
       where: { kidId_storyId: { kidId: dto.kidId, storyId: dto.storyId } },
     });
 
-    const result = await this.prisma.storyProgress.upsert({
+    // Completion is monotonic: once a story is completed it stays completed
+    // until the dedicated remove/reset endpoint clears it (which hard-deletes
+    // the row for kids). Completion is also auto-derived when progress reaches
+    // 100, so a read-to-end finish is recorded even if the client never sends
+    // an explicit `completed` flag, and a later partial-progress ping can no
+    // longer silently un-complete the story.
+    const shouldComplete =
+      existing?.completed === true ||
+      dto.completed === true ||
+      clampedProgress >= 100;
+
+    // Upsert progress/time only. Completion is applied via an atomic flip below
+    // (updateMany gated on completed:false) so that two concurrent 100%
+    // completions can't both observe a pre-completion state and each call
+    // adjustReadingLevel — only the request that actually flips false->true
+    // performs the (non-idempotent) reading-level adjustment.
+    let result = await this.prisma.storyProgress.upsert({
       where: { kidId_storyId: { kidId: dto.kidId, storyId: dto.storyId } },
       update: {
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
         lastAccessed: new Date(),
         totalTimeSpent: { increment: sessionTime },
       },
       create: {
         kidId: dto.kidId,
         storyId: dto.storyId,
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
+        completed: false,
         totalTimeSpent: sessionTime,
       },
     });
 
-    if (dto.completed && (!existing || !existing.completed)) {
+    let newlyCompleted = false;
+    if (shouldComplete && !result.completed) {
+      const flipped = await this.prisma.storyProgress.updateMany({
+        where: { kidId: dto.kidId, storyId: dto.storyId, completed: false },
+        data: { completed: true },
+      });
+      newlyCompleted = flipped.count === 1;
+      if (newlyCompleted) result = { ...result, completed: true };
+    }
+
+    if (newlyCompleted) {
       this.adjustReadingLevel(
         dto.kidId,
         dto.storyId,
@@ -1141,6 +1487,7 @@ export class StoryService {
     });
 
     const sessionTime = normalizeSessionTime(dto.sessionTime);
+    const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     // If restoring a soft-deleted record, reset totalTimeSpent instead of
     // accumulating stale time from before the removal.
@@ -1148,11 +1495,21 @@ export class StoryService {
       ? sessionTime
       : { increment: sessionTime };
 
+    const shouldComplete =
+      existing?.completed === true ||
+      dto.completed === true ||
+      clampedProgress >= 100;
+
+    // Completion is monotonic under concurrency: the update path never writes
+    // `completed`, so a stale partial-progress request (which read the row
+    // before another request completed it) can't overwrite completed:true with
+    // false. Completion is only ever flipped to true via the atomic updateMany
+    // below (gated on completed:false). The remove/reset endpoint remains the
+    // only way to clear it.
     const result = await this.prisma.userStoryProgress.upsert({
       where: { userId_storyId: { userId, storyId: dto.storyId } },
       update: {
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
         lastAccessed: new Date(),
         totalTimeSpent: totalTimeSpentUpdate,
         // Restore soft-deleted records when user re-reads a removed story
@@ -1162,17 +1519,26 @@ export class StoryService {
       create: {
         userId,
         storyId: dto.storyId,
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
+        completed: false,
         totalTimeSpent: sessionTime,
       },
     });
+
+    let completed = result.completed;
+    if (shouldComplete && !completed) {
+      await this.prisma.userStoryProgress.updateMany({
+        where: { userId, storyId: dto.storyId, completed: false },
+        data: { completed: true },
+      });
+      completed = true;
+    }
 
     return {
       id: result.id,
       storyId: result.storyId,
       progress: result.progress,
-      completed: result.completed,
+      completed,
       lastAccessed: result.lastAccessed,
       totalTimeSpent: result.totalTimeSpent,
     };


### PR DESCRIPTION
## What
Two related improvements in `story.service.ts` (+ updated `story.service.spec.ts`):

**Reliable read status (#4)**
- `setProgress` / `setUserProgress`: `completed = existing.completed || dto.completed === true || progress >= 100` — monotonic + auto-derived. Fixes the un-complete-on-later-ping bug and missing completion on audio read-to-end. The reading-level adjust still fires exactly once. Reset endpoints remain the only way to clear completion.
- `enrichWithReadStatus`: now selects `completed` and treats `completed === true` as `done`, matching the Library's source of truth.

**Fresh-first home feed (#5)**
- Logged-in users: home returns fresh (unread) stories first; already-read stories are excluded then **backfilled** to fill the page (ranked last). Implemented via a top-level-AND `userProgress` anti-join in `getStories` / `getStoriesCursor` / `getHomePageStories`, so it isn't bypassed by the recommended-OR / id rewrites.
- **Guests and `@Public` responses are unchanged** (filter is gated on `userId`).
- Pagination metadata stays correct (`totalCount` over the full set; fresh→read tiling verified across offset pages; cursor uses an opaque composite `f:`/`r:` cursor).

## Verification
Run in an isolated Docker sandbox (no host installs): `prisma generate` + `pnpm build` (compiles) + `pnpm test src/story` → **93/93 tests pass**, including the updated `story.service.spec.ts`. No DB needed (Prisma mocked).

## Risk / notes
- **Behavior change for logged-in web** (this endpoint is `@OptionalAuth`, shared with the web app): authenticated web home is now fresh-first + backfill too. Superadmin uses separate endpoints (unaffected).
- Monotonic completion means a client can no longer un-complete via `completed:false`/lower progress — only the remove/reset endpoints clear it.
- No migration (fields already exist).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story lists for signed-in users now prioritize fresh (unread) stories and backfill with recently accessed read stories to complete the page.
  * Home page sections (recommended/seasonal/top-liked) now follow the same fresh-first behavior.
  * Cursor pagination for authenticated browsing supports seamless fresh-to-read continuation.
* **Bug Fixes**
  * Read status is more precise based on progress and completion, and progress updates now clamp to valid ranges with monotonic completion.
* **Tests**
  * Updated story library and home-page query assertions/mocks to match fresh-first ordering and read-status enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->