### PR TITLE
fix(guest): mark finished stories as "done" for guest read status

### DIFF
--- a/src/guest/dto/guest.dto.ts
+++ b/src/guest/dto/guest.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, Max, Min } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export type ReadStatus = 'done' | 'reading';
 
@@ -14,6 +22,13 @@ export class UpdateGuestProgressDto {
   @Min(0)
   @Max(100)
   progress: number;
+
+  @ApiPropertyOptional({
+    description: 'Whether the story has been finished/completed',
+  })
+  @IsOptional()
+  @IsBoolean()
+  completed?: boolean;
 }
 
 export class CreateGuestSessionResponseDto {

--- a/src/guest/guest-session.service.ts
+++ b/src/guest/guest-session.service.ts
@@ -25,6 +25,8 @@ export type GuestStoryAccessResult =
 export interface StoryProgress {
   /** Progress percentage (0-100) */
   progress: number;
+  /** Whether the story has been finished/completed (monotonic once true) */
+  completed?: boolean;
   /** Timestamp when the story was last read */
   lastReadAt: Date;
 }
@@ -208,12 +210,14 @@ export class GuestSessionService {
    * @param sessionId - The session ID
    * @param storyId - The story ID
    * @param progress - Progress percentage (0-100)
+   * @param completed - Explicit completion flag from the client (optional)
    * @returns The updated guest session, or null if session not found
    */
   async updateGuestProgress(
     sessionId: string,
     storyId: string,
     progress: number,
+    completed?: boolean,
   ): Promise<GuestSession | null> {
     const session = await this.getGuestSession(sessionId);
 
@@ -227,10 +231,20 @@ export class GuestSessionService {
     // Validate progress is between 0 and 100
     const clampedProgress = Math.max(0, Math.min(100, progress));
 
-    // Update reading history only when clampedProgress > 0
-    if (clampedProgress > 0 || session.readingHistory[storyId]) {
+    // Completion is monotonic: once a story is finished it stays finished.
+    // Derive it from the explicit flag or a full progress reading.
+    const existing = session.readingHistory[storyId];
+    const isCompleted =
+      existing?.completed === true ||
+      completed === true ||
+      clampedProgress >= 100;
+
+    // Update reading history when there is progress, a completion signal, or
+    // an existing entry to preserve.
+    if (clampedProgress > 0 || isCompleted || existing) {
       session.readingHistory[storyId] = {
         progress: clampedProgress,
+        completed: isCompleted,
         lastReadAt: new Date(),
       };
     }

--- a/src/guest/guest.controller.ts
+++ b/src/guest/guest.controller.ts
@@ -343,7 +343,7 @@ export class GuestController {
         },
         update: {
           progress: clampedProgress,
-          completed: clampedProgress >= 100,
+          completed: dto.completed === true || clampedProgress >= 100,
           lastAccessed: new Date(),
           isDeleted: false,
         },
@@ -351,7 +351,7 @@ export class GuestController {
           userId,
           storyId: dto.storyId,
           progress: clampedProgress,
-          completed: clampedProgress >= 100,
+          completed: dto.completed === true || clampedProgress >= 100,
           lastAccessed: new Date(),
         },
       });
@@ -364,6 +364,7 @@ export class GuestController {
         guestSessionId,
         dto.storyId,
         clampedProgress,
+        dto.completed,
       );
       if (!updated) {
         this.logger.warn(
@@ -425,7 +426,11 @@ export class GuestController {
       this.validateSessionId(guestSessionId);
     }
 
-    let progressData: { progress: number; lastAccessed: Date } | null = null;
+    let progressData: {
+      progress: number;
+      lastAccessed: Date;
+      completed: boolean;
+    } | null = null;
 
     if (userId) {
       // Authenticated user - get from database
@@ -438,6 +443,7 @@ export class GuestController {
         select: {
           progress: true,
           lastAccessed: true,
+          completed: true,
         },
       });
 
@@ -448,6 +454,7 @@ export class GuestController {
       progressData = {
         progress: record.progress,
         lastAccessed: record.lastAccessed,
+        completed: record.completed === true,
       };
     } else if (guestSessionId) {
       // Guest user - get from Redis
@@ -469,6 +476,7 @@ export class GuestController {
       progressData = {
         progress: storyProgress.progress,
         lastAccessed: storyProgress.lastReadAt,
+        completed: storyProgress.completed === true,
       };
     }
 
@@ -505,10 +513,10 @@ export class GuestController {
     }
 
     const readStatus: ReadStatus | null =
-      progressData.progress <= 0
-        ? null
-        : progressData.progress >= 100
-          ? 'done'
+      progressData.completed || progressData.progress >= 100
+        ? 'done'
+        : progressData.progress <= 0
+          ? null
           : 'reading';
 
     return {
@@ -579,6 +587,7 @@ export class GuestController {
         select: {
           storyId: true,
           progress: true,
+          completed: true,
           lastAccessed: true,
           story: {
             select: {
@@ -608,10 +617,10 @@ export class GuestController {
       return {
         stories: progressRecords.map((record) => {
           const readStatus: ReadStatus | null =
-            record.progress <= 0
-              ? null
-              : record.progress >= 100
-                ? 'done'
+            record.completed || record.progress >= 100
+              ? 'done'
+              : record.progress <= 0
+                ? null
                 : 'reading';
           return {
             storyId: record.storyId,
@@ -680,10 +689,10 @@ export class GuestController {
       const storiesWithProgress = stories.map((story) => {
         const progress = history[story.id];
         const readStatus: ReadStatus | null =
-          progress.progress <= 0
-            ? null
-            : progress.progress >= 100
-              ? 'done'
+          progress.completed === true || progress.progress >= 100
+            ? 'done'
+            : progress.progress <= 0
+              ? null
               : 'reading';
         return {
           storyId: story.id,

--- a/src/guest/guest.controller.ts
+++ b/src/guest/guest.controller.ts
@@ -34,6 +34,7 @@ import {
 } from './guest-session.service';
 import { PrismaService } from '@/prisma/prisma.service';
 import { ReadStatus } from './dto/guest.dto';
+import { deriveReadStatus } from '@/shared/utils/read-status.util';
 import { StoryService } from '@/story/story.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { GuestActivityEvent } from './events/guest-activity.event';
@@ -336,14 +337,17 @@ export class GuestController {
     const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     if (userId) {
-      // Authenticated user - update in database
+      // Authenticated user - update in database.
+      // Completion is monotonic: only ever set `completed` to true, never
+      // downgrade a finished story on a later partial-progress update.
+      const markCompleted = dto.completed === true || clampedProgress >= 100;
       await this.prisma.userStoryProgress.upsert({
         where: {
           userId_storyId: { userId, storyId: dto.storyId },
         },
         update: {
           progress: clampedProgress,
-          completed: dto.completed === true || clampedProgress >= 100,
+          ...(markCompleted ? { completed: true } : {}),
           lastAccessed: new Date(),
           isDeleted: false,
         },
@@ -351,7 +355,7 @@ export class GuestController {
           userId,
           storyId: dto.storyId,
           progress: clampedProgress,
-          completed: dto.completed === true || clampedProgress >= 100,
+          completed: markCompleted,
           lastAccessed: new Date(),
         },
       });
@@ -512,12 +516,10 @@ export class GuestController {
       return null;
     }
 
-    const readStatus: ReadStatus | null =
-      progressData.completed || progressData.progress >= 100
-        ? 'done'
-        : progressData.progress <= 0
-          ? null
-          : 'reading';
+    const readStatus: ReadStatus | null = deriveReadStatus(
+      progressData.progress,
+      progressData.completed,
+    );
 
     return {
       storyId,
@@ -616,12 +618,10 @@ export class GuestController {
 
       return {
         stories: progressRecords.map((record) => {
-          const readStatus: ReadStatus | null =
-            record.completed || record.progress >= 100
-              ? 'done'
-              : record.progress <= 0
-                ? null
-                : 'reading';
+          const readStatus: ReadStatus | null = deriveReadStatus(
+            record.progress,
+            record.completed,
+          );
           return {
             storyId: record.storyId,
             title: record.story.title,
@@ -688,12 +688,10 @@ export class GuestController {
       // Map stories with progress and readStatus
       const storiesWithProgress = stories.map((story) => {
         const progress = history[story.id];
-        const readStatus: ReadStatus | null =
-          progress.completed === true || progress.progress >= 100
-            ? 'done'
-            : progress.progress <= 0
-              ? null
-              : 'reading';
+        const readStatus: ReadStatus | null = deriveReadStatus(
+          progress.progress,
+          progress.completed,
+        );
         return {
           storyId: story.id,
           title: story.title,

--- a/src/shared/utils/read-status.util.ts
+++ b/src/shared/utils/read-status.util.ts
@@ -1,0 +1,23 @@
+/**
+ * Derive a story's read status from its progress percentage and an optional
+ * explicit completion flag.
+ *
+ * Single source of truth shared by the guest controller and story service so
+ * the rule can't silently diverge between call sites.
+ *
+ * - `done`    – explicitly completed, or progress has reached 100%
+ * - `reading` – some progress (> 0) but not finished
+ * - `null`    – no meaningful progress yet
+ */
+export const deriveReadStatus = (
+  progress: number | null | undefined,
+  completed?: boolean,
+): 'done' | 'reading' | null => {
+  if (completed === true || (progress != null && progress >= 100)) {
+    return 'done';
+  }
+  if (progress == null || progress <= 0) {
+    return null;
+  }
+  return 'reading';
+};

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -818,13 +818,14 @@ export class StoryService {
     return stories.map((story) => {
       const progress = readingHistory[story.id];
       const progressValue = progress?.progress;
+      const isCompleted = progress?.completed === true;
       return {
         ...story,
         readStatus:
-          progressValue == null || progressValue <= 0
-            ? null
-            : progressValue >= 100
-              ? 'done'
+          isCompleted || (progressValue != null && progressValue >= 100)
+            ? 'done'
+            : progressValue == null || progressValue <= 0
+              ? null
               : 'reading',
       };
     });

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -66,6 +66,7 @@ import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { VoiceType, VOICE_TYPE_MIGRATION_MAP } from '../voice/dto/voice.dto';
 import { DEFAULT_VOICE } from '../voice/voice.constants';
 import { STORY_INVALIDATION_KEYS } from '@/shared/constants/cache-keys.constants';
+import { deriveReadStatus } from '@/shared/utils/read-status.util';
 import {
   DEFAULT_CURSOR_LIMIT,
   PaginationUtil,
@@ -774,19 +775,12 @@ export class StoryService {
 
     return stories.map((story) => {
       const progress = progressMap.get(story.id);
-      const progressValue = progress?.progress ?? 0;
-      const completed = progress?.completed === true;
       // Align home read-status with the library's `completed` boolean: a story
       // is "done" when explicitly completed OR at 100% progress, "reading" when
       // partially read, and unseen only when there is no meaningful progress.
       return {
         ...story,
-        readStatus:
-          completed || progressValue >= 100
-            ? 'done'
-            : progressValue <= 0
-              ? null
-              : 'reading',
+        readStatus: deriveReadStatus(progress?.progress, progress?.completed),
       };
     });
   }
@@ -817,16 +811,9 @@ export class StoryService {
     const readingHistory = session.readingHistory;
     return stories.map((story) => {
       const progress = readingHistory[story.id];
-      const progressValue = progress?.progress;
-      const isCompleted = progress?.completed === true;
       return {
         ...story,
-        readStatus:
-          isCompleted || (progressValue != null && progressValue >= 100)
-            ? 'done'
-            : progressValue == null || progressValue <= 0
-              ? null
-              : 'reading',
+        readStatus: deriveReadStatus(progress?.progress, progress?.completed),
       };
     });
   }


### PR DESCRIPTION
## Problem

As a **guest**, finishing a story still showed the **"reading"** tag on the home feed/library instead of **"done"**.

**Root cause:** guest read status was derived *only* from `progress >= 100`, but the reader reports progress as a **page count**, never a percentage. A finished short story therefore stored a small page number with no completion signal, so it was never marked done. The client also dropped the `completed` flag for guests entirely.

## Fix

Propagate an explicit `completed` flag through the guest progress flow and treat it as `done`:

- `UpdateGuestProgressDto` accepts an optional `completed` boolean.
- `StoryProgress` persists `completed` (**monotonic** — once finished, stays finished); `updateGuestProgress` stores it.
- All guest read-status derivations honor `completed`: single-story progress, reading history, and `enrichWithGuestReadStatus` (home feed).
- The authenticated `/guest/progress` upsert also honors the explicit flag.

## Companion PR

Requires the mobile change that actually sends `completed` for guests (separate mobile PR). Backward compatible: `completed` is optional, so older clients are unaffected.

## Testing

- Static verification only (Docker/sandbox unavailable in this environment, so no install was run). Type consistency checked against the Prisma `UserStoryProgress.completed` field and the `StoryProgress` interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “completed” flag for updating reading progress, including marking items as completed even when progress is below 100%.
* **Bug Fixes**
  * Improved read status calculation so “done” and “reading” are consistent across progress updates, progress responses, and history for both authenticated and guest views.
  * History entries now reflect completed state reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->