### PR TITLE
fix(tts): batch completed on partial success + retry transient failures

### DIFF
--- a/src/voice/queue/tts-batch-job.interface.ts
+++ b/src/voice/queue/tts-batch-job.interface.ts
@@ -18,6 +18,12 @@ export interface TtsBatchJobData {
     duplicateIndices?: number[];
   }>;
   totalParagraphs: number;
+  /**
+   * Self-heal round for this job. Absent/0 on the initial run; incremented on
+   * each delayed follow-up that re-attempts paragraphs which exhausted the
+   * whole provider chain. Bounded by MAX_RETRY_GENERATIONS.
+   */
+  retryGeneration?: number;
 }
 
 export interface TtsBatchJobResult {

--- a/src/voice/queue/tts-batch-queue.constants.ts
+++ b/src/voice/queue/tts-batch-queue.constants.ts
@@ -17,6 +17,19 @@ export const TTS_BATCH_REDIS_PREFIX = 'tts-batch';
 /** TTL for batch tracking Redis keys (30 minutes) */
 export const TTS_BATCH_REDIS_TTL = 1800;
 
+/**
+ * Maximum number of delayed self-heal rounds after the initial run. Each round
+ * re-attempts only the paragraphs that exhausted the whole provider chain, so
+ * this bounds the total work and guarantees the chain can't loop forever.
+ */
+export const MAX_RETRY_GENERATIONS = 2;
+
+/**
+ * Delay before a self-heal retry job runs. Gives a transient provider outage
+ * time to recover before we re-attempt the failed paragraphs.
+ */
+export const TTS_BATCH_RETRY_DELAY_MS = 45_000;
+
 export const TTS_BATCH_QUEUE_OPTIONS = {
   attempts: 3,
   backoff: { type: 'exponential' as const, delay: 5_000 },

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -9,6 +9,7 @@ import {
   TTS_BATCH_QUEUE_OPTIONS,
   TTS_BATCH_REDIS_PREFIX,
   TTS_BATCH_REDIS_TTL,
+  TTS_BATCH_RETRY_DELAY_MS,
 } from './tts-batch-queue.constants';
 import {
   TtsBatchJobData,
@@ -78,6 +79,48 @@ export class TtsBatchQueueService implements OnModuleDestroy {
     return batchJobId;
   }
 
+  /**
+   * Queue a delayed self-heal round for paragraphs that exhausted the whole
+   * provider chain. Re-uses the ORIGINAL batchJobId (so recovered paragraphs
+   * land in the same completed/failed tracking sets and the client polling the
+   * batch sees them heal), but with a distinct BullMQ jobId per generation and
+   * a delay so a transient outage has time to recover. The tracking keys are
+   * left intact — only their TTL is refreshed so they survive until the retry
+   * runs.
+   */
+  async queueRetryBatch(
+    original: TtsBatchJobData,
+    failedParagraphs: TtsBatchJobData['paragraphs'],
+    generation: number,
+  ): Promise<void> {
+    const { batchJobId } = original;
+
+    const jobData: TtsBatchJobData = {
+      ...original,
+      paragraphs: failedParagraphs,
+      retryGeneration: generation,
+    };
+
+    await this.batchQueue.add(TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS, jobData, {
+      ...TTS_BATCH_QUEUE_OPTIONS,
+      jobId: `${batchJobId}:retry:${generation}`,
+      delay: TTS_BATCH_RETRY_DELAY_MS,
+    });
+
+    const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
+    const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;
+    const failedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:failed`;
+    const pipeline = this.redis.pipeline();
+    pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
+    await pipeline.exec();
+
+    this.logger.log(
+      `TTS batch retry queued: ${batchJobId} (generation ${generation}) — ${failedParagraphs.length} paragraph(s), delay ${TTS_BATCH_RETRY_DELAY_MS}ms`,
+    );
+  }
+
   async getBatchStatus(
     batchJobId: string,
     userId?: string,
@@ -123,10 +166,15 @@ export class TtsBatchQueueService implements OnModuleDestroy {
     audioUrl: string,
   ): Promise<void> {
     const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;
+    const failedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:failed`;
     const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
     const pipeline = this.redis.pipeline();
     pipeline.hset(completedKey, String(index), audioUrl);
+    // A self-heal retry can complete a paragraph that a previous run marked
+    // failed — clear it from the failed set so it isn't reported in both.
+    pipeline.srem(failedKey, String(index));
     pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
     pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
     await pipeline.exec();
   }

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -101,11 +101,15 @@ export class TtsBatchQueueService implements OnModuleDestroy {
       retryGeneration: generation,
     };
 
-    await this.batchQueue.add(TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS, jobData, {
-      ...TTS_BATCH_QUEUE_OPTIONS,
-      jobId: `${batchJobId}:retry:${generation}`,
-      delay: TTS_BATCH_RETRY_DELAY_MS,
-    });
+    await this.batchQueue.add(
+      TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS,
+      jobData,
+      {
+        ...TTS_BATCH_QUEUE_OPTIONS,
+        jobId: `${batchJobId}:retry:${generation}`,
+        delay: TTS_BATCH_RETRY_DELAY_MS,
+      },
+    );
 
     const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
     const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -263,9 +263,7 @@ export class TtsBatchProcessor extends WorkerHost {
     const totalQueued = snapshot?.totalQueued ?? totalParagraphs;
 
     const status =
-      aggregateCompleted > 0
-        ? TtsBatchStatus.COMPLETED
-        : TtsBatchStatus.FAILED;
+      aggregateCompleted > 0 ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
 
     await this.queueService.updateBatchMeta(batchJobId, {
       status,

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -13,9 +13,18 @@ import { QuotaExhaustedError } from '../errors/quota-exhausted.error';
 
 const MAX_CONCURRENT_PER_JOB = 5;
 
+/** Transient (non-quota) retries on the SAME provider before cascading */
+const MAX_ATTEMPTS_PER_PROVIDER = 2;
+
+/** Base backoff (ms) between transient retries on the same provider */
+const RETRY_BACKOFF_MS = 300;
+
 type TtsProvider = 'elevenlabs' | 'deepgram' | 'edgetts';
 
-/** Fallback chain when a provider's quota is exhausted */
+/** Provider precedence — used to only advance the shared hint forwards */
+const PROVIDER_ORDER: TtsProvider[] = ['elevenlabs', 'deepgram', 'edgetts'];
+
+/** Fallback chain when a provider fails (quota exhaustion or transient errors) */
 const PROVIDER_FALLBACK: Record<TtsProvider, TtsProvider[]> = {
   elevenlabs: ['deepgram', 'edgetts'],
   deepgram: ['edgetts'],
@@ -58,6 +67,10 @@ export class TtsBatchProcessor extends WorkerHost {
     ];
   }
 
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   async process(job: Job<TtsBatchJobData>): Promise<TtsBatchJobResult> {
     const {
       batchJobId,
@@ -75,46 +88,91 @@ export class TtsBatchProcessor extends WorkerHost {
 
     let completedCount = 0;
     let failedCount = 0;
-    let currentProvider: TtsProvider = provider;
+
+    // Shared hint: once we learn a provider is quota-exhausted, later paragraphs
+    // start straight from the next provider instead of re-hitting the dead one.
+    // It only ever moves forwards through PROVIDER_ORDER.
+    let preferredProvider: TtsProvider = provider;
+
+    const advancePreferred = (exhausted: TtsProvider): void => {
+      const next = PROVIDER_FALLBACK[exhausted]?.[0];
+      if (
+        next &&
+        PROVIDER_ORDER.indexOf(next) > PROVIDER_ORDER.indexOf(preferredProvider)
+      ) {
+        preferredProvider = next;
+      }
+    };
+
+    /**
+     * Generate a single paragraph, walking the provider fallback chain.
+     * - Transient errors: retried up to MAX_ATTEMPTS_PER_PROVIDER on the SAME
+     *   provider (with backoff), then cascade to the next provider.
+     * - Quota errors: no point retrying the same provider — cascade immediately.
+     * Throws the last error only after the whole chain is exhausted.
+     */
+    const generateWithFallback = async (
+      index: number,
+      text: string,
+    ): Promise<{ index: number; audioUrl: string }> => {
+      const chain: TtsProvider[] = [
+        preferredProvider,
+        ...PROVIDER_FALLBACK[preferredProvider],
+      ];
+      let lastError: unknown;
+
+      for (const activeProvider of chain) {
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS_PER_PROVIDER; attempt++) {
+          try {
+            const result = await this.ttsService.generateSingleParagraphTTS(
+              storyId,
+              text,
+              voiceId,
+              userId,
+              { isPremium, providerOverride: activeProvider },
+            );
+            return { index, audioUrl: result.audioUrl };
+          } catch (err) {
+            lastError = err;
+
+            if (this.isQuotaError(err)) {
+              // Quota exhausted — retrying the same provider is pointless.
+              this.logger.warn(
+                `TTS batch ${batchJobId}: ${activeProvider} quota exhausted for paragraph ${index}, cascading to fallback`,
+              );
+              advancePreferred(activeProvider);
+              break; // move to the next provider in the chain
+            }
+
+            const errorMessage =
+              err instanceof Error ? err.message : String(err);
+            if (attempt < MAX_ATTEMPTS_PER_PROVIDER) {
+              this.logger.warn(
+                `TTS batch ${batchJobId}: transient failure on ${activeProvider} for paragraph ${index} (attempt ${attempt}/${MAX_ATTEMPTS_PER_PROVIDER}) — ${errorMessage}; retrying`,
+              );
+              await this.delay(RETRY_BACKOFF_MS * attempt);
+            } else {
+              this.logger.warn(
+                `TTS batch ${batchJobId}: ${activeProvider} exhausted retries for paragraph ${index} — ${errorMessage}; cascading to fallback`,
+              );
+            }
+          }
+        }
+      }
+
+      throw lastError;
+    };
 
     for (let i = 0; i < paragraphs.length; i += MAX_CONCURRENT_PER_JOB) {
       const chunk = paragraphs.slice(i, i + MAX_CONCURRENT_PER_JOB);
 
       const results = await Promise.allSettled(
-        chunk.map(async ({ index, text }) => {
-          const result = await this.ttsService.generateSingleParagraphTTS(
-            storyId,
-            text,
-            voiceId,
-            userId,
-            { isPremium, providerOverride: currentProvider },
-          );
-          return { index, audioUrl: result.audioUrl };
-        }),
+        chunk.map(({ index, text }) => generateWithFallback(index, text)),
       );
-
-      // Detect quota exhaustion — switch provider for remaining chunks
-      const hasQuotaError = results.some(
-        (r) => r.status === 'rejected' && this.isQuotaError(r.reason),
-      );
-
-      if (hasQuotaError) {
-        const fallbacks = PROVIDER_FALLBACK[currentProvider] ?? [];
-        if (fallbacks.length > 0) {
-          this.logger.warn(
-            `TTS batch ${batchJobId}: ${currentProvider} quota exhausted, switching to ${fallbacks[0]} for remaining paragraphs`,
-          );
-          currentProvider = fallbacks[0];
-        }
-      }
-
-      // Collect quota-failed paragraphs for retry through the fallback chain
-      let retryParagraphs: Array<{ index: number; text: string }> = [];
 
       for (let j = 0; j < results.length; j++) {
         const result = results[j];
-        const paragraph = chunk[j];
-        const paragraphIndex = paragraph.index;
+        const paragraphIndex = chunk[j].index;
         const allIndices = this.getDuplicateIndices(paragraphs, paragraphIndex);
 
         if (result.status === 'fulfilled') {
@@ -134,15 +192,14 @@ export class TtsBatchProcessor extends WorkerHost {
             );
             throw redisErr;
           }
-        } else if (hasQuotaError && this.isQuotaError(result.reason)) {
-          retryParagraphs.push({ index: paragraphIndex, text: paragraph.text });
         } else {
+          // Only reached once every provider + retry has been exhausted.
           const errorMessage =
             result.reason instanceof Error
               ? result.reason.message
               : String(result.reason);
           this.logger.warn(
-            `TTS batch ${batchJobId}: TTS generation failed for paragraph ${paragraphIndex} — ${errorMessage}`,
+            `TTS batch ${batchJobId}: paragraph ${paragraphIndex} failed after all providers — ${errorMessage}`,
           );
           try {
             for (const idx of allIndices) {
@@ -158,117 +215,13 @@ export class TtsBatchProcessor extends WorkerHost {
           failedCount++;
         }
       }
-
-      // Cascade quota-failed paragraphs through the remaining fallback chain
-      let retryProvider: TtsProvider | undefined = hasQuotaError
-        ? currentProvider
-        : undefined;
-
-      while (retryParagraphs.length > 0 && retryProvider) {
-        this.logger.log(
-          `TTS batch ${batchJobId}: retrying ${retryParagraphs.length} quota-failed paragraphs with ${retryProvider}`,
-        );
-
-        const retryResults = await Promise.allSettled(
-          retryParagraphs.map(async ({ index, text }) => {
-            const result = await this.ttsService.generateSingleParagraphTTS(
-              storyId,
-              text,
-              voiceId,
-              userId,
-              { isPremium, providerOverride: retryProvider! },
-            );
-            return { index, audioUrl: result.audioUrl };
-          }),
-        );
-
-        const nextRetryParagraphs: Array<{ index: number; text: string }> = [];
-
-        for (let r = 0; r < retryResults.length; r++) {
-          const retryResult = retryResults[r];
-          const retryParagraph = retryParagraphs[r];
-          const allRetryIndices = this.getDuplicateIndices(
-            paragraphs,
-            retryParagraph.index,
-          );
-
-          if (retryResult.status === 'fulfilled') {
-            try {
-              for (const idx of allRetryIndices) {
-                await this.queueService.markParagraphCompleted(
-                  batchJobId,
-                  idx,
-                  retryResult.value.audioUrl,
-                );
-              }
-              completedCount++;
-            } catch (redisErr) {
-              this.logger.error(
-                `TTS batch ${batchJobId}: Redis write failed for retried paragraph ${retryParagraph.index}`,
-                redisErr,
-              );
-              throw redisErr;
-            }
-          } else if (this.isQuotaError(retryResult.reason)) {
-            // Cascade to next provider
-            nextRetryParagraphs.push({
-              index: retryParagraph.index,
-              text: retryParagraph.text,
-            });
-          } else {
-            const retryErrorMsg =
-              retryResult.reason instanceof Error
-                ? retryResult.reason.message
-                : String(retryResult.reason);
-            this.logger.warn(
-              `TTS batch ${batchJobId}: retry with ${retryProvider} failed for paragraph ${retryParagraph.index} — ${retryErrorMsg}`,
-            );
-            try {
-              for (const idx of allRetryIndices) {
-                await this.queueService.markParagraphFailed(batchJobId, idx);
-              }
-            } catch (redisErr) {
-              this.logger.error(
-                `TTS batch ${batchJobId}: Redis write failed for failed retry paragraph ${retryParagraph.index}`,
-                redisErr,
-              );
-              throw redisErr;
-            }
-            failedCount++;
-          }
-        }
-
-        // Advance to the next provider in the fallback chain
-        retryParagraphs = nextRetryParagraphs;
-        if (retryParagraphs.length > 0) {
-          const nextFallbacks = PROVIDER_FALLBACK[retryProvider] ?? [];
-          if (nextFallbacks.length > 0) {
-            this.logger.warn(
-              `TTS batch ${batchJobId}: ${retryProvider} quota also exhausted, cascading to ${nextFallbacks[0]}`,
-            );
-            retryProvider = nextFallbacks[0];
-            currentProvider = retryProvider;
-          } else {
-            // No more providers — mark remaining as failed
-            this.logger.error(
-              `TTS batch ${batchJobId}: all providers exhausted, marking ${retryParagraphs.length} paragraphs as failed`,
-            );
-            for (const p of retryParagraphs) {
-              const allIndices = this.getDuplicateIndices(paragraphs, p.index);
-              for (const idx of allIndices) {
-                await this.queueService.markParagraphFailed(batchJobId, idx);
-              }
-              failedCount++;
-            }
-            retryParagraphs = [];
-            retryProvider = undefined;
-          }
-        }
-      }
     }
 
-    const success = failedCount === 0;
-    const status = success ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
+    // A batch with ANY usable audio is COMPLETED (partial success is still
+    // playable per-paragraph); only a batch where every paragraph failed is
+    // FAILED. The error note flags partial failures for observability.
+    const status =
+      completedCount > 0 ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
 
     await this.queueService.updateBatchMeta(batchJobId, {
       status,
@@ -281,7 +234,7 @@ export class TtsBatchProcessor extends WorkerHost {
       `TTS batch ${batchJobId} finished: ${completedCount} completed, ${failedCount} failed`,
     );
 
-    return { success, completedCount, failedCount };
+    return { success: failedCount === 0, completedCount, failedCount };
   }
 
   @OnWorkerEvent('failed')

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -1,7 +1,10 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
-import { TTS_BATCH_QUEUE_NAME } from './tts-batch-queue.constants';
+import {
+  MAX_RETRY_GENERATIONS,
+  TTS_BATCH_QUEUE_NAME,
+} from './tts-batch-queue.constants';
 import {
   TtsBatchJobData,
   TtsBatchJobResult,
@@ -80,14 +83,21 @@ export class TtsBatchProcessor extends WorkerHost {
       isPremium,
       provider,
       paragraphs,
+      totalParagraphs,
+      retryGeneration,
     } = job.data;
 
+    const generation = retryGeneration ?? 0;
+
     this.logger.log(
-      `Processing TTS batch ${batchJobId}: ${paragraphs.length} paragraphs for story ${storyId} with ${provider}`,
+      `Processing TTS batch ${batchJobId} (generation ${generation}): ${paragraphs.length} paragraphs for story ${storyId} with ${provider}`,
     );
 
     let completedCount = 0;
     let failedCount = 0;
+    // Paragraphs that exhausted the whole provider chain this run — candidates
+    // for a delayed self-heal round.
+    const failedThisRun: TtsBatchJobData['paragraphs'] = [];
 
     // Shared hint: once we learn a provider is quota-exhausted, later paragraphs
     // start straight from the next provider instead of re-hitting the dead one.
@@ -213,28 +223,63 @@ export class TtsBatchProcessor extends WorkerHost {
             throw redisErr;
           }
           failedCount++;
+          failedThisRun.push(chunk[j]);
         }
       }
     }
 
-    // A batch with ANY usable audio is COMPLETED (partial success is still
-    // playable per-paragraph); only a batch where every paragraph failed is
-    // FAILED. The error note flags partial failures for observability.
+    // Self-heal: schedule a delayed follow-up for paragraphs that exhausted the
+    // whole provider chain this run, bounded by MAX_RETRY_GENERATIONS so it can
+    // never loop. The retry re-uses this batchJobId, so recovered paragraphs
+    // heal in place for anyone still polling the batch.
+    if (failedThisRun.length > 0 && generation < MAX_RETRY_GENERATIONS) {
+      try {
+        await this.queueService.queueRetryBatch(
+          job.data,
+          failedThisRun,
+          generation + 1,
+        );
+        this.logger.log(
+          `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
+        );
+      } catch (retryErr) {
+        this.logger.error(
+          `TTS batch ${batchJobId}: failed to schedule self-heal retry`,
+          retryErr,
+        );
+      }
+    }
+
+    // Derive the batch status from the AGGREGATE Redis state, not this run's
+    // local counts: a retry run only touches a subset and must never clobber an
+    // already-partially-good batch back to FAILED. A batch with ANY usable
+    // audio is COMPLETED (partial narration is playable per-paragraph); only an
+    // all-failed batch is FAILED. An empty error string clears a stale
+    // partial-failure note once the batch has fully healed.
+    const snapshot = await this.queueService.getBatchStatus(batchJobId);
+    const aggregateCompleted =
+      snapshot?.completedParagraphs.length ?? completedCount;
+    const aggregateFailed = snapshot?.failedParagraphs.length ?? failedCount;
+    const totalQueued = snapshot?.totalQueued ?? totalParagraphs;
+
     const status =
-      completedCount > 0 ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
+      aggregateCompleted > 0
+        ? TtsBatchStatus.COMPLETED
+        : TtsBatchStatus.FAILED;
 
     await this.queueService.updateBatchMeta(batchJobId, {
       status,
-      ...(failedCount > 0
-        ? { error: `${failedCount}/${paragraphs.length} paragraphs failed` }
-        : {}),
+      error:
+        aggregateFailed > 0
+          ? `${aggregateFailed}/${totalQueued} paragraphs failed`
+          : '',
     });
 
     this.logger.log(
-      `TTS batch ${batchJobId} finished: ${completedCount} completed, ${failedCount} failed`,
+      `TTS batch ${batchJobId} finished (generation ${generation}): ${completedCount} completed / ${failedCount} failed this run; aggregate ${aggregateCompleted} completed / ${aggregateFailed} failed`,
     );
 
-    return { success: failedCount === 0, completedCount, failedCount };
+    return { success: aggregateFailed === 0, completedCount, failedCount };
   }
 
   @OnWorkerEvent('failed')


### PR DESCRIPTION
## Two fixes to the TTS batch processor

### 1. Partial-batch status
A batch was marked `FAILED` if **any single paragraph** failed (`failedCount === 0 ? COMPLETED : FAILED`), even though the other paragraphs produced perfectly good audio. The client then treats the whole story's narration as failed.

Now: **COMPLETED whenever at least one paragraph produced audio** (partial success is playable per-paragraph); only an all-failed batch is `FAILED`. The `error` note still records `N/total paragraphs failed` for observability.

### 2. Transient-failure retry gap
Previously **only quota (402) errors** cascaded through the provider fallback chain. A transient failure (network blip, provider 5xx, timeout) was marked failed **immediately, with zero retries**.

Now each paragraph walks the fallback chain via `generateWithFallback()`:
- **Transient errors** → retried on the same provider up to `MAX_ATTEMPTS_PER_PROVIDER` (with backoff), then cascade to the next provider.
- **Quota errors** → cascade immediately (retrying the same provider is pointless), and advance a shared `preferredProvider` hint so later paragraphs skip the exhausted provider.
- A paragraph is only marked failed after the **entire** chain is exhausted.

Redis-write failures still throw (real infra failure → job fails), unchanged.

### Testing
Type-consistent with the existing service signatures. **Needs a run of the backend unit tests + a manual queue smoke test before merge** — I couldn't run the suite in this environment.

Branch is off `develop-v1.2.0`, independent of the in-flight `security/vuln-batch-1` work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delayed “self-heal” retries for failed text-to-speech paragraphs, with bounded retry generations and configurable wait time.
* **Bug Fixes**
  * Improved paragraph generation resilience with per-paragraph provider fallback, transient-error retries, and faster cascade on quota exhaustion.
  * Batch status and error reporting now reflect aggregate paragraph outcomes consistently (including clearer handling of duplicates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->