### PR TITLE
fix(ci): stop malware-scan self-matching + suppress durabletask generic-path FPs

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -9,14 +9,19 @@ permissions:
 #  - weekly (and on demand): deep scan with Cobenian/shai-hulud-detect
 #
 # The deep scan exits non-zero on ANY finding, and many of its broad content
-# heuristics false-positive on legitimate AI / crypto / analytics SDKs (e.g.
-# elevenlabs' /v1/models path matching a "durabletask C2" string). So we run the
-# scanner for its data (--json), then gate ourselves: a curated allowlist drops
-# verified known-good false positives, the build fails only on UNRESOLVED HIGH
-# findings, and medium/low are reported as advisory. Suppression requires BOTH a
-# package-path AND the exact benign reason to match, so a genuinely malicious
-# package (hash match, compromised-package list, or real IOC string) is never
-# silenced and will still fail the build.
+# heuristics false-positive on legitimate AI / crypto / analytics SDKs (e.g. an
+# audio SDK's OpenAPI mock fixtures embedding REST paths that a PyPI-malware C2
+# heuristic also greps for). So we run the scanner for its data (--json), then
+# gate ourselves: a curated allowlist drops verified known-good false positives,
+# the build fails only on UNRESOLVED HIGH findings, and medium/low are reported
+# as advisory. Suppression requires BOTH a package-path AND the benign reason to
+# match, so a genuinely malicious package (hash match, compromised-package list,
+# or a real IOC string) is never silenced and will still fail the build.
+#
+# NOTE: allowlist reasons must NOT contain the detector's literal IOC search
+# strings (C2 domains/paths, beacon tokens) — the deep scan reads this very file
+# and would flag it. Match indicator *families* by prefix instead of pasting the
+# raw IOC here.
 
 on:
   push:
@@ -92,16 +97,25 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Verified known-good false positives (reviewed 2026-06-29).
-          # Each rule is "<path-substring>|<exact-reason>". A finding is suppressed
-          # ONLY when the file path contains <path-substring> AND the message equals
-          # <exact-reason> exactly. The reason is the FP signature itself, so a real
-          # compromise of the same package (hash match / compromised-package / a
-          # different IOC string) has a different message and is never silenced —
-          # even when it shares the package and the HIGH severity.
+          # Verified known-good false positives (reviewed 2026-07-06).
+          # Each rule is "<path-substring>|<reason-glob>". A finding is suppressed
+          # ONLY when the file path contains <path-substring> AND the message
+          # matches <reason-glob> (shell glob; a trailing * matches an indicator
+          # family). The reason is the FP signature itself, so a real compromise
+          # of the same package (hash match / compromised-package / a different
+          # IOC family) has a different message and is never silenced — even when
+          # it shares the package and the HIGH severity.
+          #
+          # elevenlabs is a legit audio/TTS SDK; its bundled OpenAPI mock fixtures
+          # embed REST paths that the durabletask *PyPI* C2 heuristic greps for.
+          # durabletask is a Python package — a Node SDK cannot be its real victim;
+          # a genuine compromise would surface as a hash/compromised-package
+          # finding with a different message. Prefix-match the durabletask C2 /
+          # beacon families so new mock files or version bumps don't reopen this,
+          # and so we never have to paste the raw C2 strings into this file.
           ALLOW=(
-            "/elevenlabs/|durabletask C2 reference (/v1/models)"
-            "/elevenlabs/|durabletask C2 reference (/audio.mp3)"
+            '/elevenlabs/|durabletask C2 reference (*'
+            '/elevenlabs/|durabletask beacon string (*'
             "/formdata-polyfill/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
             "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
             "/@noble/ed25519/|Ethereum wallet address patterns detected"
@@ -123,7 +137,10 @@ jobs:
             matched=no
             for rule in "${ALLOW[@]}"; do
               p="${rule%%|*}"; m="${rule#*|}"
-              if [[ "$file" == *"$p"* && "$msg" == "$m" ]]; then matched=yes; break; fi
+              # $m is an unquoted glob: exact rules (no metachars) still match
+              # literally; a trailing * matches an indicator family.
+              # shellcheck disable=SC2053
+              if [[ "$file" == *"$p"* && "$msg" == $m ]]; then matched=yes; break; fi
             done
             if [ "$matched" = yes ]; then
               sup=$((sup+1))

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -106,16 +106,20 @@ jobs:
           # IOC family) has a different message and is never silenced — even when
           # it shares the package and the HIGH severity.
           #
-          # elevenlabs is a legit audio/TTS SDK; its bundled OpenAPI mock fixtures
-          # embed REST paths that the durabletask *PyPI* C2 heuristic greps for.
-          # durabletask is a Python package — a Node SDK cannot be its real victim;
-          # a genuine compromise would surface as a hash/compromised-package
-          # finding with a different message. Prefix-match the durabletask C2 /
-          # beacon families so new mock files or version bumps don't reopen this,
-          # and so we never have to paste the raw C2 strings into this file.
+          # durabletask is a PyPI (Python) compromise; its C2 "reference" heuristic
+          # greps ALL files for generic REST-ish paths (leading-slash strings such
+          # as an API's /models or /audio route) that legitimately appear across
+          # many JS/TS API-SDK fixtures (elevenlabs, etc.). We ship no Python /
+          # durabletask dependency, so a leading-slash C2 "reference" is always a
+          # false positive here — matched globally (empty path scope) so a new SDK
+          # or a version bump can't reopen it. The SPECIFIC IOCs remain blocking:
+          # the C2 *domain*, beacon tokens, the stage-2 payload filename, and any
+          # hash / compromised-package match all have messages that do NOT start
+          # with "durabletask C2 reference (/", so none are suppressed. Matching
+          # the "(/*" shape (not the raw paths) also keeps the detector's literal
+          # IOC strings out of this file, so the scan can't flag its own config.
           ALLOW=(
-            '/elevenlabs/|durabletask C2 reference (*'
-            '/elevenlabs/|durabletask beacon string (*'
+            '|durabletask C2 reference (/*'
             "/formdata-polyfill/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
             "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
             "/@noble/ed25519/|Ethereum wallet address patterns detected"


### PR DESCRIPTION
Fixes the failing weekly **shai-hulud-detect** deep scan (all repos).

## Root cause (two false positives)
1. The durabletask-PyPI C2 heuristic greps files for literal IOC strings — and our allowlist **pasted those strings into the workflow**, so the scanner flagged its own config file.
2. **elevenlabs@1.59.0** shipped fixtures matching a generic REST path (`/api/public/version`) not previously allowlisted.

## Fix
- Scrub every literal IOC string from the workflow (no more self-match).
- Suppress the `durabletask C2 reference (/*` **generic leading-slash path family globally** (any package) — durable against new SDKs / version bumps. We ship no Python/durabletask dependency, so a generic-path C2 "reference" is always an FP.
- Real IOCs stay blocking: the C2 **domain**, **beacon** tokens, **stage-2 filename**, and any **hash / compromised-package** match don't start with `(/`, so none are suppressed.

## Verified
Green end-to-end via `workflow_dispatch` on this branch (run 28805728430): `shai-hulud-detect (weekly): success` against the actual installed `elevenlabs@1.59.0`.

Same fix opened across all 9 repos.