### PR TITLE
ci(deploy): corepack enable so pnpm resolves on the server (fixes Deploy to Dev)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -365,6 +365,7 @@ jobs:
           command_timeout: 10m
           script: |
             source ~/.nvm/nvm.sh
+            corepack enable
             cd /home/ubuntu/storytime/production/storytime-api
             [ -f .env ] && chmod 600 .env
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -368,6 +368,7 @@ jobs:
           command_timeout: 10m
           script: |
             source ~/.nvm/nvm.sh
+            corepack enable
             cd /home/ubuntu/storytime/development/storytime-api
 
             # Install Node dependencies

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -351,6 +351,7 @@ jobs:
           command_timeout: 10m
           script: |
             source ~/.nvm/nvm.sh
+            corepack enable
             cd /home/ubuntu/storytime/staging/storytime-api
             [ -f .env ] && chmod 600 .env
 


### PR DESCRIPTION
The 'Deploy to Dev' step failed with **`pnpm: command not found` (exit 127)** — the SSH script sources nvm but has no pnpm shim, though `packageManager` is `pnpm@10.15.1`. Added `corepack enable` after `source ~/.nvm/nvm.sh` in all three deploy workflows (matches the existing malware-scan.yml pattern).

**Merging this re-triggers the dev deploy** and ships everything on develop-v1.2.0 (TTS #394, DB shutdown #395, notification emitters #396, cancel alert #397).