### PR TITLE
fix(pm2): run single-instance dev & staging in fork mode

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -48,7 +48,9 @@ module.exports = {
       ...baseConfig,
       name: 'storytime-api-staging',
       instances: stagingInstances,
-      exec_mode: 'cluster',
+      // Single-instance staging runs in fork mode (no cluster master +
+      // worker doubling); only cluster when explicitly scaled past 1.
+      exec_mode: stagingInstances > 1 ? 'cluster' : 'fork',
       env: {
         NODE_ENV: 'staging',
       },


### PR DESCRIPTION
## Why

Dev and staging are each configured for `instances: 1`, but staging's `exec_mode` was hard-coded to `'cluster'`. Cluster mode spawns a **master + worker (two node processes) per environment** even at one instance, and each crash-loop restart could leak a Prisma query-engine child. On the box this had accumulated to **37 orphaned query-engine processes (~322 MB RSS)** on a 3.7 GB server.

## Change

- Staging `exec_mode` now mirrors dev: `stagingInstances > 1 ? 'cluster' : 'fork'`. At the default of one instance both run in **fork mode = a single process each**, no cluster doubling.
- Production is unchanged (intentionally multi-instance cluster).
- Crash-loop caps (`min_uptime`/`max_restarts`/`restart_delay`) already present in this branch from #369 keep leaks from re-accumulating.

## Already applied on the server (immediate relief)

- Killed the 37 orphaned query-engine processes (freed ~320 MB).
- Restarted dev + staging into fork mode (`fork_mode / instances=1 / restarts=0`); both healthy (`/api/v1/health` → 200).

This PR makes the fork behaviour permanent so the next deploy doesn't revert staging to cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staging deployments now choose the appropriate run mode automatically, using single-process mode for one instance and clustered mode for multiple instances.
  * This prevents unintended extra process duplication when staging is configured to run with only one instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->