### PR TITLE
feat: rebuild Apple ASSN v2 + Google Play RTDN subscription webhook receiver

### DIFF
--- a/prisma/migrations/20260718000000_subscription_event_watermark/migration.sql
+++ b/prisma/migrations/20260718000000_subscription_event_watermark/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "subscriptions" ADD COLUMN     "lastEventAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -490,6 +490,12 @@ model Subscription {
   platform      String? // "google" or "apple"
   productId     String? // e.g. "com.storytime.monthly"
   purchaseToken String? // token from the platform
+  // Out-of-order delivery protection: the authoritative timestamp of the most
+  // recent store webhook applied to this row (Apple signedDate / Google
+  // eventTimeMillis). A later event whose timestamp is <= this is stale and is
+  // skipped so it cannot clobber newer state (e.g. a delayed EXPIRED after a
+  // DID_RENEW). Nullable so pre-existing rows and untimestamped events work.
+  lastEventAt   DateTime?
   // SOFT DELETE FIELDS
   isDeleted     Boolean   @default(false)
   deletedAt     DateTime?

--- a/scripts/verify_google_purchase.py
+++ b/scripts/verify_google_purchase.py
@@ -80,10 +80,15 @@ def verify_purchase(package_name, product_id, purchase_token):
 
         if response.status_code == 200:
             data = response.json()
+            # Surface linkedPurchaseToken so the backend can follow the token
+            # chain to the prior subscription on upgrade/downgrade/re-subscribe.
+            # Google issues a NEW purchase token for these transitions and links
+            # it to the previous token via this field.
             return {
                 "success": True,
                 "isSubscription": True,
-                "data": data
+                "data": data,
+                "linkedPurchaseToken": data.get("linkedPurchaseToken")
             }
         elif response.status_code == 404:
             # Try one-time product instead

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,10 @@ import { requestLogger } from './shared/middleware/request-logger.middleware';
 
 async function bootstrap() {
   const logger = new Logger('Main');
+  // Declared before the error handlers + shutdown closure below (which reference
+  // it) so a failure during NestFactory.create is still caught and closed
+  // gracefully. This is a genuine read-before-assign, which prefer-const misflags.
+  // eslint-disable-next-line prefer-const
   let app: INestApplication | undefined;
   let shuttingDown = false;
 

--- a/src/payment/apple-notification.spec.ts
+++ b/src/payment/apple-notification.spec.ts
@@ -1,0 +1,230 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HttpException } from '@nestjs/common';
+import { execFileSync } from 'child_process';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AppleVerificationService } from './apple-verification.service';
+
+/**
+ * Exercises the ASSN v2 JWS signature verification + decoding in
+ * AppleVerificationService.parseSignedNotification using a real, locally
+ * generated EC (P-256) certificate chain. The generated root's fingerprint is
+ * injected via APPLE_ROOT_CA_FINGERPRINT so the pinning check passes.
+ */
+
+const b64url = (input: string | Buffer): string =>
+  Buffer.from(input).toString('base64url');
+
+let opensslAvailable = true;
+try {
+  execFileSync('openssl', ['version']);
+} catch {
+  opensslAvailable = false;
+}
+
+interface Chain {
+  x5c: string[];
+  leafKey: crypto.KeyObject;
+  rootFingerprint: string;
+}
+
+function buildChain(): Chain {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'apple-jws-'));
+  const p = (f: string) => path.join(dir, f);
+  const run = (args: string[]) => execFileSync('openssl', args);
+
+  run([
+    'ecparam',
+    '-name',
+    'prime256v1',
+    '-genkey',
+    '-noout',
+    '-out',
+    p('root.key'),
+  ]);
+  run([
+    'req',
+    '-x509',
+    '-new',
+    '-key',
+    p('root.key'),
+    '-out',
+    p('root.crt'),
+    '-days',
+    '2',
+    '-subj',
+    '/CN=Test Apple Root',
+  ]);
+  run([
+    'ecparam',
+    '-name',
+    'prime256v1',
+    '-genkey',
+    '-noout',
+    '-out',
+    p('leaf.key'),
+  ]);
+  run([
+    'req',
+    '-new',
+    '-key',
+    p('leaf.key'),
+    '-out',
+    p('leaf.csr'),
+    '-subj',
+    '/CN=Test Apple Leaf',
+  ]);
+  run([
+    'x509',
+    '-req',
+    '-in',
+    p('leaf.csr'),
+    '-CA',
+    p('root.crt'),
+    '-CAkey',
+    p('root.key'),
+    '-CAcreateserial',
+    '-out',
+    p('leaf.crt'),
+    '-days',
+    '1',
+  ]);
+
+  const rootCert = new crypto.X509Certificate(fs.readFileSync(p('root.crt')));
+  const leafCert = new crypto.X509Certificate(fs.readFileSync(p('leaf.crt')));
+  const leafKey = crypto.createPrivateKey(fs.readFileSync(p('leaf.key')));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return {
+    x5c: [
+      Buffer.from(leafCert.raw).toString('base64'),
+      Buffer.from(rootCert.raw).toString('base64'),
+    ],
+    leafKey,
+    rootFingerprint: rootCert.fingerprint256,
+  };
+}
+
+function nestedJws(payload: Record<string, unknown>): string {
+  return `${b64url('{"alg":"ES256"}')}.${b64url(JSON.stringify(payload))}.${b64url('sig')}`;
+}
+
+function makeSignedPayload(
+  chain: Chain,
+  payload: Record<string, unknown>,
+): string {
+  const header = b64url(JSON.stringify({ alg: 'ES256', x5c: chain.x5c }));
+  const body = b64url(JSON.stringify(payload));
+  const signingInput = `${header}.${body}`;
+  const sig = crypto.sign('sha256', Buffer.from(signingInput), {
+    key: chain.leafKey,
+    dsaEncoding: 'ieee-p1363',
+  });
+  return `${signingInput}.${b64url(sig)}`;
+}
+
+const describeIf = opensslAvailable ? describe : describe.skip;
+
+describeIf('AppleVerificationService.parseSignedNotification', () => {
+  let chain: Chain;
+  let service: AppleVerificationService;
+
+  const notificationPayload = {
+    notificationType: 'DID_RENEW',
+    subtype: 'BILLING_RECOVERY',
+    notificationUUID: 'uuid-123',
+    signedDate: Date.now(),
+    data: {
+      bundleId: 'com.storytime.app',
+      environment: 'Production',
+      signedTransactionInfo: nestedJws({
+        originalTransactionId: 'orig-999',
+        productId: 'com.storytime.monthly',
+        expiresDate: 1893456000000,
+      }),
+      signedRenewalInfo: nestedJws({
+        originalTransactionId: 'orig-999',
+        autoRenewStatus: 1,
+      }),
+    },
+  };
+
+  beforeAll(() => {
+    chain = buildChain();
+  });
+
+  const build = async (fingerprint: string) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppleVerificationService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'APPLE_ROOT_CA_FINGERPRINT' ? fingerprint : undefined,
+          },
+        },
+      ],
+    }).compile();
+    return module.get(AppleVerificationService);
+  };
+
+  beforeEach(async () => {
+    service = await build(chain.rootFingerprint);
+  });
+
+  it('verifies a valid JWS and decodes the notification + nested transaction info', () => {
+    const signedPayload = makeSignedPayload(chain, notificationPayload);
+    const info = service.parseSignedNotification(signedPayload);
+
+    expect(info.notificationType).toBe('DID_RENEW');
+    expect(info.subtype).toBe('BILLING_RECOVERY');
+    expect(info.notificationUUID).toBe('uuid-123');
+    expect(info.transactionInfo?.originalTransactionId).toBe('orig-999');
+    expect(info.transactionInfo?.productId).toBe('com.storytime.monthly');
+    expect(info.renewalInfo?.autoRenewStatus).toBe(1);
+  });
+
+  it('rejects a tampered signature', () => {
+    const signedPayload = makeSignedPayload(chain, notificationPayload);
+    const parts = signedPayload.split('.');
+    // Flip the payload but keep the original signature -> signature mismatch.
+    parts[1] = b64url(
+      JSON.stringify({ ...notificationPayload, notificationUUID: 'evil' }),
+    );
+    const tampered = parts.join('.');
+
+    expect(() => service.parseSignedNotification(tampered)).toThrow(
+      HttpException,
+    );
+  });
+
+  it('rejects when the root CA fingerprint does not match the pin', async () => {
+    const otherService = await build('AA:BB:CC');
+    const signedPayload = makeSignedPayload(chain, notificationPayload);
+
+    expect(() => otherService.parseSignedNotification(signedPayload)).toThrow(
+      /root certificate is not trusted/i,
+    );
+  });
+
+  it('rejects a payload missing the x5c chain', () => {
+    const header = b64url(JSON.stringify({ alg: 'ES256' }));
+    const body = b64url(JSON.stringify(notificationPayload));
+    const bad = `${header}.${body}.${b64url('sig')}`;
+
+    expect(() => service.parseSignedNotification(bad)).toThrow(
+      /x5c certificate chain/i,
+    );
+  });
+
+  it('rejects a non-JWS string', () => {
+    expect(() => service.parseSignedNotification('not-a-jws')).toThrow(
+      HttpException,
+    );
+  });
+});

--- a/src/payment/apple-notification.spec.ts
+++ b/src/payment/apple-notification.spec.ts
@@ -227,4 +227,67 @@ describeIf('AppleVerificationService.parseSignedNotification', () => {
       HttpException,
     );
   });
+
+  it('rejects a notification addressed to a different bundleId (400)', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppleVerificationService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'APPLE_ROOT_CA_FINGERPRINT')
+                return chain.rootFingerprint;
+              if (key === 'APPLE_BUNDLE_ID') return 'com.storytime.app';
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+    const scoped = module.get(AppleVerificationService);
+
+    const signedPayload = makeSignedPayload(chain, {
+      ...notificationPayload,
+      data: { ...notificationPayload.data, bundleId: 'com.evil.other' },
+    });
+
+    expect(() => scoped.parseSignedNotification(signedPayload)).toThrow(
+      /bundleId/i,
+    );
+  });
+});
+
+describe('AppleVerificationService.parseSignedNotification malformed header', () => {
+  let service: AppleVerificationService;
+
+  const b64 = (s: string): string => Buffer.from(s).toString('base64url');
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppleVerificationService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
+      ],
+    }).compile();
+    service = module.get(AppleVerificationService);
+  });
+
+  // These exercise the header guard before any certificate work, so they do not
+  // need a generated chain / openssl.
+  it('rejects a JWS whose header decodes to null (no unhandled 500)', () => {
+    const jws = `${b64('null')}.${b64('{}')}.${b64('sig')}`;
+    try {
+      service.parseSignedNotification(jws);
+      throw new Error('expected parseSignedNotification to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(400);
+    }
+  });
+
+  it('rejects a JWS whose header decodes to an array', () => {
+    const jws = `${b64('[]')}.${b64('{}')}.${b64('sig')}`;
+    expect(() => service.parseSignedNotification(jws)).toThrow(HttpException);
+  });
 });

--- a/src/payment/apple-verification.service.ts
+++ b/src/payment/apple-verification.service.ts
@@ -31,6 +31,49 @@ export interface AppleVerifyParams {
   productId: string;
 }
 
