### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'ci'


### PR DESCRIPTION
Adds `.github/dependabot.yml` so Dependabot opens weekly update PRs for npm (pnpm) and GitHub Actions, minor/patch grouped. Complements the existing Dependabot alerts and the manual vulnerability-batch work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly checks for npm and GitHub Actions updates.
  * Configured dependency updates to group compatible minor and patch releases.
  * Limited the number of simultaneously open dependency update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->