### PR TITLE
fix(db): graceful shutdown to stop dev-restart Postgres connection leaks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { INestApplication, Logger, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
@@ -11,19 +11,44 @@ import { requestLogger } from './shared/middleware/request-logger.middleware';
 
 async function bootstrap() {
   const logger = new Logger('Main');
+  let app: INestApplication | undefined;
+  let shuttingDown = false;
+
+  // Close the Nest app (which runs onModuleDestroy on every provider — e.g.
+  // PrismaService.$disconnect() and BullMQ teardown) BEFORE the process exits.
+  // A bare process.exit() bypasses enableShutdownHooks and orphans the open
+  // database connections; in dev's restart-on-save loop those leaked
+  // connections pile up until Postgres refuses new ones. A short unref'd
+  // timeout guarantees we still exit even if close() hangs.
+  const shutdown = async (code: number, reason: string): Promise<void> => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.log(`Shutting down (${reason})`);
+    const force = setTimeout(() => process.exit(code), 8000);
+    force.unref();
+    try {
+      await app?.close();
+    } catch (err) {
+      logger.error('Error during graceful shutdown', err as Error);
+    } finally {
+      clearTimeout(force);
+      process.exit(code);
+    }
+  };
 
   process.on('unhandledRejection', (reason) => {
     logger.error('Unhandled Rejection', reason);
-    // Exit to avoid running in a potentially corrupt state
-    setTimeout(() => process.exit(1), 1000);
+    void shutdown(1, 'unhandledRejection');
   });
 
   process.on('uncaughtException', (error) => {
     logger.error('Uncaught Exception', error);
-    process.exit(1);
+    void shutdown(1, 'uncaughtException');
   });
 
-  const app = await NestFactory.create(AppModule, {
+  app = await NestFactory.create(AppModule, {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });
 


### PR DESCRIPTION
## Problem
Local dev hits Postgres connection exhaustion that grows with every hot-restart.

## Root cause
`main.ts` handles `unhandledRejection`/`uncaughtException` by calling `process.exit(1)`. **`process.exit()` bypasses `enableShutdownHooks()`**, so `PrismaService.onModuleDestroy()` → `$disconnect()` never runs and the open connections are orphaned. `nest start --watch` restarts on every save; in dev those transient errors fire this path repeatedly, and each restart opens a fresh pool on top of the leaked connections until Postgres refuses new ones.

## Fix
Both handlers now `await app.close()` (which runs every provider's `onModuleDestroy`, including Prisma's `$disconnect`) before exiting, guarded by a `shuttingDown` flag and an 8s unref'd force-exit so shutdown can't hang. Graceful `SIGTERM`/`SIGINT` restarts were already covered by `enableShutdownHooks()`.

## Note
If the DB is managed (e.g. Supabase), also point local `DATABASE_URL` at the **connection pooler** (`:6543`, `?pgbouncer=true&connection_limit=1`) — that caps real server connections regardless of any SIGKILL'd restart that no in-process handler can catch. Branch is off `develop-v1.2.0`, independent of the vuln WIP.