### PR TITLE
test: mock NotificationService in payment + story specs (fixes Test)

### DIFF
--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -7,6 +7,7 @@ import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
 import { Prisma } from '@prisma/client';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotificationService } from '../notification/notification.service';
 
 // Type-safe mock for PrismaService
 type MockPrismaService = {
@@ -72,6 +73,10 @@ describe('PaymentService', () => {
         },
         { provide: AppleVerificationService, useValue: mockAppleVerification },
         { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: NotificationService,
+          useValue: { sendNotification: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -8,6 +8,7 @@ import { ElevenLabsService } from './elevenlabs.service';
 import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from './text-to-speech.service';
 import { GuestSessionService } from '../guest/guest-session.service';
+import { NotificationService } from '../notification/notification.service';
 
 // Mock dependencies
 const mockPrismaService = {
@@ -76,6 +77,13 @@ describe('StoryService - Library & Generation', () => {
           useValue: { del: jest.fn(), get: jest.fn(), set: jest.fn() },
         },
         { provide: GuestSessionService, useValue: mockGuestSessionService },
+        {
+          provide: NotificationService,
+          useValue: {
+            sendNotification: jest.fn(),
+            broadcastNewStoryToUsers: jest.fn(),
+          },
+        },
       ],
     }).compile();
 


### PR DESCRIPTION
PaymentService/StoryService inject NotificationService (the notification emitters), but their specs didn't provide it → 'Nest can't resolve dependencies of the PaymentService … NotificationService at index [5]' → all tests error. Added a mocked NotificationService to both test modules. Unblocks the release→prod deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated payment and story service test setups to include notification handling.
  * Added mocked notification actions to improve test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->