### PR TITLE
feat(notification): admin broadcast → inbox + StoryFinished on web completion

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -56,6 +56,7 @@ import {
 } from '@/shared/constants/cache-keys.constants';
 import { DashboardUtil } from './utils/dashboard.util';
 import { BroadcastNotificationDto } from './dto/broadcast-notification.dto';
+import { NotificationService } from '../notification/notification.service';
 import { CreateAdminTicketDto } from './dto/create-admin-ticket.dto';
 import { ResetQuotaDto } from './dto/reset-quota.dto';
 import { GuestStatsDto, GuestActivityFilterDto } from './dto/guest-stats.dto';
@@ -85,6 +86,7 @@ export class AdminService {
     private readonly couponService: CouponService,
     private readonly googleVerificationService: GoogleVerificationService,
     private readonly appleVerificationService: AppleVerificationService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   // =====================
@@ -1815,11 +1817,7 @@ export class AdminService {
 
   async getAiCreditAnalytics(
     duration:
-      | 'yearly'
-      | 'quarterly'
-      | 'monthly'
-      | 'weekly'
-      | 'daily' = 'yearly',
+      'yearly' | 'quarterly' | 'monthly' | 'weekly' | 'daily' = 'yearly',
   ): Promise<AiCreditAnalyticsDto> {
     const now = new Date();
     let startDate: Date;
@@ -2740,7 +2738,7 @@ export class AdminService {
    */
   async broadcastNotification(
     dto: BroadcastNotificationDto,
-  ): Promise<{ sent: boolean; topic: string }> {
+  ): Promise<{ sent: boolean; topic: string; inAppDelivered: number }> {
     const topic = dto.topic ?? 'all_users';
 
     await this.eventEmitter.emitAsync('notification.broadcast', {
@@ -2752,7 +2750,24 @@ export class AdminService {
     this.logger.log(
       `Broadcast notification emitted to topic "${topic}": "${dto.title}"`,
     );
-    return { sent: true, topic };
+
+    // Also write an in-app inbox entry for every user so the broadcast shows in
+    // the app's notification list, not just as an ephemeral push.
+    let inAppDelivered = 0;
+    try {
+      const inApp = await this.notificationService.broadcastInAppToAllUsers(
+        dto.title,
+        dto.body,
+        dto.data,
+      );
+      inAppDelivered = inApp.delivered;
+    } catch (error) {
+      this.logger.error(
+        `In-app broadcast failed for "${dto.title}": ${(error as Error).message}`,
+      );
+    }
+
+    return { sent: true, topic, inAppDelivered };
   }
 
   /**

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1817,7 +1817,11 @@ export class AdminService {
 
   async getAiCreditAnalytics(
     duration:
-      'yearly' | 'quarterly' | 'monthly' | 'weekly' | 'daily' = 'yearly',
+      | 'yearly'
+      | 'quarterly'
+      | 'monthly'
+      | 'weekly'
+      | 'daily' = 'yearly',
   ): Promise<AiCreditAnalyticsDto> {
     const now = new Date();
     let startDate: Date;

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -142,6 +142,65 @@ export class NotificationService {
     );
   }
 
+  /**
+   * Write an in-app inbox record for every active user (batched). Used by admin
+   * broadcasts so an announcement lands in the in-app inbox, not just push.
+   * Best-effort per user; category defaults to SYSTEM_ALERT.
+   */
+  async broadcastInAppToAllUsers(
+    title: string,
+    body: string,
+    data?: Record<string, unknown>,
+  ): Promise<{ delivered: number; failed: number }> {
+    const BATCH = 500;
+    let cursor: string | undefined;
+    let delivered = 0;
+    let failed = 0;
+    for (;;) {
+      const users = await this.prisma.user.findMany({
+        where: { isDeleted: false, isSuspended: false },
+        select: { id: true },
+        orderBy: { id: 'asc' },
+        take: BATCH,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+      if (users.length === 0) {
+        break;
+      }
+      for (const user of users) {
+        try {
+          const result = await this.inAppProvider.send({
+            userId: user.id,
+            category: PrismaCategory.SYSTEM_ALERT,
+            title,
+            body,
+            data,
+          });
+          if (result.success) {
+            delivered++;
+          } else {
+            failed++;
+          }
+        } catch (error) {
+          failed++;
+          this.logger.warn(
+            `In-app broadcast failed for user ${user.id.substring(0, 8)}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      cursor = users[users.length - 1].id;
+      if (users.length < BATCH) {
+        break;
+      }
+    }
+    this.logger.log(
+      `In-app broadcast "${title}": ${delivered} delivered, ${failed} failed`,
+    );
+    return { delivered, failed };
+  }
+
   async sendNotification(
     type: Notifications,
     data: Record<string, unknown>,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -1547,11 +1547,30 @@ export class StoryService {
 
     let completed = result.completed;
     if (shouldComplete && !completed) {
-      await this.prisma.userStoryProgress.updateMany({
+      const flipped = await this.prisma.userStoryProgress.updateMany({
         where: { userId, storyId: dto.storyId, completed: false },
         data: { completed: true },
       });
       completed = true;
+
+      // Best-effort StoryFinished notification on the user (web) completion
+      // path — mirrors the kid setProgress path. Only on the true false->true
+      // transition; never breaks progress recording.
+      if (flipped.count === 1) {
+        try {
+          await this.notificationService.sendNotification(
+            'StoryFinished',
+            { kidName: user.name ?? 'You', storyTitle: story.title },
+            userId,
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Failed to send StoryFinished (user path): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
     }
 
     return {


### PR DESCRIPTION
Two notification fixes:

1. **Admin broadcast → in-app inbox.** `POST /admin/notifications/broadcast` was push-only (FCM topic). It now *also* writes an in-app inbox entry for every active user via `NotificationService.broadcastInAppToAllUsers` (batched, category SYSTEM_ALERT), and returns `inAppDelivered`. This makes the broadcast a real way to demo/send in-app notifications.

2. **StoryFinished on the web completion path.** StoryFinished only emitted on the *kid* progress path (`setProgress`). The web app records completion via the *user* path (`setUserProgress` / `POST /stories/user/progress`), which had no emit — so finishing a story on web produced nothing in the inbox. Now it emits StoryFinished to the user on the true completion transition (best-effort).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin broadcasts now also create in-app inbox notifications for active users.
  * Broadcast results include the number of successfully delivered in-app notifications.
  * Users receive a notification when they complete a story.

* **Bug Fixes**
  * Notification delivery failures no longer interrupt broadcasts or story progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->