### PR TITLE
feat(notification): SubscriptionAlert on store-side cancel path

### DIFF
--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -46,7 +46,7 @@ export class PaymentService {
    * break the payment/subscription flow.
    */
   private async emitNotification(
-    type: 'PaymentSuccess' | 'PaymentFailed',
+    type: 'PaymentSuccess' | 'PaymentFailed' | 'SubscriptionAlert',
     data: Record<string, unknown>,
     userId: string,
   ): Promise<void> {
@@ -470,6 +470,15 @@ export class PaymentService {
       where: { id: existing.id },
       data: { status: 'cancelled', endsAt },
     });
+
+    const cancelledPlan = existing.productId
+      ? this.resolvePlanDisplay(existing.productId)
+      : existing.plan;
+    await this.emitNotification(
+      'SubscriptionAlert',
+      { message: `Your ${cancelledPlan} subscription was cancelled.` },
+      userId,
+    );
 
     if (appleAutoRenewWarning) {
       return {


### PR DESCRIPTION
Follow-up to #396. The `PaymentService.cancelSubscription` path (Google Play / Apple store-side cancel) now emits `SubscriptionAlert` when the subscription flips to cancelled — previously only the subscription-module cancel emitted it. Best-effort (wrapped, never throws).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when a subscription is cancelled, including the cancelled plan’s name.
  * Expanded notification support for subscription-related alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->