### PR TITLE
test: mock NotificationService in admin spec (unblocks prod deploy)

### DIFF
--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -7,6 +7,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CouponService } from '../../coupon/coupon.service';
 import { GoogleVerificationService } from '../../payment/google-verification.service';
 import { AppleVerificationService } from '../../payment/apple-verification.service';
+import { NotificationService } from '../../notification/notification.service';
 
 // Mock Cache Manager
 const mockCacheManager = {
@@ -127,6 +128,10 @@ describe('AdminService', () => {
         {
           provide: AppleVerificationService,
           useValue: mockAppleVerificationService,
+        },
+        {
+          provide: NotificationService,
+          useValue: { broadcastInAppToAllUsers: jest.fn() },
         },
       ],
     }).compile();


### PR DESCRIPTION
AdminService injects NotificationService (admin broadcast → inbox, #402) but admin.service.spec.ts didn't provide it → DI failure → all AdminService tests error → staging Test failed → prod held. Adds the mock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated admin service tests with a mock notification provider to support in-app broadcast scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->