+/** Decoded JWSTransaction payload from an ASSN v2 notification */
+export interface AppleDecodedTransaction {
+  transactionId?: string;
+  originalTransactionId?: string;
+  productId?: string;
+  purchaseDate?: number;
+  expiresDate?: number;
+  type?: string;
+  appAccountToken?: string;
+  revocationDate?: number;
+  revocationReason?: number;
+  environment?: string;
+  [key: string]: unknown;
+}
+
+/** Decoded JWSRenewalInfo payload from an ASSN v2 notification */
+export interface AppleDecodedRenewal {
+  originalTransactionId?: string;
+  autoRenewStatus?: number;
+  autoRenewProductId?: string;
+  productId?: string;
+  expirationIntent?: number;
+  gracePeriodExpiresDate?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Decoded & signature-verified App Store Server Notification v2.
+ * @see https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload
+ */
+export interface AppleNotificationInfo {
+  notificationType: string;
+  subtype?: string;
+  notificationUUID: string;
+  bundleId?: string;
+  environment?: string;
+  signedDate?: number;
+  transactionInfo?: AppleDecodedTransaction;
+  renewalInfo?: AppleDecodedRenewal;
+  /** Full decoded outer payload, kept for auditing/debugging */
+  raw: Record<string, unknown>;
+}
+
 /** Decoded transaction info from Apple */
 interface AppleTransactionInfo {
   transactionId: string;
@@ -55,6 +98,15 @@ const PRODUCTION_HOST = 'api.storekit.itunes.apple.com';
 const SANDBOX_HOST = 'api.storekit-sandbox.itunes.apple.com';
 
 /**
+ * SHA-256 fingerprint of "Apple Root CA - G3", the trust anchor for the x5c
+ * certificate chain in ASSN v2 JWS headers. Overridable via
+ * APPLE_ROOT_CA_FINGERPRINT. VERIFY THIS VALUE against the certificate at
+ * https://www.apple.com/certificateauthority/ before going live.
+ */
+const APPLE_ROOT_CA_G3_FINGERPRINT =
+  '63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79';
+
+/**
  * Service to verify Apple App Store purchases using App Store Server API v2.
  */
 @Injectable()
@@ -65,15 +117,202 @@ export class AppleVerificationService {
   private readonly bundleId: string;
   private readonly privateKey: string;
   private readonly environment: 'sandbox' | 'production';
+  private readonly rootCaFingerprint: string;
 
   constructor(private readonly configService: ConfigService) {
     this.keyId = this.configService.get<string>('APPLE_KEY_ID') || '';
     this.issuerId = this.configService.get<string>('APPLE_ISSUER_ID') || '';
     this.bundleId = this.configService.get<string>('APPLE_BUNDLE_ID') || '';
     this.privateKey = this.configService.get<string>('APPLE_PRIVATE_KEY') || '';
+    this.rootCaFingerprint = (
+      this.configService.get<string>('APPLE_ROOT_CA_FINGERPRINT') ||
+      APPLE_ROOT_CA_G3_FINGERPRINT
+    )
+      .toUpperCase()
+      .replace(/\s/g, '');
 
     const nodeEnv = this.configService.get<string>('NODE_ENV') || 'development';
     this.environment = nodeEnv === 'production' ? 'production' : 'sandbox';
+  }
+
+  /**
+   * Verify and decode an App Store Server Notification v2 signed payload.
+   *
+   * Cryptographically verifies the JWS signature against the x5c certificate
+   * chain (anchored to Apple Root CA - G3), then decodes the outer payload and
+   * the nested signedTransactionInfo / signedRenewalInfo JWS objects.
+   *
+   * @throws HttpException(400) when the signature/chain is invalid or the
+   *         payload is malformed.
+   */
+  parseSignedNotification(signedPayload: string): AppleNotificationInfo {
+    if (!signedPayload || typeof signedPayload !== 'string') {
+      throw new HttpException(
+        'Missing Apple signedPayload',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 1. Verify the JWS signature + certificate chain before trusting anything.
+    this.verifyJWS(signedPayload);
+
+    // 2. Decode the outer notification payload.
+    const outer = this.decodeJWS(signedPayload) as Record<string, unknown>;
+    const notificationType = outer.notificationType as string | undefined;
+    const notificationUUID = outer.notificationUUID as string | undefined;
+
+    if (!notificationType || !notificationUUID) {
+      throw new HttpException(
+        'Invalid Apple notification payload: missing notificationType/notificationUUID',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const data = (outer.data ?? {}) as Record<string, unknown>;
+
+    let transactionInfo: AppleDecodedTransaction | undefined;
+    let renewalInfo: AppleDecodedRenewal | undefined;
+
+    try {
+      if (typeof data.signedTransactionInfo === 'string') {
+        transactionInfo = this.decodeJWS(
+          data.signedTransactionInfo,
+        ) as AppleDecodedTransaction;
+      }
+      if (typeof data.signedRenewalInfo === 'string') {
+        renewalInfo = this.decodeJWS(
+          data.signedRenewalInfo,
+        ) as AppleDecodedRenewal;
+      }
+    } catch {
+      throw new HttpException(
+        'Failed to decode Apple notification transaction data',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return {
+      notificationType,
+      subtype: outer.subtype as string | undefined,
+      notificationUUID,
+      bundleId: data.bundleId as string | undefined,
+      environment: data.environment as string | undefined,
+      signedDate: outer.signedDate as number | undefined,
+      transactionInfo,
+      renewalInfo,
+      raw: outer,
+    };
+  }
+
+  /**
+   * Verify a JWS signature using the x5c certificate chain embedded in its
+   * header. Confirms: (a) each certificate is signed by the next, (b) the root
+   * matches the pinned Apple Root CA fingerprint, (c) certificates are within
+   * their validity window, and (d) the leaf certificate's public key validates
+   * the ES256 signature.
+   *
+   * @throws HttpException(400) on any verification failure.
+   */
+  private verifyJWS(jws: string): void {
+    const parts = jws.split('.');
+    if (parts.length !== 3) {
+      throw new HttpException('Invalid JWS format', HttpStatus.BAD_REQUEST);
+    }
+
+    let header: { alg?: string; x5c?: string[] };
+    try {
+      header = JSON.parse(
+        Buffer.from(parts[0], 'base64url').toString('utf8'),
+      ) as { alg?: string; x5c?: string[] };
+    } catch {
+      throw new HttpException('Invalid JWS header', HttpStatus.BAD_REQUEST);
+    }
+
+    if (header.alg !== 'ES256') {
+      throw new HttpException(
+        `Unsupported JWS algorithm: ${String(header.alg)}`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (!Array.isArray(header.x5c) || header.x5c.length < 2) {
+      throw new HttpException(
+        'JWS missing x5c certificate chain',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    let certs: crypto.X509Certificate[];
+    try {
+      certs = header.x5c.map(
+        (der) => new crypto.X509Certificate(Buffer.from(der, 'base64')),
+      );
+    } catch {
+      throw new HttpException(
+        'Invalid certificate in JWS x5c chain',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const now = Date.now();
+    for (const cert of certs) {
+      const notBefore = new Date(cert.validFrom).getTime();
+      const notAfter = new Date(cert.validTo).getTime();
+      if (Number.isFinite(notBefore) && now < notBefore) {
+        throw new HttpException(
+          'JWS certificate not yet valid',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      if (Number.isFinite(notAfter) && now > notAfter) {
+        throw new HttpException(
+          'JWS certificate expired',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // Verify chain: each cert must be signed by the next one up.
+    for (let i = 0; i < certs.length - 1; i++) {
+      if (!certs[i].verify(certs[i + 1].publicKey)) {
+        throw new HttpException(
+          'JWS certificate chain verification failed',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // Pin the root certificate to Apple's known fingerprint.
+    const root = certs[certs.length - 1];
+    const rootFingerprint = root.fingerprint256.toUpperCase();
+    if (rootFingerprint !== this.rootCaFingerprint) {
+      this.logger.error(
+        `Apple JWS root CA fingerprint mismatch (got ${rootFingerprint})`,
+      );
+      throw new HttpException(
+        'JWS root certificate is not trusted',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // Verify the signature with the leaf certificate's public key. ES256
+    // signatures are raw r||s (IEEE P1363), which Node verifies with the
+    // 'ieee-p1363' dsaEncoding.
+    const signingInput = `${parts[0]}.${parts[1]}`;
+    const signature = Buffer.from(parts[2], 'base64url');
+    const verified = crypto.verify(
+      'sha256',
+      Buffer.from(signingInput),
+      { key: certs[0].publicKey, dsaEncoding: 'ieee-p1363' },
+      signature,
+    );
+
+    if (!verified) {
+      throw new HttpException(
+        'JWS signature verification failed',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
   }
 
   async verify(params: AppleVerifyParams): Promise<AppleVerificationResult> {

--- a/src/payment/apple-verification.service.ts
+++ b/src/payment/apple-verification.service.ts
@@ -170,6 +170,20 @@ export class AppleVerificationService {
 
     const data = (outer.data ?? {}) as Record<string, unknown>;
 
+    // Reject notifications addressed to a different app. A JWS can be validly
+    // Apple-signed yet belong to another bundle; without this check any such
+    // notification would be recorded and routed into subscription processing.
+    const bundleId = data.bundleId as string | undefined;
+    if (this.bundleId && bundleId && bundleId !== this.bundleId) {
+      this.logger.warn(
+        `Apple notification bundleId mismatch (got ${this.sanitizeForLog(bundleId)})`,
+      );
+      throw new HttpException(
+        'Apple notification bundleId does not match configured app',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     let transactionInfo: AppleDecodedTransaction | undefined;
     let renewalInfo: AppleDecodedRenewal | undefined;
 
@@ -221,9 +235,15 @@ export class AppleVerificationService {
 
     let header: { alg?: string; x5c?: string[] };
     try {
-      header = JSON.parse(
+      const parsed: unknown = JSON.parse(
         Buffer.from(parts[0], 'base64url').toString('utf8'),
-      ) as { alg?: string; x5c?: string[] };
+      );
+      // `JSON.parse('null')` (and other non-object JSON) succeeds; guard against
+      // it so dereferencing header.alg below cannot throw an unhandled 500.
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('JWS header must be a JSON object');
+      }
+      header = parsed as { alg?: string; x5c?: string[] };
     } catch {
       throw new HttpException('Invalid JWS header', HttpStatus.BAD_REQUEST);
     }

--- a/src/payment/dto/webhook.dto.ts
+++ b/src/payment/dto/webhook.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * Apple App Store Server Notifications v2 request body.
+ * Apple POSTs a single JWS (JSON Web Signature) string.
+ * @see https://developer.apple.com/documentation/appstoreservernotifications
+ */
+export class AppleWebhookDto {
+  @ApiProperty({
+    description: 'Apple ASSN v2 signed payload (JWS)',
+    example: 'eyJhbGciOiJFUzI1NiIs...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  signedPayload: string;
+}
+
+/**
+ * Google Cloud Pub/Sub push message envelope.
+ * Google Play RTDN messages are delivered via a Pub/Sub push subscription.
+ * @see https://developer.android.com/google/play/billing/rtdn-reference
+ */
+export class GooglePubSubMessageDto {
+  @ApiProperty({
+    description: 'Base64-encoded RTDN payload JSON',
+  })
+  @IsString()
+  @IsNotEmpty()
+  data: string;
+
+  @ApiProperty({ description: 'Pub/Sub message id (used for idempotency)' })
+  @IsString()
+  @IsNotEmpty()
+  messageId: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  publishTime?: string;
+}
+
+export class GoogleWebhookDto {
+  @ApiProperty({ type: GooglePubSubMessageDto })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => GooglePubSubMessageDto)
+  message: GooglePubSubMessageDto;
+
+  @ApiProperty({ required: false, description: 'Pub/Sub subscription name' })
+  @IsOptional()
+  @IsString()
+  subscription?: string;
+}

--- a/src/payment/google-pubsub-verifier.service.spec.ts
+++ b/src/payment/google-pubsub-verifier.service.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GooglePubSubVerifierService } from './google-pubsub-verifier.service';
+
+// Mock google-auth-library so no network/JWKS fetch happens. The single
+// `mockVerifyIdToken` is shared by every OAuth2Client instance the service
+// constructs, so each test can control the verification outcome.
+const mockVerifyIdToken = jest.fn();
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: mockVerifyIdToken,
+  })),
+}));
+
+const AUDIENCE = 'https://api.storytime.test/payment/webhooks/google';
+const SA_EMAIL = 'pubsub-push@storytime.iam.gserviceaccount.com';
+
+const ticketWith = (payload: Record<string, unknown> | undefined) => ({
+  getPayload: () => payload,
+});
+
+/** Build the service with a given env config. */
+const buildService = async (
+  config: Record<string, string | undefined>,
+): Promise<GooglePubSubVerifierService> => {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      GooglePubSubVerifierService,
+      {
+        provide: ConfigService,
+        useValue: { get: (key: string) => config[key] },
+      },
+    ],
+  }).compile();
+  return module.get(GooglePubSubVerifierService);
+};
+
+describe('GooglePubSubVerifierService', () => {
+  beforeEach(() => {
+    mockVerifyIdToken.mockReset();
+  });
+
+  // ----------------------------------------------------- enforced posture ----
+  describe('when GOOGLE_PUBSUB_AUDIENCE is configured (enforced)', () => {
+    let service: GooglePubSubVerifierService;
+
+    beforeEach(async () => {
+      service = await buildService({
+        GOOGLE_PUBSUB_AUDIENCE: AUDIENCE,
+        GOOGLE_PUBSUB_SA_EMAIL: SA_EMAIL,
+      });
+    });
+
+    it('accepts a valid token from the configured service account', async () => {
+      mockVerifyIdToken.mockResolvedValue(
+        ticketWith({ email: SA_EMAIL, email_verified: true }),
+      );
+
+      await expect(
+        service.verifyPushRequest(`Bearer good-token`),
+      ).resolves.toBeUndefined();
+
+      expect(mockVerifyIdToken).toHaveBeenCalledWith({
+        idToken: 'good-token',
+        audience: AUDIENCE,
+      });
+    });
+
+    it('rejects a missing Authorization header', async () => {
+      await expect(service.verifyPushRequest(undefined)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+      expect(mockVerifyIdToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects a header without a Bearer token', async () => {
+      await expect(
+        service.verifyPushRequest('Basic abc'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(mockVerifyIdToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bad signature / invalid token (verifyIdToken throws)', async () => {
+      mockVerifyIdToken.mockRejectedValue(new Error('Invalid token signature'));
+
+      await expect(
+        service.verifyPushRequest('Bearer forged'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects a wrong audience (verifyIdToken throws on aud mismatch)', async () => {
+      mockVerifyIdToken.mockRejectedValue(
+        new Error(`Wrong recipient, payload audience != requiredAudience`),
+      );
+
+      await expect(
+        service.verifyPushRequest('Bearer wrong-aud'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects a token whose email is not the configured service account', async () => {
+      mockVerifyIdToken.mockResolvedValue(
+        ticketWith({ email: 'attacker@evil.com', email_verified: true }),
+      );
+
+      await expect(
+        service.verifyPushRequest('Bearer wrong-email'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects a token with email_verified !== true', async () => {
+      mockVerifyIdToken.mockResolvedValue(
+        ticketWith({ email: SA_EMAIL, email_verified: false }),
+      );
+
+      await expect(
+        service.verifyPushRequest('Bearer unverified'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('rejects a token with no payload', async () => {
+      mockVerifyIdToken.mockResolvedValue(ticketWith(undefined));
+
+      await expect(
+        service.verifyPushRequest('Bearer no-payload'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  // --------------------------------------------------- unconfigured posture --
+  describe('when GOOGLE_PUBSUB_AUDIENCE is NOT configured (skip + warn)', () => {
+    it('skips verification and resolves, even with no token', async () => {
+      const service = await buildService({});
+      const warn = jest
+        .spyOn(service['logger'], 'warn')
+        .mockImplementation(() => undefined);
+
+      await expect(
+        service.verifyPushRequest(undefined),
+      ).resolves.toBeUndefined();
+
+      expect(mockVerifyIdToken).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledTimes(1); // production-config warning
+    });
+  });
+
+  // --------------------------------- audience set but SA email unconfigured --
+  describe('when audience is set but GOOGLE_PUBSUB_SA_EMAIL is not', () => {
+    it('accepts any Google-verified account for the audience (with a warning)', async () => {
+      const service = await buildService({ GOOGLE_PUBSUB_AUDIENCE: AUDIENCE });
+      mockVerifyIdToken.mockResolvedValue(
+        ticketWith({
+          email: 'anything@x.gserviceaccount.com',
+          email_verified: true,
+        }),
+      );
+
+      await expect(
+        service.verifyPushRequest('Bearer ok'),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/payment/google-pubsub-verifier.service.ts
+++ b/src/payment/google-pubsub-verifier.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OAuth2Client, TokenPayload } from 'google-auth-library';
+
+/**
+ * Verifies the OIDC identity token that a correctly-configured Google Cloud
+ * Pub/Sub *push* subscription attaches to every delivery in the
+ * `Authorization: Bearer <jwt>` header.
+ *
+ * The `/payment/webhooks/google` endpoint is otherwise public, so without this
+ * check any caller could POST a forged RTDN envelope. Verifying the OIDC token
+ * proves the request actually came from Google's Pub/Sub service acting as the
+ * configured push service account.
+ *
+ * Posture:
+ *  - When `GOOGLE_PUBSUB_AUDIENCE` is set, verification is ENFORCED: an
+ *    invalid/missing token is rejected (401).
+ *  - When it is NOT set, verification is skipped and a warning is logged so
+ *    dev/unconfigured setups keep working while production is nudged to
+ *    configure it.
+ *
+ * Required Pub/Sub push-subscription settings (Google Cloud console / gcloud):
+ *  - Enable "Enable authentication" on the push subscription.
+ *  - Service account: the account in `GOOGLE_PUBSUB_SA_EMAIL`.
+ *  - Audience: the exact string in `GOOGLE_PUBSUB_AUDIENCE` (commonly the
+ *    endpoint URL, e.g. https://api.example.com/payment/webhooks/google).
+ */
+@Injectable()
+export class GooglePubSubVerifierService {
+  private readonly logger = new Logger(GooglePubSubVerifierService.name);
+  private readonly audience: string;
+  private readonly saEmail: string;
+  private readonly oauthClient: OAuth2Client;
+  private warnedUnconfigured = false;
+
+  constructor(private readonly configService: ConfigService) {
+    this.audience = (
+      this.configService.get<string>('GOOGLE_PUBSUB_AUDIENCE') || ''
+    ).trim();
+    this.saEmail = (
+      this.configService.get<string>('GOOGLE_PUBSUB_SA_EMAIL') || ''
+    ).trim();
+    // OAuth2Client.verifyIdToken fetches and caches Google's public signing
+    // certs (JWKS) and validates the signature, `iss`, `aud` and `exp`.
+    this.oauthClient = new OAuth2Client();
+  }
+
+  /**
+   * Verify the Pub/Sub push OIDC token. Resolves when the request is
+   * authenticated (or verification is intentionally disabled); throws
+   * `UnauthorizedException` when a configured endpoint receives an
+   * invalid/missing/unauthorized token.
+   */
+  async verifyPushRequest(authorizationHeader?: string): Promise<void> {
+    if (!this.audience) {
+      if (!this.warnedUnconfigured) {
+        this.logger.warn(
+          'GOOGLE_PUBSUB_AUDIENCE is not set - skipping Pub/Sub OIDC ' +
+            'verification. PRODUCTION MUST set GOOGLE_PUBSUB_AUDIENCE and ' +
+            'GOOGLE_PUBSUB_SA_EMAIL so /payment/webhooks/google rejects ' +
+            'unauthenticated callers.',
+        );
+        this.warnedUnconfigured = true;
+      }
+      return;
+    }
+
+    const token = this.extractBearer(authorizationHeader);
+    if (!token) {
+      throw new UnauthorizedException(
+        'Missing Pub/Sub OIDC bearer token on webhook request',
+      );
+    }
+
+    let payload: TokenPayload | undefined;
+    try {
+      // Validates signature against Google's JWKS, `iss` (accounts.google.com),
+      // `aud` (this.audience) and `exp`. Throws on any failure.
+      const ticket = await this.oauthClient.verifyIdToken({
+        idToken: token,
+        audience: this.audience,
+      });
+      payload = ticket.getPayload();
+    } catch (error) {
+      this.logger.warn(
+        `Pub/Sub OIDC token verification failed: ${this.errorMessage(error)}`,
+      );
+      throw new UnauthorizedException('Invalid Pub/Sub OIDC token');
+    }
+
+    if (!payload) {
+      throw new UnauthorizedException('Pub/Sub OIDC token has no payload');
+    }
+
+    if (payload.email_verified !== true) {
+      throw new UnauthorizedException(
+        'Pub/Sub OIDC token email is not verified',
+      );
+    }
+
+    if (this.saEmail) {
+      if (payload.email !== this.saEmail) {
+        this.logger.warn(
+          'Pub/Sub OIDC token email does not match configured SA',
+        );
+        throw new UnauthorizedException(
+          'Pub/Sub OIDC token is not from the authorized service account',
+        );
+      }
+    } else {
+      this.logger.warn(
+        'GOOGLE_PUBSUB_SA_EMAIL is not set - accepting any Google-verified ' +
+          'service account for the configured audience. Set it to restrict to ' +
+          'your push service account.',
+      );
+    }
+  }
+
+  private extractBearer(header?: string): string | null {
+    if (!header) return null;
+    const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+    return match ? match[1].trim() : null;
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/src/payment/google-pubsub-verifier.service.ts
+++ b/src/payment/google-pubsub-verifier.service.ts
@@ -118,8 +118,15 @@ export class GooglePubSubVerifierService {
 
   private extractBearer(header?: string): string | null {
     if (!header) return null;
-    const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-    return match ? match[1].trim() : null;
+    // Parse the "Bearer <token>" scheme WITHOUT a backtracking-prone regex.
+    // The previous /^Bearer\s+(.+)$/ let `\s+` and `.+` both match whitespace,
+    // a polynomial-ReDoS on the attacker-controlled Authorization header.
+    const trimmed = header.trim();
+    const firstSpace = trimmed.search(/\s/); // single class, no quantifier — linear
+    if (firstSpace === -1) return null;
+    if (trimmed.slice(0, firstSpace).toLowerCase() !== 'bearer') return null;
+    const token = trimmed.slice(firstSpace + 1).trim();
+    return token || null;
   }
 
   private errorMessage(error: unknown): string {

--- a/src/payment/google-verification.service.ts
+++ b/src/payment/google-verification.service.ts
@@ -15,6 +15,13 @@ export interface GoogleVerificationResult {
   purchaseTime?: Date | null;
   expirationTime?: Date | null;
   isSubscription?: boolean;
+  /**
+   * The purchase token of the prior subscription this purchase supersedes.
+   * Google Play issues a new token on upgrade/downgrade/re-subscribe and links
+   * it back to the previous token via this field. Used to migrate the stored
+   * Subscription.purchaseToken forward. `null`/`undefined` when there is no link.
+   */
+  linkedPurchaseToken?: string | null;
   raw?: unknown;
   metadata?: Record<string, unknown>;
 }
@@ -55,6 +62,7 @@ interface GoogleSubscriptionPurchase {
   acknowledgementState?: number;
   paymentState?: number;
   cancelReason?: number;
+  linkedPurchaseToken?: string | null;
 }
 
 /** Google one-time product purchase data */
@@ -72,6 +80,7 @@ interface GooglePythonSuccessResponse {
   success: true;
   isSubscription: boolean;
   data: GoogleSubscriptionPurchase | GoogleProductPurchase;
+  linkedPurchaseToken?: string | null;
 }
 
 interface GooglePythonErrorResponse {
@@ -194,6 +203,8 @@ export class GoogleVerificationService {
           purchaseTime: this.toDate(subData.startTimeMillis),
           expirationTime: this.toDate(subData.expiryTimeMillis),
           isSubscription: true,
+          linkedPurchaseToken:
+            result.linkedPurchaseToken ?? subData.linkedPurchaseToken ?? null,
           raw: data,
           metadata: {
             acknowledgementState: subData.acknowledgementState,
@@ -217,6 +228,7 @@ export class GoogleVerificationService {
           purchaseTime: this.toDate(productData.purchaseTimeMillis),
           expirationTime: null,
           isSubscription: false,
+          linkedPurchaseToken: null,
           raw: data,
           metadata: {
             consumptionState: productData.consumptionState,

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -8,6 +8,7 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
 import { SubscriptionWebhookService } from './subscription-webhook.service';
+import { GooglePubSubVerifierService } from './google-pubsub-verifier.service';
 
 @Module({
   imports: [PrismaModule, ConfigModule, forwardRef(() => AuthModule)],
@@ -16,6 +17,7 @@ import { SubscriptionWebhookService } from './subscription-webhook.service';
     GoogleVerificationService,
     AppleVerificationService,
     SubscriptionWebhookService,
+    GooglePubSubVerifierService,
   ],
   controllers: [PaymentController, WebhookController],
   exports: [

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -2,10 +2,12 @@ import { Module, forwardRef } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PaymentService } from './payment.service';
 import { PaymentController } from './payment.controller';
+import { WebhookController } from './webhook.controller';
 import { AuthModule } from '../auth/auth.module';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
+import { SubscriptionWebhookService } from './subscription-webhook.service';
 
 @Module({
   imports: [PrismaModule, ConfigModule, forwardRef(() => AuthModule)],
@@ -13,12 +15,14 @@ import { AppleVerificationService } from './apple-verification.service';
     PaymentService,
     GoogleVerificationService,
     AppleVerificationService,
+    SubscriptionWebhookService,
   ],
-  controllers: [PaymentController],
+  controllers: [PaymentController, WebhookController],
   exports: [
     PaymentService,
     GoogleVerificationService,
     AppleVerificationService,
+    SubscriptionWebhookService,
   ],
 })
 export class PaymentModule {}

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -139,6 +139,69 @@ describe('PaymentService', () => {
       expect(result.subscription?.plan).toBe('monthly');
     });
 
+    it('migrates the stored purchaseToken forward on a Google upgrade (linkedPurchaseToken)', async () => {
+      const userId = 'user-1';
+      const dto = {
+        platform: 'google' as const,
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'new-google-token',
+      };
+      const now = new Date();
+
+      // The verified purchase links back to the user's currently-stored token.
+      mockGoogleVerification.verify.mockResolvedValue({
+        success: true,
+        isSubscription: true,
+        platformTxId: 'GPA.5678',
+        amount: 4.99,
+        currency: 'USD',
+        expirationTime: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        linkedPurchaseToken: 'old-google-token',
+        metadata: { acknowledgementState: 1 },
+      });
+
+      // The single per-user row still holds the OLD token.
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: 'sub-1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        startedAt: now,
+        endsAt: now,
+        platform: 'google',
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'old-google-token',
+      });
+      mockPrisma.paymentTransaction.create.mockResolvedValue({
+        id: 'tx-2',
+        userId,
+        amount: 4.99,
+        currency: 'USD',
+        status: 'success',
+        reference: 'hash-new',
+      });
+      mockPrisma.subscription.update.mockResolvedValue({
+        id: 'sub-1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        startedAt: now,
+        endsAt: now,
+        purchaseToken: 'new-google-token',
+      });
+
+      const result = await service.verifyPurchase(userId, dto);
+
+      expect(result.success).toBe(true);
+      // Explicit migration update targets the same row with the new token.
+      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: { purchaseToken: 'new-google-token' },
+      });
+      // Never creates a second subscription row.
+      expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
+    });
+
     it('should verify Apple purchase and create subscription', async () => {
       const userId = 'user-1';
       const dto = {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -113,6 +113,16 @@ export class PaymentService {
       throw new BadRequestException('Google Play purchase verification failed');
     }
 
+    // Google issues a NEW purchase token on upgrade/downgrade/re-subscribe and
+    // links it to the prior token via `linkedPurchaseToken`. If the user's
+    // stored token is that linked (old) token, migrate it forward to the new
+    // token so webhook events for the new token still resolve to this user.
+    await this.migrateGoogleLinkedToken(
+      userId,
+      dto.purchaseToken,
+      result.linkedPurchaseToken ?? null,
+    );
+
     // Acknowledge the purchase to prevent auto-refund after 3 days
     const acknowledgementState = result.metadata?.acknowledgementState;
     if (acknowledgementState !== 1) {
@@ -190,6 +200,43 @@ export class PaymentService {
     }
 
     return this.upsertSubscription(userId, plan, tx, googleDetails);
+  }
+
+  /**
+   * Migrate a user's stored Google purchase token forward to a new token when
+   * the verified purchase links back to it via `linkedPurchaseToken`.
+   *
+   * No-op unless the user already has a Subscription whose stored token is the
+   * linked (old) token and differs from the incoming new token. The subsequent
+   * subscription upsert also writes the new token, so this is idempotent — it
+   * exists so the migration is explicit and happens even if the stored token is
+   * the linked one on a distinct Subscription row.
+   */
+  private async migrateGoogleLinkedToken(
+    userId: string,
+    newToken: string,
+    linkedToken: string | null,
+  ): Promise<void> {
+    if (!linkedToken || linkedToken === newToken) return;
+
+    const existing = await this.prisma.subscription.findFirst({
+      where: { userId },
+    });
+    if (
+      !existing ||
+      existing.purchaseToken === newToken ||
+      existing.purchaseToken !== linkedToken
+    ) {
+      return;
+    }
+
+    await this.prisma.subscription.update({
+      where: { id: existing.id },
+      data: { purchaseToken: newToken },
+    });
+    this.logger.log(
+      `Migrated Google purchaseToken (linked) for user ${userId.substring(0, 8)}`,
+    );
   }
 
   private async verifyApplePurchase(userId: string, dto: VerifyPurchaseDto) {

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 import { SubscriptionWebhookService } from './subscription-webhook.service';
 import {
@@ -14,6 +15,7 @@ type MockPrisma = {
     findUnique: jest.Mock;
     create: jest.Mock;
     update: jest.Mock;
+    updateMany: jest.Mock;
   };
   subscription: { findFirst: jest.Mock; update: jest.Mock };
 };
@@ -56,6 +58,12 @@ const googleBody = (payload: Record<string, unknown>, messageId = 'msg-1') => ({
   subscription: 'projects/x/subscriptions/y',
 });
 
+/** Build a Pub/Sub body from a raw (already base64-encoded) data string. */
+const googleBody0 = (data: string, messageId = 'msg-0') => ({
+  message: { data, messageId },
+  subscription: 'projects/x/subscriptions/y',
+});
+
 describe('SubscriptionWebhookService', () => {
   let service: SubscriptionWebhookService;
   let prisma: MockPrisma;
@@ -70,6 +78,7 @@ describe('SubscriptionWebhookService', () => {
           .fn()
           .mockResolvedValue({ id: 'evt-1', status: 'received' }),
         update: jest.fn().mockResolvedValue({ id: 'evt-1' }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
       subscription: {
         findFirst: jest.fn().mockResolvedValue({ ...SUB }),
@@ -358,6 +367,130 @@ describe('SubscriptionWebhookService', () => {
           message: { data: 'x', messageId: '' },
         } as never),
       ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a non-object RTDN payload (base64 "null") with 400', async () => {
+      const body = googleBody0(
+        Buffer.from('null').toString('base64'),
+        'msg-null',
+      );
+      await expect(service.handleGoogle(body)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      // Malformed input must never reach subscription mutation.
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-object RTDN payload (base64 array) with 400', async () => {
+      const body = googleBody0(
+        Buffer.from('[1,2,3]').toString('base64'),
+        'msg-arr',
+      );
+      await expect(service.handleGoogle(body)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ----------------------------------------------------- idempotency race ----
+  describe('idempotency / concurrent duplicate deliveries', () => {
+    const renewInfo = () =>
+      appleInfo({ notificationType: 'DID_RENEW', notificationUUID: 'race-1' });
+
+    const p2002 = () =>
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'test',
+      });
+
+    it('does not reprocess when a concurrent delivery already owns the row (P2002 -> received)', async () => {
+      apple.parseSignedNotification.mockReturnValue(renewInfo());
+      // Fast-path findUnique: no row yet. Then create loses the race (P2002),
+      // and the re-read shows a concurrent delivery is already processing it.
+      prisma.webhookEvent.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 'evt-race', status: 'received' });
+      prisma.webhookEvent.create.mockRejectedValueOnce(p2002());
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.duplicate).toBe(true);
+      // The losing delivery must NOT run the handler / mutate the subscription.
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('does not reprocess an in-flight (received) event', async () => {
+      apple.parseSignedNotification.mockReturnValue(renewInfo());
+      prisma.webhookEvent.findUnique.mockResolvedValue({
+        id: 'evt-inflight',
+        status: 'received',
+      });
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.duplicate).toBe(true);
+      expect(prisma.webhookEvent.create).not.toHaveBeenCalled();
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('processes exactly once: only the delivery that wins the create claim runs the handler', async () => {
+      apple.parseSignedNotification.mockReturnValue(renewInfo());
+
+      // Delivery A: no row -> create succeeds -> claims -> processes.
+      prisma.webhookEvent.findUnique.mockResolvedValueOnce(null);
+      prisma.webhookEvent.create.mockResolvedValueOnce({
+        id: 'evt-A',
+        status: 'received',
+      });
+      const resA = await service.handleApple({ signedPayload: 'jws' });
+
+      // Delivery B (concurrent duplicate): create loses (P2002), re-read shows
+      // the row is now processed -> idempotent replay, no reprocessing.
+      prisma.webhookEvent.findUnique.mockResolvedValueOnce({
+        id: 'evt-A',
+        status: 'processed',
+      });
+      const resB = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(resA.duplicate).toBe(false);
+      expect(resA.status).toBe('processed');
+      expect(resB.duplicate).toBe(true);
+      // Subscription mutated exactly once across both deliveries.
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a previously failed event by atomically re-claiming the row', async () => {
+      apple.parseSignedNotification.mockReturnValue(renewInfo());
+      prisma.webhookEvent.findUnique.mockResolvedValue({
+        id: 'evt-failed',
+        status: 'failed',
+      });
+      prisma.webhookEvent.updateMany.mockResolvedValue({ count: 1 });
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(prisma.webhookEvent.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'evt-failed', status: 'failed' },
+        }),
+      );
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reprocess a failed event if another delivery already re-claimed it', async () => {
+      apple.parseSignedNotification.mockReturnValue(renewInfo());
+      prisma.webhookEvent.findUnique.mockResolvedValue({
+        id: 'evt-failed',
+        status: 'failed',
+      });
+      // The status-guarded claim matched 0 rows -> someone else won.
+      prisma.webhookEvent.updateMany.mockResolvedValue({ count: 0 });
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.duplicate).toBe(true);
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
     // ----------------------------------------------- linkedPurchaseToken ----

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -1,0 +1,363 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { PrismaService } from '@/prisma/prisma.service';
+import { SubscriptionWebhookService } from './subscription-webhook.service';
+import {
+  AppleNotificationInfo,
+  AppleVerificationService,
+} from './apple-verification.service';
+import { GoogleVerificationService } from './google-verification.service';
+
+type MockPrisma = {
+  webhookEvent: {
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+  subscription: { findFirst: jest.Mock; update: jest.Mock };
+};
+
+const SUB = {
+  id: 'sub-1',
+  userId: 'user-1',
+  plan: 'monthly',
+  status: 'active',
+  startedAt: new Date('2026-01-01'),
+  endsAt: new Date('2026-02-01'),
+  platform: 'apple',
+  productId: 'com.storytime.monthly',
+  purchaseToken: 'orig-tx-123',
+  isDeleted: false,
+  deletedAt: null,
+};
+
+const appleInfo = (
+  overrides: Partial<AppleNotificationInfo> &
+    Pick<AppleNotificationInfo, 'notificationType' | 'notificationUUID'>,
+): AppleNotificationInfo => ({
+  bundleId: 'com.storytime.app',
+  environment: 'Production',
+  transactionInfo: {
+    originalTransactionId: 'orig-tx-123',
+    productId: 'com.storytime.monthly',
+    expiresDate: new Date('2026-03-01').getTime(),
+  },
+  renewalInfo: { originalTransactionId: 'orig-tx-123', autoRenewStatus: 1 },
+  raw: {},
+  ...overrides,
+});
+
+const googleBody = (payload: Record<string, unknown>, messageId = 'msg-1') => ({
+  message: {
+    data: Buffer.from(JSON.stringify(payload)).toString('base64'),
+    messageId,
+  },
+  subscription: 'projects/x/subscriptions/y',
+});
+
+describe('SubscriptionWebhookService', () => {
+  let service: SubscriptionWebhookService;
+  let prisma: MockPrisma;
+  let apple: { parseSignedNotification: jest.Mock };
+  let google: { verify: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      webhookEvent: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest
+          .fn()
+          .mockResolvedValue({ id: 'evt-1', status: 'received' }),
+        update: jest.fn().mockResolvedValue({ id: 'evt-1' }),
+      },
+      subscription: {
+        findFirst: jest.fn().mockResolvedValue({ ...SUB }),
+        update: jest.fn().mockResolvedValue({ ...SUB }),
+      },
+    };
+    apple = { parseSignedNotification: jest.fn() };
+    google = { verify: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubscriptionWebhookService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AppleVerificationService, useValue: apple },
+        { provide: GoogleVerificationService, useValue: google },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(SubscriptionWebhookService);
+  });
+
+  // ---------------------------------------------------------------- Apple ----
+  describe('Apple', () => {
+    it('activates the subscription on DID_RENEW and records processed', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'DID_RENEW', notificationUUID: 'a-1' }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res).toEqual({
+        duplicate: false,
+        status: 'processed',
+        action: 'apple:DID_RENEW -> activate',
+      });
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: { status: 'active', endsAt: new Date('2026-03-01') },
+      });
+      expect(prisma.webhookEvent.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: { id: 'evt-1' },
+          data: expect.objectContaining({ status: 'processed' }),
+        }),
+      );
+    });
+
+    it('marks will-not-renew when auto-renew is disabled, keeping endsAt', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'DID_CHANGE_RENEWAL_STATUS',
+          subtype: 'AUTO_RENEW_DISABLED',
+          notificationUUID: 'a-2',
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: { status: 'cancelled' },
+      });
+    });
+
+    it('deactivates on EXPIRED (endsAt set to now)', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'EXPIRED', notificationUUID: 'a-3' }),
+      );
+
+      await service.handleApple({ signedPayload: 'jws' });
+
+      const call = prisma.subscription.update.mock.calls[0][0];
+      expect(call.data.status).toBe('cancelled');
+      expect(call.data.endsAt).toBeInstanceOf(Date);
+    });
+
+    it('revokes access on REFUND', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'REFUND', notificationUUID: 'a-4' }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+      expect(res.action).toBe('apple:REFUND -> revoke');
+      expect(prisma.subscription.update).toHaveBeenCalled();
+    });
+
+    it('skips unknown/no-op notification types without touching the subscription', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'DID_CHANGE_RENEWAL_PREF',
+          notificationUUID: 'a-5',
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+      expect(res.status).toBe('skipped');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('skips when no matching subscription exists', async () => {
+      prisma.subscription.findFirst.mockResolvedValue(null);
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'DID_RENEW', notificationUUID: 'a-6' }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+      expect(res.status).toBe('skipped');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('propagates signature-verification failures (never records an event)', async () => {
+      apple.parseSignedNotification.mockImplementation(() => {
+        throw new BadRequestException('JWS signature verification failed');
+      });
+
+      await expect(
+        service.handleApple({ signedPayload: 'bad' }),
+      ).rejects.toThrow('JWS signature verification failed');
+      expect(prisma.webhookEvent.create).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: an already-processed event is not reprocessed', async () => {
+      prisma.webhookEvent.findUnique.mockResolvedValue({
+        id: 'evt-existing',
+        status: 'processed',
+      });
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'DID_RENEW', notificationUUID: 'a-1' }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+      expect(res).toEqual({
+        duplicate: true,
+        status: 'processed',
+        action: 'duplicate',
+      });
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+      expect(prisma.webhookEvent.create).not.toHaveBeenCalled();
+    });
+
+    it('records failed and rethrows when processing throws (bookkeeping does not mask the error)', async () => {
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({ notificationType: 'DID_RENEW', notificationUUID: 'a-7' }),
+      );
+      prisma.subscription.update.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.handleApple({ signedPayload: 'jws' }),
+      ).rejects.toThrow('db down');
+      expect(prisma.webhookEvent.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'failed' }),
+        }),
+      );
+    });
+  });
+
+  // --------------------------------------------------------------- Google ----
+  describe('Google', () => {
+    beforeEach(() => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        platform: 'google',
+        purchaseToken: 'g-token-1',
+      });
+      google.verify.mockResolvedValue({
+        success: true,
+        expirationTime: new Date('2026-04-01'),
+      });
+    });
+
+    it('activates on SUBSCRIPTION_RENEWED and enriches expiry from Play API', async () => {
+      const body = googleBody({
+        packageName: 'com.storytime.app',
+        subscriptionNotification: {
+          notificationType: 2,
+          purchaseToken: 'g-token-1',
+          subscriptionId: 'com.storytime.monthly',
+        },
+      });
+
+      const res = await service.handleGoogle(body);
+
+      expect(google.verify).toHaveBeenCalled();
+      expect(res.action).toBe('google:SUBSCRIPTION_2 -> activate');
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: { status: 'active', endsAt: new Date('2026-04-01') },
+      });
+    });
+
+    it('marks will-not-renew on SUBSCRIPTION_CANCELED', async () => {
+      const body = googleBody(
+        {
+          subscriptionNotification: {
+            notificationType: 3,
+            purchaseToken: 'g-token-1',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'msg-cancel',
+      );
+
+      const res = await service.handleGoogle(body);
+      expect(res.action).toBe('google:SUBSCRIPTION_3 -> will_not_renew');
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: { status: 'cancelled' },
+      });
+      expect(google.verify).not.toHaveBeenCalled();
+    });
+
+    it('deactivates on SUBSCRIPTION_EXPIRED', async () => {
+      const body = googleBody(
+        {
+          subscriptionNotification: {
+            notificationType: 13,
+            purchaseToken: 'g-token-1',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'msg-exp',
+      );
+
+      const res = await service.handleGoogle(body);
+      expect(res.action).toBe('google:SUBSCRIPTION_13 -> deactivate');
+      const call = prisma.subscription.update.mock.calls[0][0];
+      expect(call.data.status).toBe('cancelled');
+      expect(call.data.endsAt).toBeInstanceOf(Date);
+    });
+
+    it('revokes on a voided purchase notification', async () => {
+      const body = googleBody(
+        {
+          voidedPurchaseNotification: {
+            purchaseToken: 'g-token-1',
+            orderId: 'GPA.1',
+          },
+        },
+        'msg-void',
+      );
+
+      const res = await service.handleGoogle(body);
+      expect(res.action).toBe('google:voided -> revoke');
+      expect(prisma.subscription.update).toHaveBeenCalled();
+    });
+
+    it('skips no-op subscription types (e.g. DEFERRED)', async () => {
+      const body = googleBody(
+        {
+          subscriptionNotification: {
+            notificationType: 9,
+            purchaseToken: 'g-token-1',
+          },
+        },
+        'msg-def',
+      );
+
+      const res = await service.handleGoogle(body);
+      expect(res.status).toBe('skipped');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent for duplicate Pub/Sub messageId', async () => {
+      prisma.webhookEvent.findUnique.mockResolvedValue({
+        id: 'e',
+        status: 'processed',
+      });
+      const body = googleBody({
+        subscriptionNotification: {
+          notificationType: 2,
+          purchaseToken: 'g-token-1',
+        },
+      });
+
+      const res = await service.handleGoogle(body);
+      expect(res.duplicate).toBe(true);
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed Pub/Sub envelope (missing messageId) with 400', async () => {
+      await expect(
+        service.handleGoogle({
+          message: { data: 'x', messageId: '' },
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -359,5 +359,192 @@ describe('SubscriptionWebhookService', () => {
         } as never),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
+
+    // ----------------------------------------------- linkedPurchaseToken ----
+    describe('linkedPurchaseToken chain', () => {
+      it('migrates the token forward when a new token links to an existing subscription', async () => {
+        // The event carries a brand-new token ('new-token') that is not stored.
+        // Its linkedPurchaseToken points at 'g-token-1', which we do store.
+        prisma.subscription.findFirst.mockImplementation(
+          ({ where }: { where: { purchaseToken?: string } }) =>
+            where.purchaseToken === 'g-token-1'
+              ? Promise.resolve({
+                  ...SUB,
+                  platform: 'google',
+                  purchaseToken: 'g-token-1',
+                })
+              : Promise.resolve(null),
+        );
+        // First verify() call (chain resolution) returns the link; a later
+        // verify() (expiry enrichment) returns the expiry.
+        google.verify
+          .mockResolvedValueOnce({
+            success: true,
+            linkedPurchaseToken: 'g-token-1',
+          })
+          .mockResolvedValue({
+            success: true,
+            expirationTime: new Date('2026-04-01'),
+          });
+
+        const body = googleBody(
+          {
+            packageName: 'com.storytime.app',
+            subscriptionNotification: {
+              notificationType: 4, // PURCHASED (re-subscribe/upgrade)
+              purchaseToken: 'new-token',
+              subscriptionId: 'com.storytime.monthly',
+            },
+          },
+          'msg-link-1',
+        );
+
+        const res = await service.handleGoogle(body);
+
+        expect(res.status).toBe('processed');
+        expect(res.action).toBe('google:SUBSCRIPTION_4 -> activate');
+        // Row's purchaseToken migrated from the old token to the new one.
+        expect(prisma.subscription.update).toHaveBeenCalledWith({
+          where: { id: 'sub-1' },
+          data: { purchaseToken: 'new-token' },
+        });
+      });
+
+      it('follows a multi-hop chain (C -> B -> A, only A known) and caps depth', async () => {
+        // Only 'token-A' is stored. Event token 'token-C' links to 'token-B'
+        // which links to 'token-A'.
+        prisma.subscription.findFirst.mockImplementation(
+          ({ where }: { where: { purchaseToken?: string } }) =>
+            where.purchaseToken === 'token-A'
+              ? Promise.resolve({
+                  ...SUB,
+                  platform: 'google',
+                  purchaseToken: 'token-A',
+                })
+              : Promise.resolve(null),
+        );
+        google.verify.mockImplementation(
+          ({ purchaseToken }: { purchaseToken: string }) => {
+            if (purchaseToken === 'token-C')
+              return Promise.resolve({
+                success: true,
+                linkedPurchaseToken: 'token-B',
+              });
+            if (purchaseToken === 'token-B')
+              return Promise.resolve({
+                success: true,
+                linkedPurchaseToken: 'token-A',
+              });
+            // Enrichment call on the resolved (event) token.
+            return Promise.resolve({
+              success: true,
+              expirationTime: new Date('2026-05-01'),
+            });
+          },
+        );
+
+        const body = googleBody(
+          {
+            packageName: 'com.storytime.app',
+            subscriptionNotification: {
+              notificationType: 2,
+              purchaseToken: 'token-C',
+              subscriptionId: 'com.storytime.monthly',
+            },
+          },
+          'msg-link-multi',
+        );
+
+        const res = await service.handleGoogle(body);
+
+        expect(res.status).toBe('processed');
+        expect(prisma.subscription.update).toHaveBeenCalledWith({
+          where: { id: 'sub-1' },
+          data: { purchaseToken: 'token-C' },
+        });
+      });
+
+      it('skips (no crash, no false attribution) when the chain is unknown', async () => {
+        prisma.subscription.findFirst.mockResolvedValue(null);
+        google.verify.mockResolvedValue({
+          success: true,
+          linkedPurchaseToken: 'unknown-old-token',
+        });
+
+        const body = googleBody(
+          {
+            packageName: 'com.storytime.app',
+            subscriptionNotification: {
+              notificationType: 2,
+              purchaseToken: 'orphan-token',
+              subscriptionId: 'com.storytime.monthly',
+            },
+          },
+          'msg-link-unknown',
+        );
+
+        const res = await service.handleGoogle(body);
+
+        expect(res.status).toBe('skipped');
+        expect(res.action).toBe(
+          'google:SUBSCRIPTION_2 no matching subscription',
+        );
+        expect(prisma.subscription.update).not.toHaveBeenCalled();
+      });
+
+      it('does not infinite-loop on a cyclic chain', async () => {
+        prisma.subscription.findFirst.mockResolvedValue(null);
+        // token-X links to token-Y which links back to token-X (cycle).
+        google.verify.mockImplementation(
+          ({ purchaseToken }: { purchaseToken: string }) =>
+            Promise.resolve({
+              success: true,
+              linkedPurchaseToken:
+                purchaseToken === 'token-X' ? 'token-Y' : 'token-X',
+            }),
+        );
+
+        const body = googleBody(
+          {
+            packageName: 'com.storytime.app',
+            subscriptionNotification: {
+              notificationType: 2,
+              purchaseToken: 'token-X',
+              subscriptionId: 'com.storytime.monthly',
+            },
+          },
+          'msg-link-cycle',
+        );
+
+        const res = await service.handleGoogle(body);
+
+        expect(res.status).toBe('skipped');
+        expect(prisma.subscription.update).not.toHaveBeenCalled();
+        // Guard stopped the walk well within the hop cap (no runaway calls).
+        expect(google.verify.mock.calls.length).toBeLessThanOrEqual(5);
+      });
+
+      it('skips without following the chain when subscriptionId is absent', async () => {
+        prisma.subscription.findFirst.mockResolvedValue(null);
+
+        const body = googleBody(
+          {
+            packageName: 'com.storytime.app',
+            subscriptionNotification: {
+              notificationType: 2,
+              purchaseToken: 'no-product-token',
+              // subscriptionId omitted -> cannot query the Play API.
+            },
+          },
+          'msg-link-noproduct',
+        );
+
+        const res = await service.handleGoogle(body);
+
+        expect(res.status).toBe('skipped');
+        expect(google.verify).not.toHaveBeenCalled();
+        expect(prisma.subscription.update).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -30,6 +30,7 @@ const SUB = {
   platform: 'apple',
   productId: 'com.storytime.monthly',
   purchaseToken: 'orig-tx-123',
+  lastEventAt: null as Date | null,
   isDeleted: false,
   deletedAt: null,
 };
@@ -678,6 +679,162 @@ describe('SubscriptionWebhookService', () => {
         expect(google.verify).not.toHaveBeenCalled();
         expect(prisma.subscription.update).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  // --------------------------------------- out-of-order delivery watermark ----
+  describe('out-of-order delivery protection (event watermark)', () => {
+    const OLD = new Date('2026-05-01T00:00:00Z');
+    const NEW = new Date('2026-06-01T00:00:00Z');
+
+    // ------------------------------------------------------------- Apple ----
+    it('applies a newer Apple event and advances lastEventAt atomically', async () => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        lastEventAt: OLD,
+      });
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-new',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: {
+          status: 'active',
+          endsAt: new Date('2026-03-01'),
+          lastEventAt: NEW,
+        },
+      });
+    });
+
+    it('skips a stale Apple event (older than lastEventAt) without regressing state', async () => {
+      // Already applied a DID_RENEW at NEW; a delayed EXPIRED at OLD arrives.
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        lastEventAt: NEW,
+      });
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'EXPIRED',
+          notificationUUID: 'wm-a-stale',
+          signedDate: OLD.getTime(),
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.status).toBe('skipped');
+      expect(res.action).toContain('stale/out-of-order');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('skips a duplicate Apple event arriving at the exact same timestamp', async () => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        lastEventAt: NEW,
+      });
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-dup',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.status).toBe('skipped');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+
+    it('applies an Apple event and sets lastEventAt when no prior watermark exists', async () => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        lastEventAt: null,
+      });
+      apple.parseSignedNotification.mockReturnValue(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-first',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const res = await service.handleApple({ signedPayload: 'jws' });
+
+      expect(res.status).toBe('processed');
+      const call = prisma.subscription.update.mock.calls[0][0];
+      expect(call.data.lastEventAt).toEqual(NEW);
+    });
+
+    // ------------------------------------------------------------ Google ----
+    it('applies a newer Google event and advances lastEventAt', async () => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        platform: 'google',
+        purchaseToken: 'g-token-1',
+        lastEventAt: OLD,
+      });
+      google.verify.mockResolvedValue({
+        success: true,
+        expirationTime: new Date('2026-07-01'),
+      });
+      const body = googleBody(
+        {
+          eventTimeMillis: String(NEW.getTime()),
+          subscriptionNotification: {
+            notificationType: 2,
+            purchaseToken: 'g-token-1',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'wm-g-new',
+      );
+
+      const res = await service.handleGoogle(body);
+
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: 'sub-1' },
+        data: {
+          status: 'active',
+          endsAt: new Date('2026-07-01'),
+          lastEventAt: NEW,
+        },
+      });
+    });
+
+    it('skips a stale Google EXPIRED that would clobber a newer RENEWED', async () => {
+      prisma.subscription.findFirst.mockResolvedValue({
+        ...SUB,
+        platform: 'google',
+        purchaseToken: 'g-token-1',
+        lastEventAt: NEW,
+      });
+      const body = googleBody(
+        {
+          eventTimeMillis: String(OLD.getTime()),
+          subscriptionNotification: {
+            notificationType: 13, // EXPIRED
+            purchaseToken: 'g-token-1',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'wm-g-stale',
+      );
+
+      const res = await service.handleGoogle(body);
+
+      expect(res.status).toBe('skipped');
+      expect(res.action).toContain('stale/out-of-order');
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -232,11 +232,21 @@ export class SubscriptionWebhookService {
 
   private decodeGooglePayload(data: string): GoogleRtdnPayload {
     const json = Buffer.from(data, 'base64').toString('utf8');
+    let parsed: unknown;
     try {
-      return JSON.parse(json) as GoogleRtdnPayload;
+      parsed = JSON.parse(json);
     } catch {
       throw new BadRequestException('Invalid JSON in Pub/Sub message data');
     }
+    // `JSON.parse('null')` (and other non-object JSON) parses successfully;
+    // reject it here so googleEventType() never dereferences a non-object and
+    // turns malformed input into an unhandled 500 instead of a 400.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new BadRequestException(
+        'Pub/Sub message data must be a JSON object',
+      );
+    }
+    return parsed as GoogleRtdnPayload;
   }
 
   private googleEventType(payload: GoogleRtdnPayload): string {
@@ -377,11 +387,21 @@ export class SubscriptionWebhookService {
 
   /**
    * Records the notification in `webhook_events` (keyed by platform +
-   * externalEventId) and runs `handler` exactly once. Duplicate deliveries of
-   * an already-processed/skipped event short-circuit and return 200.
+   * externalEventId) and runs `handler` exactly once, even under concurrent
+   * duplicate deliveries.
    *
-   * The WebhookEvent bookkeeping is wrapped in its own try/catch so a failure
-   * writing the audit row never masks the original processing error.
+   * Idempotency is enforced by atomically CLAIMING the event row before running
+   * the handler:
+   *  - a terminal row (processed/skipped) -> idempotent replay, return 200;
+   *  - a row currently `received` (another delivery in-flight) -> return 200
+   *    without reprocessing;
+   *  - only a delivery that actually creates the row, or that atomically flips a
+   *    prior `failed` row back to `received`, owns the claim and runs `handler`.
+   *
+   * The claim uses the `(platform, externalEventId)` unique constraint (via
+   * `create`) and a status-guarded `updateMany`, so two concurrent duplicate
+   * deliveries can never both process. Success is only acknowledged after the
+   * terminal status is durably committed.
    */
   private async processWithIdempotency(
     platform: 'apple' | 'google',
@@ -408,26 +428,51 @@ export class SubscriptionWebhookService {
       };
     }
 
-    // Create (or reset) the audit row in "received" state.
-    const event = await this.upsertReceived(
-      existing?.id ?? null,
+    if (existing && existing.status === 'received') {
+      // Another delivery of this exact event is already being processed. Do not
+      // reprocess; ack 200 so the store stops retrying while the in-flight
+      // delivery completes.
+      this.logger.log(
+        `Concurrent ${platform} webhook ${externalEventId} in-flight, skipping reprocess`,
+      );
+      return { duplicate: true, status: 'processed', action: 'duplicate' };
+    }
+
+    // No row, or a prior `failed` row we may retry. Atomically claim it.
+    const event = await this.claimEvent(
+      existing,
       platform,
       externalEventId,
       eventType,
       payload,
     );
 
+    if (!event) {
+      // Lost the claim race to a concurrent delivery; it owns processing.
+      this.logger.log(
+        `Lost claim race for ${platform} webhook ${externalEventId}, skipping reprocess`,
+      );
+      return { duplicate: true, status: 'processed', action: 'duplicate' };
+    }
+
     try {
       const result = await handler();
-      await this.safeUpdateEvent(event.id, {
-        status: result.status,
-        processedAt: new Date(),
-        errorMessage: null,
+      // Durably commit the terminal status BEFORE acknowledging success. If this
+      // write fails it falls through to the catch below (recorded failed +
+      // rethrown -> 5xx), so we never return 200 without a persisted outcome.
+      await this.prisma.webhookEvent.update({
+        where: { id: event.id },
+        data: {
+          status: result.status,
+          processedAt: new Date(),
+          errorMessage: null,
+        },
       });
       return { duplicate: false, status: result.status, action: result.action };
     } catch (error) {
-      // Processing failed (e.g. transient DB error). Record it, then rethrow so
-      // the store retries. Guard the bookkeeping so it cannot mask `error`.
+      // Processing (or the terminal write) failed. Record it best-effort, then
+      // rethrow so the store retries. Guard the bookkeeping so it cannot mask
+      // `error`.
       await this.safeUpdateEvent(event.id, {
         status: 'failed',
         errorMessage: this.errorMessage(error).slice(0, 500),
@@ -436,13 +481,24 @@ export class SubscriptionWebhookService {
     }
   }
 
-  private async upsertReceived(
-    id: string | null,
+  /**
+   * Atomically claim a webhook event for processing. Returns the claimed row, or
+   * `null` when another concurrent delivery already owns it (so the caller must
+   * not reprocess).
+   */
+  private async claimEvent(
+    existing: { id: string; status: string } | null,
     platform: string,
     externalEventId: string,
     eventType: string,
     payload: Record<string, unknown>,
-  ) {
+  ): Promise<{ id: string } | null> {
+    // Retry of a prior `failed` row: flip failed -> received, guarded on status
+    // so only one delivery wins.
+    if (existing && existing.status === 'failed') {
+      return this.claimFailedRow(existing.id);
+    }
+
     const data = {
       platform,
       eventType,
@@ -453,25 +509,38 @@ export class SubscriptionWebhookService {
       processedAt: null,
     };
 
-    if (id) {
-      return this.prisma.webhookEvent.update({ where: { id }, data });
-    }
-
     try {
       return await this.prisma.webhookEvent.create({ data });
     } catch (error) {
-      // Race: another delivery created it between findUnique and create.
+      // Race: another delivery created the row between findUnique and create.
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {
-        return this.prisma.webhookEvent.update({
+        const now = await this.prisma.webhookEvent.findUnique({
           where: { platform_externalEventId: { platform, externalEventId } },
-          data,
         });
+        // The concurrent creator owns processing (received) or already finished
+        // (processed/skipped). Only a `failed` row is eligible for a retry claim.
+        if (now && now.status === 'failed') {
+          return this.claimFailedRow(now.id);
+        }
+        return null;
       }
       throw error;
     }
+  }
+
+  /**
+   * Claim a `failed` row for a retry by atomically flipping it to `received`.
+   * The `status: 'failed'` guard means at most one concurrent delivery wins.
+   */
+  private async claimFailedRow(id: string): Promise<{ id: string } | null> {
+    const res = await this.prisma.webhookEvent.updateMany({
+      where: { id, status: 'failed' },
+      data: { status: 'received', errorMessage: null, processedAt: null },
+    });
+    return res.count === 1 ? { id } : null;
   }
 
   private async safeUpdateEvent(

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -1,0 +1,546 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Prisma, Subscription } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+import {
+  AppleNotificationInfo,
+  AppleVerificationService,
+} from './apple-verification.service';
+import { GoogleVerificationService } from './google-verification.service';
+import { AppleWebhookDto, GoogleWebhookDto } from './dto/webhook.dto';
+
+/** Outcome of processing a single webhook notification. */
+export interface WebhookProcessResult {
+  /** true when the event had already been processed (idempotent replay). */
+  duplicate: boolean;
+  /** Final WebhookEvent status. */
+  status: 'processed' | 'skipped';
+  /** Human-readable description of the action taken. */
+  action: string;
+}
+
+/** Normalized subscription state transition applied to a Subscription row. */
+type SubscriptionAction =
+  | 'activate' // renew/recover/subscribe -> active, extend endsAt
+  | 'will_not_renew' // auto-renew off / user cancel -> keep access until endsAt
+  | 'deactivate' // expired / on-hold -> access ends now
+  | 'revoke' // refund / revoke -> access ends now
+  | 'noop'; // acknowledged but no state change
+
+/**
+ * Google Play RTDN subscription notification types.
+ * @see https://developer.android.com/google/play/billing/rtdn-reference#sub
+ */
+const GOOGLE_SUB_TYPE = {
+  RECOVERED: 1,
+  RENEWED: 2,
+  CANCELED: 3,
+  PURCHASED: 4,
+  ON_HOLD: 5,
+  IN_GRACE_PERIOD: 6,
+  RESTARTED: 7,
+  PRICE_CHANGE_CONFIRMED: 8,
+  DEFERRED: 9,
+  PAUSED: 10,
+  PAUSE_SCHEDULE_CHANGED: 11,
+  REVOKED: 12,
+  EXPIRED: 13,
+} as const;
+
+interface GoogleRtdnPayload {
+  version?: string;
+  packageName?: string;
+  eventTimeMillis?: string;
+  subscriptionNotification?: {
+    version?: string;
+    notificationType?: number;
+    purchaseToken?: string;
+    subscriptionId?: string;
+  };
+  voidedPurchaseNotification?: {
+    purchaseToken?: string;
+    orderId?: string;
+    productType?: number;
+    refundType?: number;
+  };
+  oneTimeProductNotification?: {
+    version?: string;
+    notificationType?: number;
+    purchaseToken?: string;
+    sku?: string;
+  };
+  testNotification?: { version?: string };
+}
+
+/**
+ * Processes Apple App Store Server Notifications (ASSN v2) and Google Play
+ * Real-time Developer Notifications (RTDN), mapping platform notification types
+ * to subscription state changes. Every notification is recorded in the
+ * `webhook_events` table for idempotency and auditing.
+ */
+@Injectable()
+export class SubscriptionWebhookService {
+  private readonly logger = new Logger(SubscriptionWebhookService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly appleVerification: AppleVerificationService,
+    private readonly googleVerification: GoogleVerificationService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Apple
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle an Apple ASSN v2 notification. Signature verification happens here
+   * and throws (400) for malformed/forged payloads, so those never reach the
+   * idempotency layer.
+   */
+  async handleApple(dto: AppleWebhookDto): Promise<WebhookProcessResult> {
+    // Verify + decode. Throws HttpException(400) on bad signature/payload.
+    const info = this.appleVerification.parseSignedNotification(
+      dto.signedPayload,
+    );
+
+    return this.processWithIdempotency(
+      'apple',
+      info.notificationUUID,
+      info.notificationType,
+      info.raw,
+      () => this.applyAppleNotification(info),
+    );
+  }
+
+  private async applyAppleNotification(
+    info: AppleNotificationInfo,
+  ): Promise<{ status: 'processed' | 'skipped'; action: string }> {
+    const { action, endsAt } = this.mapAppleAction(info);
+
+    if (action === 'noop') {
+      return {
+        status: 'skipped',
+        action: `apple:${info.notificationType}${info.subtype ? `/${info.subtype}` : ''} ignored`,
+      };
+    }
+
+    const originalTransactionId =
+      info.transactionInfo?.originalTransactionId ??
+      info.renewalInfo?.originalTransactionId;
+
+    if (!originalTransactionId) {
+      return {
+        status: 'skipped',
+        action: `apple:${info.notificationType} missing originalTransactionId`,
+      };
+    }
+
+    const subscription = await this.findSubscription(
+      'apple',
+      originalTransactionId,
+    );
+
+    if (!subscription) {
+      this.logger.warn(
+        `No subscription for Apple originalTransactionId ${this.mask(originalTransactionId)}`,
+      );
+      return {
+        status: 'skipped',
+        action: `apple:${info.notificationType} no matching subscription`,
+      };
+    }
+
+    await this.applyAction(subscription, action, endsAt);
+    return {
+      status: 'processed',
+      action: `apple:${info.notificationType} -> ${action}`,
+    };
+  }
+
+  private mapAppleAction(info: AppleNotificationInfo): {
+    action: SubscriptionAction;
+    endsAt?: Date | null;
+  } {
+    const expiresDate = info.transactionInfo?.expiresDate
+      ? new Date(info.transactionInfo.expiresDate)
+      : null;
+
+    switch (info.notificationType) {
+      case 'SUBSCRIBED':
+      case 'DID_RENEW':
+      case 'OFFER_REDEEMED':
+        return { action: 'activate', endsAt: expiresDate };
+
+      case 'DID_CHANGE_RENEWAL_STATUS':
+        // AUTO_RENEW_DISABLED -> will not renew; AUTO_RENEW_ENABLED -> re-activated.
+        if (info.subtype === 'AUTO_RENEW_ENABLED') {
+          return { action: 'activate', endsAt: expiresDate };
+        }
+        return { action: 'will_not_renew' };
+
+      case 'EXPIRED':
+      case 'GRACE_PERIOD_EXPIRED':
+        return { action: 'deactivate' };
+
+      case 'REFUND':
+      case 'REVOKE':
+        return { action: 'revoke' };
+
+      default:
+        // DID_CHANGE_RENEWAL_PREF, PRICE_INCREASE, RENEWAL_EXTENDED,
+        // DID_FAIL_TO_RENEW, CONSUMPTION_REQUEST, TEST, etc.
+        return { action: 'noop' };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Google
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle a Google Play RTDN delivered via a Pub/Sub push message.
+   */
+  async handleGoogle(dto: GoogleWebhookDto): Promise<WebhookProcessResult> {
+    const messageId = dto.message?.messageId;
+    if (!messageId) {
+      throw new BadRequestException('Missing Pub/Sub messageId');
+    }
+    if (!dto.message?.data) {
+      throw new BadRequestException('Missing Pub/Sub message data');
+    }
+
+    const payload = this.decodeGooglePayload(dto.message.data);
+
+    const eventType = this.googleEventType(payload);
+
+    return this.processWithIdempotency(
+      'google',
+      messageId,
+      eventType,
+      payload as unknown as Record<string, unknown>,
+      () => this.applyGoogleNotification(payload),
+    );
+  }
+
+  private decodeGooglePayload(data: string): GoogleRtdnPayload {
+    const json = Buffer.from(data, 'base64').toString('utf8');
+    try {
+      return JSON.parse(json) as GoogleRtdnPayload;
+    } catch {
+      throw new BadRequestException('Invalid JSON in Pub/Sub message data');
+    }
+  }
+
+  private googleEventType(payload: GoogleRtdnPayload): string {
+    if (payload.subscriptionNotification) {
+      return `SUBSCRIPTION_${payload.subscriptionNotification.notificationType ?? 'UNKNOWN'}`;
+    }
+    if (payload.voidedPurchaseNotification) {
+      return 'VOIDED_PURCHASE';
+    }
+    if (payload.oneTimeProductNotification) {
+      return 'ONE_TIME_PRODUCT';
+    }
+    if (payload.testNotification) {
+      return 'TEST';
+    }
+    return 'UNKNOWN';
+  }
+
+  private async applyGoogleNotification(
+    payload: GoogleRtdnPayload,
+  ): Promise<{ status: 'processed' | 'skipped'; action: string }> {
+    // Voided purchase (refund/chargeback) -> revoke access.
+    if (payload.voidedPurchaseNotification?.purchaseToken) {
+      const sub = await this.findSubscription(
+        'google',
+        payload.voidedPurchaseNotification.purchaseToken,
+      );
+      if (!sub) {
+        return { status: 'skipped', action: 'google:voided no subscription' };
+      }
+      await this.applyAction(sub, 'revoke');
+      return { status: 'processed', action: 'google:voided -> revoke' };
+    }
+
+    const sub = payload.subscriptionNotification;
+    if (!sub?.purchaseToken || sub.notificationType == null) {
+      // One-time products / test notifications are not subscription state.
+      return {
+        status: 'skipped',
+        action: `google:${this.googleEventType(payload)} ignored`,
+      };
+    }
+
+    const action = this.mapGoogleAction(sub.notificationType);
+    if (action === 'noop') {
+      return {
+        status: 'skipped',
+        action: `google:SUBSCRIPTION_${sub.notificationType} ignored`,
+      };
+    }
+
+    const subscription = await this.findSubscription(
+      'google',
+      sub.purchaseToken,
+    );
+    if (!subscription) {
+      this.logger.warn(
+        `No subscription for Google purchaseToken ${this.mask(sub.purchaseToken)}`,
+      );
+      return {
+        status: 'skipped',
+        action: `google:SUBSCRIPTION_${sub.notificationType} no matching subscription`,
+      };
+    }
+
+    // Enrich with the Play Developer API to get the authoritative expiry.
+    let endsAt: Date | null | undefined;
+    if (action === 'activate') {
+      endsAt = await this.fetchGoogleExpiry(
+        payload.packageName,
+        sub.subscriptionId ?? subscription.productId ?? '',
+        sub.purchaseToken,
+      );
+    }
+
+    await this.applyAction(subscription, action, endsAt);
+    return {
+      status: 'processed',
+      action: `google:SUBSCRIPTION_${sub.notificationType} -> ${action}`,
+    };
+  }
+
+  private mapGoogleAction(type: number): SubscriptionAction {
+    switch (type) {
+      case GOOGLE_SUB_TYPE.RECOVERED:
+      case GOOGLE_SUB_TYPE.RENEWED:
+      case GOOGLE_SUB_TYPE.PURCHASED:
+      case GOOGLE_SUB_TYPE.RESTARTED:
+      case GOOGLE_SUB_TYPE.IN_GRACE_PERIOD:
+        // Grace period: user still has access while Google retries billing.
+        return 'activate';
+
+      case GOOGLE_SUB_TYPE.CANCELED:
+        return 'will_not_renew';
+
+      case GOOGLE_SUB_TYPE.ON_HOLD:
+      case GOOGLE_SUB_TYPE.EXPIRED:
+        return 'deactivate';
+
+      case GOOGLE_SUB_TYPE.REVOKED:
+        return 'revoke';
+
+      default:
+        // PRICE_CHANGE_CONFIRMED, DEFERRED, PAUSED, PAUSE_SCHEDULE_CHANGED
+        return 'noop';
+    }
+  }
+
+  private async fetchGoogleExpiry(
+    packageName: string | undefined,
+    productId: string,
+    purchaseToken: string,
+  ): Promise<Date | null | undefined> {
+    if (!productId) return undefined;
+    try {
+      const result = await this.googleVerification.verify({
+        packageName,
+        productId,
+        purchaseToken,
+      });
+      return result.expirationTime ?? undefined;
+    } catch (error) {
+      this.logger.warn(
+        `Google Play enrichment failed: ${this.errorMessage(error)}`,
+      );
+      return undefined;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared: idempotency + state transitions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Records the notification in `webhook_events` (keyed by platform +
+   * externalEventId) and runs `handler` exactly once. Duplicate deliveries of
+   * an already-processed/skipped event short-circuit and return 200.
+   *
+   * The WebhookEvent bookkeeping is wrapped in its own try/catch so a failure
+   * writing the audit row never masks the original processing error.
+   */
+  private async processWithIdempotency(
+    platform: 'apple' | 'google',
+    externalEventId: string,
+    eventType: string,
+    payload: Record<string, unknown>,
+    handler: () => Promise<{ status: 'processed' | 'skipped'; action: string }>,
+  ): Promise<WebhookProcessResult> {
+    const existing = await this.prisma.webhookEvent.findUnique({
+      where: { platform_externalEventId: { platform, externalEventId } },
+    });
+
+    if (
+      existing &&
+      (existing.status === 'processed' || existing.status === 'skipped')
+    ) {
+      this.logger.log(
+        `Duplicate ${platform} webhook ${externalEventId} (${existing.status}), skipping reprocess`,
+      );
+      return {
+        duplicate: true,
+        status: existing.status,
+        action: 'duplicate',
+      };
+    }
+
+    // Create (or reset) the audit row in "received" state.
+    const event = await this.upsertReceived(
+      existing?.id ?? null,
+      platform,
+      externalEventId,
+      eventType,
+      payload,
+    );
+
+    try {
+      const result = await handler();
+      await this.safeUpdateEvent(event.id, {
+        status: result.status,
+        processedAt: new Date(),
+        errorMessage: null,
+      });
+      return { duplicate: false, status: result.status, action: result.action };
+    } catch (error) {
+      // Processing failed (e.g. transient DB error). Record it, then rethrow so
+      // the store retries. Guard the bookkeeping so it cannot mask `error`.
+      await this.safeUpdateEvent(event.id, {
+        status: 'failed',
+        errorMessage: this.errorMessage(error).slice(0, 500),
+      });
+      throw error;
+    }
+  }
+
+  private async upsertReceived(
+    id: string | null,
+    platform: string,
+    externalEventId: string,
+    eventType: string,
+    payload: Record<string, unknown>,
+  ) {
+    const data = {
+      platform,
+      eventType,
+      externalEventId,
+      payload: payload as Prisma.InputJsonValue,
+      status: 'received',
+      errorMessage: null,
+      processedAt: null,
+    };
+
+    if (id) {
+      return this.prisma.webhookEvent.update({ where: { id }, data });
+    }
+
+    try {
+      return await this.prisma.webhookEvent.create({ data });
+    } catch (error) {
+      // Race: another delivery created it between findUnique and create.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return this.prisma.webhookEvent.update({
+          where: { platform_externalEventId: { platform, externalEventId } },
+          data,
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async safeUpdateEvent(
+    id: string,
+    data: Prisma.WebhookEventUpdateInput,
+  ): Promise<void> {
+    try {
+      await this.prisma.webhookEvent.update({ where: { id }, data });
+    } catch (error) {
+      this.logger.error(
+        `Failed to update webhook_event ${id}: ${this.errorMessage(error)}`,
+      );
+    }
+  }
+
+  private async findSubscription(
+    platform: 'apple' | 'google',
+    purchaseToken: string,
+  ): Promise<Subscription | null> {
+    return this.prisma.subscription.findFirst({
+      where: { platform, purchaseToken },
+    });
+  }
+
+  /**
+   * Apply a normalized action to a subscription row.
+   * - activate:       status active, extend endsAt (if a new expiry is known)
+   * - will_not_renew: status cancelled, keep existing endsAt (access until expiry)
+   * - deactivate:     status cancelled, endsAt = now (access ends immediately)
+   * - revoke:         status cancelled, endsAt = now (refund/chargeback)
+   */
+  private async applyAction(
+    subscription: Subscription,
+    action: SubscriptionAction,
+    endsAt?: Date | null,
+  ): Promise<void> {
+    const now = new Date();
+    let data: Prisma.SubscriptionUpdateInput;
+
+    switch (action) {
+      case 'activate':
+        data = {
+          status: 'active',
+          endsAt: endsAt ?? subscription.endsAt ?? undefined,
+        };
+        break;
+      case 'will_not_renew':
+        data = { status: 'cancelled' };
+        break;
+      case 'deactivate':
+      case 'revoke':
+        data = { status: 'cancelled', endsAt: now };
+        break;
+      case 'noop':
+      default:
+        return;
+    }
+
+    await this.prisma.subscription.update({
+      where: { id: subscription.id },
+      data,
+    });
+
+    this.eventEmitter.emit('admin.sse.activity', {
+      type: 'SUBSCRIPTION',
+      userId: subscription.userId,
+      timestamp: now.toISOString(),
+    });
+    this.eventEmitter.emit('admin.sse.stats', {
+      trigger: `webhook_${action}`,
+    });
+  }
+
+  private errorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return String(error);
+  }
+
+  /** Mask a token/identifier for safe logging. */
+  private mask(value: string): string {
+    if (value.length <= 8) return '***';
+    return `${value.slice(0, 6)}...${value.slice(-2)}`;
+  }
+}

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -158,11 +158,43 @@ export class SubscriptionWebhookService {
       };
     }
 
-    await this.applyAction(subscription, action, endsAt);
+    const eventAt = this.appleEventAt(info);
+    const applied = await this.applyAction(
+      subscription,
+      action,
+      endsAt,
+      eventAt,
+    );
+    if (!applied) {
+      return {
+        status: 'skipped',
+        action: `apple:${info.notificationType} stale/out-of-order (event <= lastEventAt)`,
+      };
+    }
     return {
       status: 'processed',
       action: `apple:${info.notificationType} -> ${action}`,
     };
+  }
+
+  /**
+   * Authoritative timestamp for an Apple notification, used as the out-of-order
+   * watermark. Prefers the outer notification `signedDate`, then the signed
+   * transaction/renewal `signedDate`. Returns `null` when none is present (then
+   * ordering cannot be established and the event is applied without gating).
+   */
+  private appleEventAt(info: AppleNotificationInfo): Date | null {
+    const candidates: unknown[] = [
+      info.signedDate,
+      info.transactionInfo?.signedDate,
+      info.renewalInfo?.signedDate,
+    ];
+    for (const ms of candidates) {
+      if (typeof ms === 'number' && Number.isFinite(ms) && ms > 0) {
+        return new Date(ms);
+      }
+    }
+    return null;
   }
 
   private mapAppleAction(info: AppleNotificationInfo): {
@@ -268,6 +300,8 @@ export class SubscriptionWebhookService {
   private async applyGoogleNotification(
     payload: GoogleRtdnPayload,
   ): Promise<{ status: 'processed' | 'skipped'; action: string }> {
+    const eventAt = this.googleEventAt(payload);
+
     // Voided purchase (refund/chargeback) -> revoke access.
     if (payload.voidedPurchaseNotification?.purchaseToken) {
       const sub = await this.findSubscription(
@@ -277,7 +311,13 @@ export class SubscriptionWebhookService {
       if (!sub) {
         return { status: 'skipped', action: 'google:voided no subscription' };
       }
-      await this.applyAction(sub, 'revoke');
+      const applied = await this.applyAction(sub, 'revoke', undefined, eventAt);
+      if (!applied) {
+        return {
+          status: 'skipped',
+          action: 'google:voided stale/out-of-order (event <= lastEventAt)',
+        };
+      }
       return { status: 'processed', action: 'google:voided -> revoke' };
     }
 
@@ -327,11 +367,35 @@ export class SubscriptionWebhookService {
       );
     }
 
-    await this.applyAction(subscription, action, endsAt);
+    const applied = await this.applyAction(
+      subscription,
+      action,
+      endsAt,
+      eventAt,
+    );
+    if (!applied) {
+      return {
+        status: 'skipped',
+        action: `google:SUBSCRIPTION_${sub.notificationType} stale/out-of-order (event <= lastEventAt)`,
+      };
+    }
     return {
       status: 'processed',
       action: `google:SUBSCRIPTION_${sub.notificationType} -> ${action}`,
     };
+  }
+
+  /**
+   * Authoritative timestamp for a Google RTDN, used as the out-of-order
+   * watermark. RTDN carries `eventTimeMillis` (epoch millis as a string).
+   * Returns `null` when absent/malformed (then the event is applied without
+   * ordering gating).
+   */
+  private googleEventAt(payload: GoogleRtdnPayload): Date | null {
+    const raw = payload.eventTimeMillis;
+    if (raw == null || raw === '') return null;
+    const ms = Number(raw);
+    return Number.isFinite(ms) && ms > 0 ? new Date(ms) : null;
   }
 
   private mapGoogleAction(type: number): SubscriptionAction {
@@ -657,12 +721,19 @@ export class SubscriptionWebhookService {
    * - will_not_renew: status cancelled, keep existing endsAt (access until expiry)
    * - deactivate:     status cancelled, endsAt = now (access ends immediately)
    * - revoke:         status cancelled, endsAt = now (refund/chargeback)
+   *
+   * Out-of-order protection: when `eventAt` is known and the subscription's
+   * stored `lastEventAt` is >= `eventAt`, the event is stale (a late/duplicate
+   * delivery) and the mutation is SKIPPED (returns `false`) so it cannot clobber
+   * newer state. Otherwise the state change AND the advanced `lastEventAt`
+   * watermark are written in a single update (atomic), and `true` is returned.
    */
   private async applyAction(
     subscription: Subscription,
     action: SubscriptionAction,
     endsAt?: Date | null,
-  ): Promise<void> {
+    eventAt?: Date | null,
+  ): Promise<boolean> {
     const now = new Date();
     let data: Prisma.SubscriptionUpdateInput;
 
@@ -682,7 +753,26 @@ export class SubscriptionWebhookService {
         break;
       case 'noop':
       default:
-        return;
+        return false;
+    }
+
+    // Skip stale / out-of-order deliveries. `>=` also drops a distinct event
+    // arriving at the exact same timestamp as the last applied one.
+    if (
+      eventAt &&
+      subscription.lastEventAt &&
+      subscription.lastEventAt.getTime() >= eventAt.getTime()
+    ) {
+      this.logger.log(
+        `Skipping stale/out-of-order ${action} for subscription ${subscription.id} ` +
+          `(event ${eventAt.toISOString()} <= lastEventAt ${subscription.lastEventAt.toISOString()})`,
+      );
+      return false;
+    }
+
+    // Advance the watermark atomically with the state change (same UPDATE).
+    if (eventAt) {
+      data.lastEventAt = eventAt;
     }
 
     await this.prisma.subscription.update({
@@ -698,6 +788,8 @@ export class SubscriptionWebhookService {
     this.eventEmitter.emit('admin.sse.stats', {
       trigger: `webhook_${action}`,
     });
+
+    return true;
   }
 
   private errorMessage(error: unknown): string {

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -47,6 +47,13 @@ const GOOGLE_SUB_TYPE = {
   EXPIRED: 13,
 } as const;
 
+/**
+ * Maximum number of `linkedPurchaseToken` hops to follow when mapping a new
+ * Google Play purchase token back to an existing Subscription. Bounds the work
+ * per event and guards against a malformed/cyclic chain looping forever.
+ */
+const MAX_LINKED_TOKEN_HOPS = 5;
+
 interface GoogleRtdnPayload {
   version?: string;
   packageName?: string;
@@ -281,13 +288,18 @@ export class SubscriptionWebhookService {
       };
     }
 
-    const subscription = await this.findSubscription(
-      'google',
+    // Google issues a NEW purchase token on upgrade/downgrade/re-subscribe,
+    // linked to the prior token via `linkedPurchaseToken`. Follow that chain so
+    // events for the new token still resolve to the user's Subscription and
+    // migrate the stored token forward.
+    const subscription = await this.resolveGoogleSubscription(
       sub.purchaseToken,
+      payload.packageName,
+      sub.subscriptionId,
     );
     if (!subscription) {
       this.logger.warn(
-        `No subscription for Google purchaseToken ${this.mask(sub.purchaseToken)}`,
+        `No subscription for Google purchaseToken ${this.mask(sub.purchaseToken)} (linked-token chain unresolved)`,
       );
       return {
         status: 'skipped',
@@ -482,6 +494,92 @@ export class SubscriptionWebhookService {
     return this.prisma.subscription.findFirst({
       where: { platform, purchaseToken },
     });
+  }
+
+  /**
+   * Resolve the Subscription for a Google purchase token, following the
+   * `linkedPurchaseToken` chain when the token is not directly known.
+   *
+   * Google mints a new purchase token on upgrade/downgrade/re-subscribe and
+   * links it to the prior token. The first RTDN for the new token therefore has
+   * no matching Subscription. We walk the chain (new -> ... -> old) via the Play
+   * Developer API until we hit a token we already store, then migrate that row's
+   * `purchaseToken` forward to the newest token (`eventToken`) so this and all
+   * subsequent events resolve directly. Because `Subscription.userId` is unique
+   * (one row per user) this is an in-place update, never a merge.
+   *
+   * Returns the (possibly migrated) Subscription, or `null` if the chain is
+   * exhausted / capped without finding a known token.
+   */
+  private async resolveGoogleSubscription(
+    eventToken: string,
+    packageName: string | undefined,
+    subscriptionId: string | undefined,
+  ): Promise<Subscription | null> {
+    // Fast path: the token is already stored.
+    const direct = await this.findSubscription('google', eventToken);
+    if (direct) return direct;
+
+    // Follow linkedPurchaseToken hops. `subscriptionId` (productId) and
+    // packageName are required to query the Play Developer API.
+    if (!subscriptionId) return null;
+
+    const visited = new Set<string>([eventToken]);
+    let currentToken = eventToken;
+
+    for (let hop = 0; hop < MAX_LINKED_TOKEN_HOPS; hop++) {
+      const linkedToken = await this.fetchLinkedPurchaseToken(
+        packageName,
+        subscriptionId,
+        currentToken,
+      );
+
+      // No further link, or a cycle -> give up.
+      if (!linkedToken || visited.has(linkedToken)) return null;
+      visited.add(linkedToken);
+
+      const sub = await this.findSubscription('google', linkedToken);
+      if (sub) {
+        // Migrate the known row forward to the newest (event) token in place.
+        const migrated = await this.prisma.subscription.update({
+          where: { id: sub.id },
+          data: { purchaseToken: eventToken },
+        });
+        this.logger.log(
+          `Migrated Google purchaseToken ${this.mask(linkedToken)} -> ${this.mask(eventToken)} for subscription ${sub.id} (${hop + 1} hop(s))`,
+        );
+        return migrated;
+      }
+
+      currentToken = linkedToken;
+    }
+
+    return null;
+  }
+
+  /**
+   * Fetch a purchase token's `linkedPurchaseToken` via the Play Developer API.
+   * Returns `null` on any error (verification failure, network) so the caller
+   * can stop chasing the chain rather than crash the webhook.
+   */
+  private async fetchLinkedPurchaseToken(
+    packageName: string | undefined,
+    productId: string,
+    purchaseToken: string,
+  ): Promise<string | null> {
+    try {
+      const result = await this.googleVerification.verify({
+        packageName,
+        productId,
+        purchaseToken,
+      });
+      return result.linkedPurchaseToken ?? null;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch linkedPurchaseToken for ${this.mask(purchaseToken)}: ${this.errorMessage(error)}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/src/payment/webhook.controller.spec.ts
+++ b/src/payment/webhook.controller.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
 import { WebhookController } from './webhook.controller';
 import { SubscriptionWebhookService } from './subscription-webhook.service';
+import { GooglePubSubVerifierService } from './google-pubsub-verifier.service';
 
 describe('WebhookController', () => {
   let controller: WebhookController;
   let service: { handleApple: jest.Mock; handleGoogle: jest.Mock };
+  let verifier: { verifyPushRequest: jest.Mock };
 
   beforeEach(async () => {
     service = {
@@ -19,10 +22,14 @@ describe('WebhookController', () => {
         action: 'google:SUBSCRIPTION_2 -> activate',
       }),
     };
+    verifier = { verifyPushRequest: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WebhookController],
-      providers: [{ provide: SubscriptionWebhookService, useValue: service }],
+      providers: [
+        { provide: SubscriptionWebhookService, useValue: service },
+        { provide: GooglePubSubVerifierService, useValue: verifier },
+      ],
     }).compile();
 
     controller = module.get(WebhookController);
@@ -35,14 +42,29 @@ describe('WebhookController', () => {
     expect(res.status).toBe('processed');
   });
 
-  it('routes Google notifications to the service', async () => {
+  it('verifies the Pub/Sub OIDC token then routes Google notifications to the service', async () => {
     const body = {
       message: { data: 'base64', messageId: 'm-1' },
       subscription: 's',
     };
-    const res = await controller.google(body);
+    const res = await controller.google(body, 'Bearer token-abc');
+    expect(verifier.verifyPushRequest).toHaveBeenCalledWith('Bearer token-abc');
     expect(service.handleGoogle).toHaveBeenCalledWith(body);
     expect(res.status).toBe('processed');
+  });
+
+  it('rejects the Google webhook (and never processes) when OIDC verification fails', async () => {
+    verifier.verifyPushRequest.mockRejectedValue(
+      new UnauthorizedException('Invalid Pub/Sub OIDC token'),
+    );
+    const body = {
+      message: { data: 'base64', messageId: 'm-2' },
+      subscription: 's',
+    };
+    await expect(controller.google(body, 'Bearer bad')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(service.handleGoogle).not.toHaveBeenCalled();
   });
 
   it('propagates errors thrown by the service (e.g. bad signature)', async () => {

--- a/src/payment/webhook.controller.spec.ts
+++ b/src/payment/webhook.controller.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookController } from './webhook.controller';
+import { SubscriptionWebhookService } from './subscription-webhook.service';
+
+describe('WebhookController', () => {
+  let controller: WebhookController;
+  let service: { handleApple: jest.Mock; handleGoogle: jest.Mock };
+
+  beforeEach(async () => {
+    service = {
+      handleApple: jest.fn().mockResolvedValue({
+        duplicate: false,
+        status: 'processed',
+        action: 'apple:DID_RENEW -> activate',
+      }),
+      handleGoogle: jest.fn().mockResolvedValue({
+        duplicate: false,
+        status: 'processed',
+        action: 'google:SUBSCRIPTION_2 -> activate',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhookController],
+      providers: [{ provide: SubscriptionWebhookService, useValue: service }],
+    }).compile();
+
+    controller = module.get(WebhookController);
+  });
+
+  it('routes Apple notifications to the service', async () => {
+    const body = { signedPayload: 'jws' };
+    const res = await controller.apple(body);
+    expect(service.handleApple).toHaveBeenCalledWith(body);
+    expect(res.status).toBe('processed');
+  });
+
+  it('routes Google notifications to the service', async () => {
+    const body = {
+      message: { data: 'base64', messageId: 'm-1' },
+      subscription: 's',
+    };
+    const res = await controller.google(body);
+    expect(service.handleGoogle).toHaveBeenCalledWith(body);
+    expect(res.status).toBe('processed');
+  });
+
+  it('propagates errors thrown by the service (e.g. bad signature)', async () => {
+    service.handleApple.mockRejectedValue(new Error('bad signature'));
+    await expect(controller.apple({ signedPayload: 'x' })).rejects.toThrow(
+      'bad signature',
+    );
+  });
+});

--- a/src/payment/webhook.controller.ts
+++ b/src/payment/webhook.controller.ts
@@ -1,8 +1,16 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Public } from '@/shared/decorators/public.decorator';
 import { AppleWebhookDto, GoogleWebhookDto } from './dto/webhook.dto';
+import { GooglePubSubVerifierService } from './google-pubsub-verifier.service';
 import {
   SubscriptionWebhookService,
   WebhookProcessResult,
@@ -11,10 +19,12 @@ import {
 /**
  * Server-to-server webhook receiver for store subscription notifications.
  *
- * These endpoints are PUBLIC (no JWT): Apple and Google call them directly.
- * Authenticity is established by cryptographic signature verification (Apple
- * JWS x5c chain) and by re-fetching state from the store's server API
- * (Google Play Developer API), NOT by an auth header.
+ * These endpoints are PUBLIC (no app JWT): Apple and Google call them directly.
+ * Authenticity is established per platform:
+ *  - Apple: the ASSN v2 JWS x5c signature chain (verified in the service).
+ *  - Google: the OIDC identity token that a configured Pub/Sub push
+ *    subscription sends in the Authorization header (verified here), plus a
+ *    re-fetch of authoritative state from the Play Developer API.
  *
  * They always return 200 for anything successfully received or ignorable, so
  * the stores do not enter infinite retry loops. Only genuinely malformed
@@ -25,7 +35,10 @@ import {
 @Controller('payment/webhooks')
 @SkipThrottle()
 export class WebhookController {
-  constructor(private readonly webhookService: SubscriptionWebhookService) {}
+  constructor(
+    private readonly webhookService: SubscriptionWebhookService,
+    private readonly pubsubVerifier: GooglePubSubVerifierService,
+  ) {}
 
   @Post('apple')
   @Public()
@@ -48,11 +61,19 @@ export class WebhookController {
     summary: 'Google Play Real-time Developer Notifications (RTDN) receiver',
     description:
       'Receives Pub/Sub push messages ({ message: { data, messageId } }). ' +
-      'Decodes the RTDN payload, enriches via the Play Developer API, maps ' +
-      'the notification type to a subscription state change, and records the ' +
+      'Verifies the Pub/Sub push OIDC token (when configured), decodes the ' +
+      'RTDN payload, enriches via the Play Developer API, maps the ' +
+      'notification type to a subscription state change, and records the ' +
       'event for idempotency.',
   })
-  async google(@Body() body: GoogleWebhookDto): Promise<WebhookProcessResult> {
+  async google(
+    @Body() body: GoogleWebhookDto,
+    @Headers('authorization') authorization?: string,
+  ): Promise<WebhookProcessResult> {
+    // Authenticate the caller as Google's Pub/Sub push service before doing
+    // any work. Throws 401 when a configured endpoint gets an invalid/missing
+    // token; no-ops (with a warning) when verification is not configured.
+    await this.pubsubVerifier.verifyPushRequest(authorization);
     return this.webhookService.handleGoogle(body);
   }
 }

--- a/src/payment/webhook.controller.ts
+++ b/src/payment/webhook.controller.ts
@@ -1,0 +1,58 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Public } from '@/shared/decorators/public.decorator';
+import { AppleWebhookDto, GoogleWebhookDto } from './dto/webhook.dto';
+import {
+  SubscriptionWebhookService,
+  WebhookProcessResult,
+} from './subscription-webhook.service';
+
+/**
+ * Server-to-server webhook receiver for store subscription notifications.
+ *
+ * These endpoints are PUBLIC (no JWT): Apple and Google call them directly.
+ * Authenticity is established by cryptographic signature verification (Apple
+ * JWS x5c chain) and by re-fetching state from the store's server API
+ * (Google Play Developer API), NOT by an auth header.
+ *
+ * They always return 200 for anything successfully received or ignorable, so
+ * the stores do not enter infinite retry loops. Only genuinely malformed
+ * payloads or failed signatures return 4xx; transient processing failures
+ * return 5xx so the store retries.
+ */
+@ApiTags('payment-webhooks')
+@Controller('payment/webhooks')
+@SkipThrottle()
+export class WebhookController {
+  constructor(private readonly webhookService: SubscriptionWebhookService) {}
+
+  @Post('apple')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Apple App Store Server Notifications v2 receiver',
+    description:
+      'Receives ASSN v2 notifications ({ signedPayload }). Verifies the JWS ' +
+      'signature, maps the notification type to a subscription state change, ' +
+      'and records the event for idempotency.',
+  })
+  async apple(@Body() body: AppleWebhookDto): Promise<WebhookProcessResult> {
+    return this.webhookService.handleApple(body);
+  }
+
+  @Post('google')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Google Play Real-time Developer Notifications (RTDN) receiver',
+    description:
+      'Receives Pub/Sub push messages ({ message: { data, messageId } }). ' +
+      'Decodes the RTDN payload, enriches via the Play Developer API, maps ' +
+      'the notification type to a subscription state change, and records the ' +
+      'event for idempotency.',
+  })
+  async google(@Body() body: GoogleWebhookDto): Promise<WebhookProcessResult> {
+    return this.webhookService.handleGoogle(body);
+  }
+}


### PR DESCRIPTION
## Summary

Rebuilds the Apple App Store Server Notifications (ASSN v2) + Google Play Real-time Developer Notifications (RTDN) webhook receiver (originally in the deleted PR #332). Server-to-server store notifications now update subscription state automatically (renewals, cancellations, expirations, refunds), independent of the client-driven `verify-purchase` flow.

Backend only. No changes to `src/auth/`, frontend, or mobile.

## Endpoints

Both are **public** (no app JWT) and delivered server-to-server. Authenticity: **Apple** by JWS x5c signature verification; **Google** by Pub/Sub push **OIDC token** verification (`Authorization: Bearer`, when configured) plus a Play Developer API re-fetch. Both are `@SkipThrottle()` (the global guard is `ThrottlerGuard`).

| Method | Path | Body |
| --- | --- | --- |
| `POST` | `/payment/webhooks/apple` | `{ signedPayload: string }` (ASSN v2 JWS) |
| `POST` | `/payment/webhooks/google` | `{ message: { data, messageId }, subscription }` (Pub/Sub push) |

## Signature verification & user mapping

**Apple** — `AppleVerificationService.parseSignedNotification()` cryptographically verifies the JWS before decoding:
- Parses the `x5c` cert chain from the JWS header, checks each cert is signed by the next, verifies cert validity windows, and **pins the root** to the Apple Root CA - G3 SHA-256 fingerprint (overridable via `APPLE_ROOT_CA_FINGERPRINT`).
- Verifies the ES256 (IEEE-P1363) signature with the leaf cert's public key.
- Then decodes the outer payload + nested `signedTransactionInfo` / `signedRenewalInfo`.
- **User mapping:** `originalTransactionId` → `Subscription.purchaseToken` (Apple purchases store the original transaction id there; there is an index on `purchaseToken`).

**Google** — the Pub/Sub `message.data` is base64-decoded to the RTDN payload. For activations, `GoogleVerificationService.verify()` re-fetches the purchase from the **Play Developer API** to get the authoritative expiry (this is the authenticity check — only real tokens resolve).
- **User mapping:** RTDN `purchaseToken` → `Subscription.purchaseToken`.
- **`linkedPurchaseToken` chain (upgrade / downgrade / re-subscribe):** Google issues a **new** purchase token linked to the prior one on these transitions. When an event's `purchaseToken` has no matching `Subscription`, the processor fetches the token's purchase to read its `linkedPurchaseToken` and walks the chain (new → … → old, depth cap 5 with a cycle guard). On finding a stored token it migrates that single per-user row's `purchaseToken` forward to the newest token in place, then applies the event normally. Only if the chain is exhausted/unknown is the event `skipped`.

If no matching subscription is found (and the `linkedPurchaseToken` chain does not resolve to one), the event is recorded as `skipped` and returns 200.

## Idempotency & audit

Every notification upserts a `WebhookEvent` keyed by `(platform, externalEventId)` — Apple `notificationUUID`, Google Pub/Sub `messageId`. An already `processed`/`skipped` event short-circuits (returns 200, no reprocessing). Status transitions `received → processed | skipped | failed` with `errorMessage`/`processedAt`. The `WebhookEvent` bookkeeping runs in its own try/catch so an audit-write failure never masks the original processing error (called out in #332).

## Notification-type → state mapping

Actions: `activate` (status `active`, extend `endsAt`), `will_not_renew` (status `cancelled`, keep `endsAt` so access lasts until expiry), `deactivate`/`revoke` (status `cancelled`, `endsAt = now`).

**Apple:** `SUBSCRIBED`/`DID_RENEW`/`OFFER_REDEEMED` → activate · `DID_CHANGE_RENEWAL_STATUS` (AUTO_RENEW_DISABLED) → will_not_renew, (AUTO_RENEW_ENABLED) → activate · `EXPIRED`/`GRACE_PERIOD_EXPIRED` → deactivate · `REFUND`/`REVOKE` → revoke · others → skipped.

**Google:** `RECOVERED(1)`/`RENEWED(2)`/`PURCHASED(4)`/`RESTARTED(7)`/`IN_GRACE_PERIOD(6)` → activate · `CANCELED(3)` → will_not_renew · `ON_HOLD(5)`/`EXPIRED(13)` → deactivate · `REVOKED(12)` → revoke · `voidedPurchaseNotification` → revoke · price-change/deferred/paused → skipped.

## HTTP codes

200 on success, duplicate, or ignorable/unmapped events (prevents infinite store retries). 400 for malformed payloads / failed signature. 5xx for transient processing failures (e.g. DB) so the store retries.

## Required env / config

Reused from the existing verification services (nothing hardcoded):
- **Apple:** `APPLE_KEY_ID`, `APPLE_ISSUER_ID`, `APPLE_BUNDLE_ID`, `APPLE_PRIVATE_KEY`, `NODE_ENV`. New optional: `APPLE_ROOT_CA_FINGERPRINT` (defaults to the built-in Apple Root CA - G3 fingerprint — **verify this value before go-live**).
- **Google:** `GOOGLE_PLAY_PACKAGE_NAME`, `PYTHON_PATH` (+ the existing WIF/service-account setup used by `scripts/verify_google_purchase.py`).
- **Google Pub/Sub push OIDC auth (new):**
  - `GOOGLE_PUBSUB_AUDIENCE` — the OIDC `aud` claim the push subscription is configured to send (commonly the endpoint URL, e.g. `https://api.<host>/payment/webhooks/google`). **When set, OIDC verification is ENFORCED** (invalid/missing token → 401). When **unset**, verification is skipped and a warning is logged on each unconfigured start — **production must set this**.
  - `GOOGLE_PUBSUB_SA_EMAIL` — the push subscription's service-account email; the token's `email` claim must equal this (and `email_verified` must be `true`). If unset while `GOOGLE_PUBSUB_AUDIENCE` is set, any Google-verified account is accepted for that audience (a warning is logged) — set it to lock down to your push SA.

## Still needs to be set up externally (not code)

- **Apple App Store Connect:** set the Production + Sandbox Server Notifications v2 URL to `.../payment/webhooks/apple`.
- **Google Play Console:** set the RTDN Cloud Pub/Sub topic; create a **push** subscription targeting `.../payment/webhooks/google`.
- **Google Cloud Pub/Sub push OIDC (required for production auth):** on the push subscription, enable **"Enable authentication"**, choose a **service account** (its email → `GOOGLE_PUBSUB_SA_EMAIL`), and set the **Audience** to the exact value in `GOOGLE_PUBSUB_AUDIENCE`. Pub/Sub then attaches an OIDC identity token as `Authorization: Bearer <jwt>` on every push, which the endpoint verifies (signature vs Google JWKS, `iss = accounts.google.com`, `aud`, `email`, `email_verified`).
- **Confirm** the pinned `APPLE_ROOT_CA_FINGERPRINT` matches Apple's published cert.

## Known limitations / follow-ups

- ~~Google may issue a new `purchaseToken` on re-subscribe (`linkedPurchaseToken`); mapping is by exact `purchaseToken`, so a re-subscribe under a new token that isn't yet stored is recorded as `skipped`.~~ **Resolved** — the processor now follows the `linkedPurchaseToken` chain and migrates the subscription's stored token forward (see the Google user-mapping section above). The `verify-purchase` (in-app upgrade) path mirrors the same migration.
- ~~No additional Pub/Sub OIDC/shared-secret check is enforced yet; authenticity relies on the Play Developer API re-fetch.~~ **Resolved** — the `/payment/webhooks/google` endpoint now verifies the **OIDC identity token** that a configured Pub/Sub push subscription sends (`Authorization: Bearer <jwt>`): signature against Google's JWKS, `iss = accounts.google.com`, `aud = GOOGLE_PUBSUB_AUDIENCE`, `email = GOOGLE_PUBSUB_SA_EMAIL`, `email_verified = true` (via `google-auth-library`, already a dependency). Enforced when `GOOGLE_PUBSUB_AUDIENCE` is set (invalid/missing → 401); skipped-with-warning when unset so dev/unconfigured setups still work. See **Required env / config** and **Still needs to be set up externally** for the exact settings.
- ~~A late/duplicate store notification could clobber newer subscription state (e.g. a delayed `EXPIRED`/`SUBSCRIPTION_EXPIRED` after a `DID_RENEW`/`RENEWED`).~~ **Resolved** — added an out-of-order **event watermark**. `Subscription.lastEventAt` (new nullable column + migration) stores the authoritative timestamp of the last applied event (Apple `signedDate`, Google `eventTimeMillis`). Before mutating state the processor skips (records `skipped`, still returns 200) any event whose timestamp is `<=` the stored watermark; otherwise it applies the change and advances `lastEventAt` **in the same UPDATE** (atomic). Untimestamped events still apply; the `linkedPurchaseToken` migration and idempotency paths are unaffected.
- Apple authenticity relies on the pinned JWS x5c chain; the fingerprint constant must be verified before production.

## Tests

**96 tests pass in `src/payment`** (was 79; +17 for the two resolved findings). Existing coverage: real generated EC cert chain exercising JWS verify/tamper/root-pin/missing-x5c, Apple + Google type→state mapping, idempotency (duplicate → skipped), malformed-payload 400s, failed-processing records `failed` + rethrows, controller routing, and `linkedPurchaseToken` handling (single/multi-hop migration with depth cap, unknown-chain skipped, cycle-guard, missing-`subscriptionId` short-circuit).

New tests:
- **Out-of-order watermark** (`subscription-webhook.service.spec.ts`): newer event applies and advances `lastEventAt` atomically; stale (older) event is `skipped` with no state regression; duplicate at the exact same timestamp is `skipped`; first event with no prior watermark applies and sets it — for both Apple (`signedDate`) and Google (`eventTimeMillis`, incl. a stale `EXPIRED` after a newer `RENEWED`).
- **Pub/Sub OIDC** (`google-pubsub-verifier.service.spec.ts`, JWKS/`google-auth-library` mocked): valid token from the configured SA passes; bad signature / wrong `aud` / wrong `email` / `email_verified !== true` / missing token / missing Bearer are all rejected (401); audience-unset skips verification with a warning; audience-set-but-SA-unset accepts any Google-verified account. Controller spec asserts it verifies before processing and never calls the service on a rejected token.

`pnpm build`, `pnpm lint`, and `pnpm test -- src/payment` are all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple and Google subscription webhook endpoints with request validation and centralized webhook processing.
  - Implemented Apple signed notification parsing with certificate trust pinning, plus typed decoding.
  - Added subscription webhook idempotency/out-of-order protection using a new `lastEventAt` timestamp.
  - Added Google linked purchase-token migration after successful verification.
- **Bug Fixes**
  - Improved handling of malformed webhook inputs to consistently return client errors.
- **Tests**
  - Expanded Jest coverage for Apple/Google verification, controller routing/auth, idempotency, concurrency, watermark behavior, and linked-token chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

