### PR TITLE
feat(notification): NewStory — per-user batched fan-out on story create

### DIFF
--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -89,6 +89,59 @@ export class NotificationService {
     this.providers.set('push', this.pushProvider);
   }
 
+  /**
+   * Fan out a NewStory notification to every active user, batched by id cursor.
+   * Each send goes through sendNotification so it respects the user's NEW_STORY
+   * preference (opt-out) and writes both the in-app record and push. Best-effort:
+   * one failure never aborts the batch. Meant to be fire-and-forget from the
+   * story-create path.
+   */
+  async broadcastNewStoryToUsers(
+    storyId: string,
+    storyTitle: string,
+  ): Promise<void> {
+    const BATCH = 500;
+    let cursor: string | undefined;
+    let sent = 0;
+    let failed = 0;
+    for (;;) {
+      const users = await this.prisma.user.findMany({
+        where: { isDeleted: false, isSuspended: false },
+        select: { id: true },
+        orderBy: { id: 'asc' },
+        take: BATCH,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+      if (users.length === 0) {
+        break;
+      }
+      for (const user of users) {
+        try {
+          await this.sendNotification(
+            'NewStory',
+            { storyTitle, storyId },
+            user.id,
+          );
+          sent++;
+        } catch (error) {
+          failed++;
+          this.logger.warn(
+            `NewStory send failed for user ${user.id.substring(0, 8)}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      cursor = users[users.length - 1].id;
+      if (users.length < BATCH) {
+        break;
+      }
+    }
+    this.logger.log(
+      `NewStory broadcast for story ${storyId}: ${sent} sent, ${failed} failed`,
+    );
+  }
+
   async sendNotification(
     type: Notifications,
     data: Record<string, unknown>,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -1235,16 +1235,17 @@ export class StoryService {
       include: { images: true, branches: true },
     });
 
-    // TODO(new-story-notification): needs batched fan-out or topic broadcast
-    // The NewStory notification is meant for many/all users. The requested emit
-    // path (notificationService.sendNotification(type, data, targetUserId))
-    // targets a single user, so announcing a new story to everyone would require
-    // a naive findMany over the whole users table + per-user loop, which we must
-    // not ship. A push-topic broadcast helper exists (notification.broadcast
-    // event -> queueTopicPush over the 'all_users' FCM topic), but it is
-    // push-only and does not route through the NewStory registry entry (no
-    // per-user in_app records), so it is not a drop-in for sendNotification.
-    // Wire this once a batched fan-out / registry-backed topic broadcast exists.
+    // Announce the new catalog story to all users — batched, preference-aware,
+    // and best-effort. Fire-and-forget so story creation isn't blocked.
+    void this.notificationService
+      .broadcastNewStoryToUsers(story.id, story.title)
+      .catch((error) =>
+        this.logger.warn(
+          `NewStory broadcast failed for story ${story.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      );
 
     await this.invalidateStoryCaches();
     return story;


### PR DESCRIPTION
Wires the last notification event (the earlier TODO). When a new catalog story is created, `NotificationService.broadcastNewStoryToUsers` iterates active users (cursor-batched, 500/page) and emits `NewStory` via `sendNotification` — so it **respects each user's NEW_STORY toggle** and writes **both inbox + push** (option b). Fire-and-forget from `createStory`; best-effort, never blocks creation.

Only the admin/catalog `createStory` path triggers it — personalized AI stories (`persistGeneratedStory`) do not.