### PR TITLE
chore(hooks): shared pre-push CodeRabbit review hook

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,19 @@
+# Git hooks
+
+Shared hooks for this repo, enabled via `core.hooksPath` (set automatically by the
+`prepare` script on `pnpm install`).
+
+## pre-push — CodeRabbit local review
+Runs a CodeRabbit review of your changes before each push so issues are caught
+locally instead of on the PR.
+
+- **Advisory by default** — it prints findings but does not block the push.
+- **Make it blocking:** `CODERABBIT_BLOCK=1 git push`
+- **Skip once:** `git push --no-verify`
+- **Requires the CodeRabbit CLI** (the hook no-ops with a hint if it's missing):
+  ```sh
+  curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+  coderabbit auth login
+  ```
+
+If hooks aren't running, enable them manually once: `git config core.hooksPath .githooks`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Local CodeRabbit review before pushing (advisory by default).
+#
+# Requires the CodeRabbit CLI:  https://cli.coderabbit.ai
+#   curl -fsSL https://cli.coderabbit.ai/install.sh | sh && coderabbit auth login
+#
+# Skip once:      git push --no-verify
+# Make blocking:  CODERABBIT_BLOCK=1 git push   (or export it in your shell)
+
+if ! command -v coderabbit >/dev/null 2>&1; then
+  printf '\033[33m[pre-push] CodeRabbit CLI not installed — skipping local review.\033[0m\n'
+  printf '           Install: curl -fsSL https://cli.coderabbit.ai/install.sh | sh && coderabbit auth login\n'
+  exit 0
+fi
+
+printf '\033[36m[pre-push] Running CodeRabbit review on your changes…\033[0m\n'
+coderabbit review --plain
+status=$?
+
+if [ "$status" -ne 0 ] && [ "${CODERABBIT_BLOCK:-0}" = "1" ]; then
+  printf '\033[31m[pre-push] CodeRabbit found issues and CODERABBIT_BLOCK=1 — push aborted. Use --no-verify to override.\033[0m\n'
+  exit 1
+fi
+exit 0

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
Adds a shared **pre-push** hook that runs a local CodeRabbit review so findings are caught before the PR (we'd been missing/ignoring bot comments post-hoc).

- Git-native via `core.hooksPath` (`.githooks/`), auto-enabled by a `prepare` script on install — **no husky dependency**.
- **Advisory by default** (prints findings, doesn't block); `CODERABBIT_BLOCK=1 git push` to block, `--no-verify` to skip.
- Requires the CodeRabbit CLI; the hook **no-ops with an install hint** if it's absent, so it never breaks pushes for anyone who hasn't installed it.

See `.githooks/README.md`. Can replicate to storytime-fe / storytime-mobile once approved.