### PR TITLE
fix: address CodeRabbit findings from #402/#396/#394 (notification + TTS)

### DIFF
--- a/src/notification/notification-scheduler.service.spec.ts
+++ b/src/notification/notification-scheduler.service.spec.ts
@@ -1,0 +1,200 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationSchedulerService } from './notification-scheduler.service';
+import { NotificationService } from './notification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RedisService } from '../redis/redis.service';
+
+const mockPrismaService = {
+  subscription: { findMany: jest.fn() },
+  user: { findMany: jest.fn() },
+  userStoryProgress: { findMany: jest.fn() },
+};
+
+const mockNotificationService = {
+  sendNotification: jest.fn(),
+};
+
+// Redis lock: default to acquiring the lock so the guarded job body runs.
+const mockRedisClient = {
+  set: jest.fn().mockResolvedValue('OK'),
+};
+const mockRedisService = { client: mockRedisClient };
+
+describe('NotificationSchedulerService', () => {
+  let service: NotificationSchedulerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationSchedulerService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: RedisService, useValue: mockRedisService },
+      ],
+    }).compile();
+
+    service = module.get(NotificationSchedulerService);
+    jest.clearAllMocks();
+    mockRedisClient.set.mockResolvedValue('OK');
+    mockNotificationService.sendNotification.mockResolvedValue(undefined);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('cluster guard (single-process execution)', () => {
+    it('skips the job body when the Redis lock is not acquired', async () => {
+      mockRedisClient.set.mockResolvedValueOnce(null);
+
+      await service.sendSubscriptionReminders();
+
+      expect(mockPrismaService.subscription.findMany).not.toHaveBeenCalled();
+      expect(mockNotificationService.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it('acquires a NX/EX lock keyed per job before running', async () => {
+      mockPrismaService.subscription.findMany.mockResolvedValueOnce([]);
+
+      await service.sendSubscriptionReminders();
+
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        'cron-lock:subscriptionReminder',
+        expect.any(String),
+        'EX',
+        expect.any(Number),
+        'NX',
+      );
+    });
+
+    it('skips the run when the lock cannot be reached (Redis error)', async () => {
+      mockRedisClient.set.mockRejectedValueOnce(new Error('redis down'));
+
+      await service.sendSubscriptionReminders();
+
+      expect(mockPrismaService.subscription.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendSubscriptionReminders', () => {
+    it('paginates beyond the first 500 candidates', async () => {
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const firstPage = Array.from({ length: 500 }, (_, i) => ({
+        id: `sub-${i}`,
+        userId: `user-${i}`,
+        plan: 'monthly',
+        endsAt: future,
+      }));
+      const secondPage = [
+        { id: 'sub-500', userId: 'user-500', plan: 'monthly', endsAt: future },
+      ];
+
+      mockPrismaService.subscription.findMany
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      await service.sendSubscriptionReminders();
+
+      expect(mockPrismaService.subscription.findMany).toHaveBeenCalledTimes(2);
+      // Second call must advance the cursor past the last id of page one.
+      expect(mockPrismaService.subscription.findMany.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          cursor: { id: 'sub-499' },
+          skip: 1,
+        }),
+      );
+      // Every candidate across both pages is processed.
+      expect(mockNotificationService.sendNotification).toHaveBeenCalledTimes(
+        501,
+      );
+    });
+
+    it('resolves the plan display name instead of the raw plan key', async () => {
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockPrismaService.subscription.findMany.mockResolvedValueOnce([
+        { id: 'sub-1', userId: 'user-1', plan: 'monthly', endsAt: future },
+      ]);
+
+      await service.sendSubscriptionReminders();
+
+      expect(mockNotificationService.sendNotification).toHaveBeenCalledWith(
+        'SubscriptionReminder',
+        expect.objectContaining({ plan: 'Monthly' }),
+        'user-1',
+      );
+    });
+
+    it('does not log the full user id on failure', async () => {
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockPrismaService.subscription.findMany.mockResolvedValueOnce([
+        {
+          id: 'sub-1',
+          userId: 'abcdef01-2345-6789-abcd-ef0123456789',
+          plan: 'monthly',
+          endsAt: future,
+        },
+      ]);
+      mockNotificationService.sendNotification.mockRejectedValueOnce(
+        new Error('boom'),
+      );
+      const errorSpy = jest
+        .spyOn(
+          (
+            service as unknown as {
+              logger: { error: (...a: unknown[]) => void };
+            }
+          ).logger,
+          'error',
+        )
+        .mockImplementation(() => undefined);
+
+      await service.sendSubscriptionReminders();
+
+      const logged = String(errorSpy.mock.calls[0][0]);
+      expect(logged).toContain('abcdef01');
+      expect(logged).not.toContain('abcdef01-2345-6789-abcd-ef0123456789');
+    });
+  });
+
+  describe('sendWeMissYouReminders', () => {
+    it('excludes soft-deleted progress from the inactivity query', async () => {
+      mockPrismaService.user.findMany.mockResolvedValueOnce([]);
+
+      await service.sendWeMissYouReminders();
+
+      const where = mockPrismaService.user.findMany.mock.calls[0][0].where;
+      expect(where.userStoryProgress).toEqual({
+        some: { isDeleted: false },
+      });
+      expect(where.NOT.userStoryProgress.some).toEqual(
+        expect.objectContaining({ isDeleted: false }),
+      );
+    });
+  });
+
+  describe('sendIncompleteStoryReminders', () => {
+    it('paginates beyond the first 500 candidates', async () => {
+      const firstPage = Array.from({ length: 500 }, (_, i) => ({
+        userId: `user-${i}`,
+        story: { title: 'A Story' },
+      }));
+      const secondPage = [{ userId: 'user-500', story: { title: 'A Story' } }];
+
+      mockPrismaService.userStoryProgress.findMany
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      await service.sendIncompleteStoryReminders();
+
+      expect(
+        mockPrismaService.userStoryProgress.findMany,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockPrismaService.userStoryProgress.findMany.mock.calls[1][0].skip,
+      ).toBe(500);
+      expect(mockNotificationService.sendNotification).toHaveBeenCalledTimes(
+        501,
+      );
+    });
+  });
+});

--- a/src/notification/notification-scheduler.service.ts
+++ b/src/notification/notification-scheduler.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service';
+import { RedisService } from '../redis/redis.service';
+import { PLANS } from '../subscription/subscription.constants';
 import { NotificationService } from './notification.service';
 
 /**
@@ -25,6 +27,16 @@ const BATCH_LIMIT = 500;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/**
+ * How long a per-job cron lock is held (seconds). Only needs to outlast the
+ * spread between cluster workers firing the same @Cron plus a normal job run,
+ * and must stay well below the daily interval so the next scheduled run is free.
+ */
+const CRON_LOCK_TTL_SECONDS = 10 * 60;
+
+/** Truncate a persistent user id before logging so full identifiers never leak. */
+const maskUserId = (id: string): string => id.substring(0, 8);
+
 @Injectable()
 export class NotificationSchedulerService {
   private readonly logger = new Logger(NotificationSchedulerService.name);
@@ -32,7 +44,52 @@ export class NotificationSchedulerService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly notificationService: NotificationService,
+    private readonly redis: RedisService,
   ) {}
+
+  /**
+   * Cluster guard. In PM2 cluster mode every worker instance registers and
+   * fires the same @Cron, so an unguarded handler dispatches each reminder once
+   * per instance. A short-lived Redis lock (SET NX EX) lets exactly one worker
+   * win the tick; the others no-op. The lock is intentionally NOT released on
+   * completion — it expires via TTL, which also prevents a late/clock-skewed
+   * worker from re-running the same tick. The daily interval is far larger than
+   * the TTL, so the next scheduled run always finds the lock free.
+   */
+  private async runExclusive(
+    jobName: string,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    const lockKey = `cron-lock:${jobName}`;
+    let acquired: string | null = null;
+    try {
+      acquired = await this.redis.client.set(
+        lockKey,
+        String(process.pid),
+        'EX',
+        CRON_LOCK_TTL_SECONDS,
+        'NX',
+      );
+    } catch (err) {
+      // If Redis is unreachable we cannot coordinate; skip rather than risk
+      // fanning out duplicate notifications across every worker.
+      this.logger.error(
+        `${jobName}: failed to acquire cron lock, skipping run: ${
+          (err as Error).message
+        }`,
+      );
+      return;
+    }
+
+    if (acquired !== 'OK') {
+      this.logger.debug(
+        `${jobName}: another instance holds the cron lock, skipping`,
+      );
+      return;
+    }
+
+    await run();
+  }
 
   /**
    * SubscriptionReminder — daily at 09:00.
@@ -41,47 +98,69 @@ export class NotificationSchedulerService {
    */
   @Cron('0 9 * * *', { name: 'subscriptionReminder' })
   async sendSubscriptionReminders(): Promise<void> {
+    await this.runExclusive('subscriptionReminder', () =>
+      this.runSubscriptionReminders(),
+    );
+  }
+
+  private async runSubscriptionReminders(): Promise<void> {
     const now = new Date();
     const windowEnd = new Date(
       now.getTime() + SUBSCRIPTION_REMINDER_DAYS * MS_PER_DAY,
     );
 
-    const subscriptions = await this.prisma.subscription.findMany({
-      where: {
-        status: 'active',
-        isDeleted: false,
-        endsAt: { gte: now, lte: windowEnd },
-      },
-      select: { userId: true, plan: true, endsAt: true },
-      take: BATCH_LIMIT,
-    });
-
     let sent = 0;
     let failed = 0;
-    for (const sub of subscriptions) {
-      if (!sub.endsAt) continue;
-      const daysLeft = Math.max(
-        1,
-        Math.ceil((sub.endsAt.getTime() - now.getTime()) / MS_PER_DAY),
-      );
-      try {
-        await this.notificationService.sendNotification(
-          'SubscriptionReminder',
-          { plan: sub.plan, daysLeft },
-          sub.userId,
+    let candidates = 0;
+    let cursor: string | undefined;
+
+    // Paginate by id cursor so every due subscription is processed, not just
+    // the first BATCH_LIMIT candidates.
+    for (;;) {
+      const subscriptions = await this.prisma.subscription.findMany({
+        where: {
+          status: 'active',
+          isDeleted: false,
+          endsAt: { gte: now, lte: windowEnd },
+        },
+        select: { id: true, userId: true, plan: true, endsAt: true },
+        orderBy: { id: 'asc' },
+        take: BATCH_LIMIT,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      });
+
+      if (subscriptions.length === 0) break;
+      candidates += subscriptions.length;
+
+      for (const sub of subscriptions) {
+        if (!sub.endsAt) continue;
+        const daysLeft = Math.max(
+          1,
+          Math.ceil((sub.endsAt.getTime() - now.getTime()) / MS_PER_DAY),
         );
-        sent++;
-      } catch (err) {
-        failed++;
-        this.logger.error(
-          `SubscriptionReminder failed for user ${sub.userId}: ${
-            (err as Error).message
-          }`,
-        );
+        try {
+          await this.notificationService.sendNotification(
+            'SubscriptionReminder',
+            { plan: PLANS[sub.plan]?.display ?? sub.plan, daysLeft },
+            sub.userId,
+          );
+          sent++;
+        } catch (err) {
+          failed++;
+          this.logger.error(
+            `SubscriptionReminder failed for user ${maskUserId(sub.userId)}: ${
+              (err as Error).message
+            }`,
+          );
+        }
       }
+
+      if (subscriptions.length < BATCH_LIMIT) break;
+      cursor = subscriptions[subscriptions.length - 1].id;
     }
+
     this.logger.log(
-      `SubscriptionReminder: ${sent} sent, ${failed} failed (${subscriptions.length} candidates)`,
+      `SubscriptionReminder: ${sent} sent, ${failed} failed (${candidates} candidates)`,
     );
   }
 
@@ -93,6 +172,10 @@ export class NotificationSchedulerService {
    */
   @Cron('0 10 * * *', { name: 'weMissYou' })
   async sendWeMissYouReminders(): Promise<void> {
+    await this.runExclusive('weMissYou', () => this.runWeMissYouReminders());
+  }
+
+  private async runWeMissYouReminders(): Promise<void> {
     const cutoff = new Date(Date.now() - INACTIVITY_DAYS * MS_PER_DAY);
 
     let sent = 0;
@@ -107,11 +190,13 @@ export class NotificationSchedulerService {
           isDeleted: false,
           isSuspended: false,
           name: { not: null },
-          // Has read at least once...
-          userStoryProgress: { some: {} },
+          // Has read at least once (ignoring soft-deleted library records)...
+          userStoryProgress: { some: { isDeleted: false } },
           // ...but nothing accessed within the inactivity window.
           NOT: {
-            userStoryProgress: { some: { lastAccessed: { gte: cutoff } } },
+            userStoryProgress: {
+              some: { isDeleted: false, lastAccessed: { gte: cutoff } },
+            },
           },
         },
         select: { id: true, name: true },
@@ -134,7 +219,9 @@ export class NotificationSchedulerService {
         } catch (err) {
           failed++;
           this.logger.error(
-            `WeMissYou failed for user ${user.id}: ${(err as Error).message}`,
+            `WeMissYou failed for user ${maskUserId(user.id)}: ${
+              (err as Error).message
+            }`,
           );
         }
       }
@@ -157,48 +244,71 @@ export class NotificationSchedulerService {
    */
   @Cron('0 11 * * *', { name: 'incompleteStoryReminder' })
   async sendIncompleteStoryReminders(): Promise<void> {
+    await this.runExclusive('incompleteStoryReminder', () =>
+      this.runIncompleteStoryReminders(),
+    );
+  }
+
+  private async runIncompleteStoryReminders(): Promise<void> {
     const cutoff = new Date(
       Date.now() - INCOMPLETE_STORY_STALE_DAYS * MS_PER_DAY,
     );
 
-    const progressRows = await this.prisma.userStoryProgress.findMany({
-      where: {
-        completed: false,
-        isDeleted: false,
-        lastAccessed: { lt: cutoff },
-        story: { isDeleted: false },
-        user: { isDeleted: false, isSuspended: false },
-      },
-      distinct: ['userId'],
-      orderBy: [{ userId: 'asc' }, { lastAccessed: 'desc' }],
-      select: {
-        userId: true,
-        story: { select: { title: true } },
-      },
-      take: BATCH_LIMIT,
-    });
-
     let sent = 0;
     let failed = 0;
-    for (const row of progressRows) {
-      try {
-        await this.notificationService.sendNotification(
-          'IncompleteStoryReminder',
-          { storyTitle: row.story.title },
-          row.userId,
-        );
-        sent++;
-      } catch (err) {
-        failed++;
-        this.logger.error(
-          `IncompleteStoryReminder failed for user ${row.userId}: ${
-            (err as Error).message
-          }`,
-        );
+    let candidates = 0;
+    let offset = 0;
+
+    // `distinct: ['userId']` yields at most one row per user. userId is not a
+    // standalone unique key, so cursor pagination isn't available here; page by
+    // a stable offset over the deterministic userId ordering instead, so every
+    // eligible user is reminded rather than only the first BATCH_LIMIT.
+    for (;;) {
+      const progressRows = await this.prisma.userStoryProgress.findMany({
+        where: {
+          completed: false,
+          isDeleted: false,
+          lastAccessed: { lt: cutoff },
+          story: { isDeleted: false },
+          user: { isDeleted: false, isSuspended: false },
+        },
+        distinct: ['userId'],
+        orderBy: [{ userId: 'asc' }, { lastAccessed: 'desc' }],
+        select: {
+          userId: true,
+          story: { select: { title: true } },
+        },
+        take: BATCH_LIMIT,
+        skip: offset,
+      });
+
+      if (progressRows.length === 0) break;
+      candidates += progressRows.length;
+
+      for (const row of progressRows) {
+        try {
+          await this.notificationService.sendNotification(
+            'IncompleteStoryReminder',
+            { storyTitle: row.story.title },
+            row.userId,
+          );
+          sent++;
+        } catch (err) {
+          failed++;
+          this.logger.error(
+            `IncompleteStoryReminder failed for user ${maskUserId(
+              row.userId,
+            )}: ${(err as Error).message}`,
+          );
+        }
       }
+
+      if (progressRows.length < BATCH_LIMIT) break;
+      offset += BATCH_LIMIT;
     }
+
     this.logger.log(
-      `IncompleteStoryReminder: ${sent} sent, ${failed} failed (${progressRows.length} candidates)`,
+      `IncompleteStoryReminder: ${sent} sent, ${failed} failed (${candidates} candidates)`,
     );
   }
 
@@ -210,6 +320,12 @@ export class NotificationSchedulerService {
    */
   @Cron('0 18 * * *', { name: 'dailyListeningReminder' })
   async sendDailyListeningReminders(): Promise<void> {
+    await this.runExclusive('dailyListeningReminder', () =>
+      this.runDailyListeningReminders(),
+    );
+  }
+
+  private async runDailyListeningReminders(): Promise<void> {
     let sent = 0;
     let failed = 0;
     let candidates = 0;
@@ -242,7 +358,7 @@ export class NotificationSchedulerService {
         } catch (err) {
           failed++;
           this.logger.error(
-            `DailyListeningReminder failed for user ${user.id}: ${
+            `DailyListeningReminder failed for user ${maskUserId(user.id)}: ${
               (err as Error).message
             }`,
           );

--- a/src/notification/notification.registry.spec.ts
+++ b/src/notification/notification.registry.spec.ts
@@ -1,0 +1,28 @@
+import { NotificationRegistry } from './notification.registry';
+
+describe('NotificationRegistry — PaymentSuccess', () => {
+  const entry = NotificationRegistry.PaymentSuccess;
+
+  it('requires a currency field', () => {
+    expect(entry.validate({ amount: 4.99, plan: 'Monthly' })).toBe(
+      'Currency is required',
+    );
+  });
+
+  it('passes validation when currency is present', () => {
+    expect(
+      entry.validate({ amount: 4.99, currency: 'USD', plan: 'Monthly' }),
+    ).toBeNull();
+  });
+
+  it('renders the currency alongside the amount', async () => {
+    const message = await entry.getTemplate({
+      amount: 4.99,
+      currency: 'EUR',
+      plan: 'Monthly',
+    });
+    expect(message).toContain('EUR');
+    expect(message).toContain('4.99');
+    expect(message).toContain('Monthly');
+  });
+});

--- a/src/notification/notification.registry.ts
+++ b/src/notification/notification.registry.ts
@@ -219,12 +219,13 @@ export const NotificationRegistry: Record<
     validate: (data) => {
       if (data.amount === undefined || data.amount === null)
         return 'Amount is required';
+      if (!data.currency) return 'Currency is required';
       if (!data.plan) return 'Plan is required';
       return null;
     },
     getTemplate: (data) => {
       return Promise.resolve(
-        `Your payment of ${data.amount} for the ${data.plan} plan was successful.`,
+        `Your payment of ${data.currency} ${data.amount} for the ${data.plan} plan was successful.`,
       );
     },
   },

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -153,6 +153,9 @@ export class NotificationService {
     data?: Record<string, unknown>,
   ): Promise<{ delivered: number; failed: number }> {
     const BATCH = 500;
+    // Max concurrent in-app sends per sub-chunk — keeps fan-out fast without
+    // exhausting the DB connection pool.
+    const BROADCAST_CONCURRENCY = 50;
     let cursor: string | undefined;
     let delivered = 0;
     let failed = 0;
@@ -167,27 +170,38 @@ export class NotificationService {
       if (users.length === 0) {
         break;
       }
-      for (const user of users) {
-        try {
-          const result = await this.inAppProvider.send({
-            userId: user.id,
-            category: PrismaCategory.SYSTEM_ALERT,
-            title,
-            body,
-            data,
-          });
-          if (result.success) {
+      // Fan out sends concurrently, but in bounded sub-chunks so a large page
+      // can't open thousands of simultaneous DB/provider calls and exhaust the
+      // connection pool.
+      for (let i = 0; i < users.length; i += BROADCAST_CONCURRENCY) {
+        const slice = users.slice(i, i + BROADCAST_CONCURRENCY);
+        const results = await Promise.all(
+          slice.map(async (user) => {
+            try {
+              const result = await this.inAppProvider.send({
+                userId: user.id,
+                category: PrismaCategory.SYSTEM_ALERT,
+                title,
+                body,
+                data,
+              });
+              return result.success;
+            } catch (error) {
+              this.logger.warn(
+                `In-app broadcast failed for user ${user.id.substring(0, 8)}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+              return false;
+            }
+          }),
+        );
+        for (const success of results) {
+          if (success) {
             delivered++;
           } else {
             failed++;
           }
-        } catch (error) {
-          failed++;
-          this.logger.warn(
-            `In-app broadcast failed for user ${user.id.substring(0, 8)}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
         }
       }
       cursor = users[users.length - 1].id;

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -348,6 +348,7 @@ export class PaymentService {
       'PaymentSuccess',
       {
         amount: transaction.amount,
+        currency: transaction.currency ?? 'USD',
         plan: PLANS[plan]?.display ?? plan,
       },
       userId,

--- a/src/voice/queue/tts-batch-queue.service.spec.ts
+++ b/src/voice/queue/tts-batch-queue.service.spec.ts
@@ -1,0 +1,49 @@
+import { TtsBatchQueueService } from './tts-batch-queue.service';
+import { TtsBatchJobData } from './tts-batch-job.interface';
+
+const makePipeline = () => {
+  const pipeline = {
+    hset: jest.fn().mockReturnThis(),
+    sadd: jest.fn().mockReturnThis(),
+    srem: jest.fn().mockReturnThis(),
+    expire: jest.fn().mockReturnThis(),
+    del: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([]),
+  };
+  return pipeline;
+};
+
+describe('TtsBatchQueueService', () => {
+  let queue: { add: jest.Mock };
+  let redis: { pipeline: jest.Mock; del: jest.Mock; quit: jest.Mock };
+  let service: TtsBatchQueueService;
+
+  beforeEach(() => {
+    queue = { add: jest.fn().mockResolvedValue(undefined) };
+    redis = {
+      pipeline: jest.fn(() => makePipeline()),
+      del: jest.fn().mockResolvedValue(undefined),
+      quit: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new TtsBatchQueueService(queue as never, redis as never);
+  });
+
+  const original: TtsBatchJobData = {
+    batchJobId: 'batch-abc',
+    storyId: 'story-1',
+    voiceId: 'voice-1',
+    userId: 'user-1',
+    isPremium: false,
+    provider: 'elevenlabs',
+    paragraphs: [{ index: 0, text: 'hi', hash: 'h0' }],
+    totalParagraphs: 1,
+  };
+
+  it('builds a retry job id without the reserved BullMQ colon separator', async () => {
+    await service.queueRetryBatch(original, original.paragraphs, 1);
+
+    const addOptions = queue.add.mock.calls[0][2];
+    expect(addOptions.jobId).not.toContain(':');
+    expect(addOptions.jobId).toBe('batch-abc-retry-1');
+  });
+});

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -106,7 +106,10 @@ export class TtsBatchQueueService implements OnModuleDestroy {
       jobData,
       {
         ...TTS_BATCH_QUEUE_OPTIONS,
-        jobId: `${batchJobId}:retry:${generation}`,
+        // BullMQ (>=5.61) rejects ':' in custom job IDs — it is the reserved
+        // internal key separator — so use hyphens or the enqueue throws and the
+        // retry is never scheduled.
+        jobId: `${batchJobId}-retry-${generation}`,
         delay: TTS_BATCH_RETRY_DELAY_MS,
       },
     );

--- a/src/voice/queue/tts-batch.processor.spec.ts
+++ b/src/voice/queue/tts-batch.processor.spec.ts
@@ -1,0 +1,125 @@
+import { Job } from 'bullmq';
+import { TtsBatchProcessor } from './tts-batch.processor';
+import { TtsBatchJobData } from './tts-batch-job.interface';
+
+const makeJob = (
+  overrides: Partial<TtsBatchJobData> = {},
+): Job<TtsBatchJobData> => {
+  const data: TtsBatchJobData = {
+    batchJobId: 'batch-1',
+    storyId: 'story-1',
+    voiceId: 'voice-1',
+    userId: 'user-1',
+    isPremium: false,
+    provider: 'elevenlabs',
+    paragraphs: [{ index: 0, text: 'hello', hash: 'h0' }],
+    totalParagraphs: 1,
+    ...overrides,
+  };
+  return { data } as unknown as Job<TtsBatchJobData>;
+};
+
+describe('TtsBatchProcessor', () => {
+  let processor: TtsBatchProcessor;
+  let queueService: {
+    markParagraphCompleted: jest.Mock;
+    markParagraphFailed: jest.Mock;
+    queueRetryBatch: jest.Mock;
+    getBatchStatus: jest.Mock;
+    updateBatchMeta: jest.Mock;
+  };
+  let ttsService: { generateSingleParagraphTTS: jest.Mock };
+
+  beforeEach(() => {
+    queueService = {
+      markParagraphCompleted: jest.fn().mockResolvedValue(undefined),
+      markParagraphFailed: jest.fn().mockResolvedValue(undefined),
+      queueRetryBatch: jest.fn().mockResolvedValue(undefined),
+      // null → processor falls back to this run's local counters.
+      getBatchStatus: jest.fn().mockResolvedValue(null),
+      updateBatchMeta: jest.fn().mockResolvedValue(undefined),
+    };
+    ttsService = { generateSingleParagraphTTS: jest.fn() };
+
+    processor = new TtsBatchProcessor(
+      queueService as never,
+      ttsService as never,
+    );
+    // Skip real backoff delays.
+    jest
+      .spyOn(processor as unknown as { delay: () => Promise<void> }, 'delay')
+      .mockResolvedValue(undefined);
+  });
+
+  describe('transient-only retry', () => {
+    it('does NOT retry the same provider on a non-transient (4xx) error', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
+
+      const result = await processor.process(makeJob({ totalParagraphs: 1 }));
+
+      // 3 providers in the chain, one attempt each — no same-provider retries.
+      expect(ttsService.generateSingleParagraphTTS).toHaveBeenCalledTimes(3);
+      expect(result.failedCount).toBe(1);
+    });
+
+    it('retries the same provider on a transient (5xx) error', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 503 });
+
+      await processor.process(makeJob({ totalParagraphs: 1 }));
+
+      // 3 providers x 2 attempts each = 6 calls.
+      expect(ttsService.generateSingleParagraphTTS).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('duplicate outcome counting', () => {
+    it('counts every duplicate index on success', async () => {
+      ttsService.generateSingleParagraphTTS.mockResolvedValue({
+        audioUrl: 'https://audio/0',
+      });
+
+      const result = await processor.process(
+        makeJob({
+          paragraphs: [
+            { index: 0, text: 'hi', hash: 'h0', duplicateIndices: [1, 2] },
+          ],
+          totalParagraphs: 3,
+        }),
+      );
+
+      expect(queueService.markParagraphCompleted).toHaveBeenCalledTimes(3);
+      expect(result.completedCount).toBe(3);
+    });
+
+    it('counts every duplicate index on failure', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
+
+      const result = await processor.process(
+        makeJob({
+          paragraphs: [
+            { index: 0, text: 'hi', hash: 'h0', duplicateIndices: [1, 2] },
+          ],
+          totalParagraphs: 3,
+          // Cap generation so no self-heal round is scheduled.
+          retryGeneration: 2,
+        }),
+      );
+
+      expect(queueService.markParagraphFailed).toHaveBeenCalledTimes(3);
+      expect(result.failedCount).toBe(3);
+    });
+  });
+
+  describe('self-heal scheduling failures', () => {
+    it('propagates a queueRetryBatch failure instead of swallowing it', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 503 });
+      queueService.queueRetryBatch.mockRejectedValue(
+        new Error('redis TTL write failed'),
+      );
+
+      await expect(
+        processor.process(makeJob({ totalParagraphs: 1, retryGeneration: 0 })),
+      ).rejects.toThrow('redis TTL write failed');
+    });
+  });
+});

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -45,18 +45,44 @@ export class TtsBatchProcessor extends WorkerHost {
     super();
   }
 
+  /** Extract an HTTP status code from a provider error, if present. */
+  private extractHttpStatus(reason: unknown): number | undefined {
+    if (!reason || typeof reason !== 'object') return undefined;
+    const err = reason as Record<string, unknown>;
+    if (typeof err.status === 'number') return err.status;
+    if (typeof err.statusCode === 'number') return err.statusCode;
+    // Axios errors store status on response.status
+    const response = err.response as Record<string, unknown> | undefined;
+    if (response && typeof response.status === 'number') return response.status;
+    return undefined;
+  }
+
   /** Check if a rejection reason indicates quota/payment exhaustion */
   private isQuotaError(reason: unknown): boolean {
     if (reason instanceof QuotaExhaustedError) return true;
-    if (reason && typeof reason === 'object') {
-      const err = reason as Record<string, unknown>;
-      // Raw HTTP 402 from providers that don't wrap in QuotaExhaustedError
-      if (err.status === 402 || err.statusCode === 402) return true;
-      // Axios errors store status on response.status
-      const response = err.response as Record<string, unknown> | undefined;
-      if (response?.status === 402) return true;
+    return this.extractHttpStatus(reason) === 402;
+  }
+
+  /**
+   * Decide whether an error is worth a same-provider retry. Permanent client
+   * errors — bad auth, invalid/unsupported input, etc. (HTTP 4xx other than
+   * rate-limiting) — will fail identically on retry, so we cascade immediately.
+   * Everything else (network blips, timeouts, 5xx, 429 rate limits, and
+   * unclassified provider errors) is treated as potentially transient. Quota
+   * errors are handled separately by isQuotaError and are never "transient".
+   */
+  private isTransientError(reason: unknown): boolean {
+    if (this.isQuotaError(reason)) return false;
+    const status = this.extractHttpStatus(reason);
+    if (
+      status !== undefined &&
+      status >= 400 &&
+      status < 500 &&
+      status !== 429
+    ) {
+      return false;
     }
-    return false;
+    return true;
   }
 
   /** Resolve duplicate indices for a paragraph from the original job data */
@@ -156,6 +182,17 @@ export class TtsBatchProcessor extends WorkerHost {
 
             const errorMessage =
               err instanceof Error ? err.message : String(err);
+
+            if (!this.isTransientError(err)) {
+              // Permanent failure (auth/validation/unsupported input) — a
+              // same-provider retry would fail identically, so skip the backoff
+              // and cascade straight to the next provider.
+              this.logger.warn(
+                `TTS batch ${batchJobId}: non-transient failure on ${activeProvider} for paragraph ${index} — ${errorMessage}; cascading to fallback without retry`,
+              );
+              break; // move to the next provider in the chain
+            }
+
             if (attempt < MAX_ATTEMPTS_PER_PROVIDER) {
               this.logger.warn(
                 `TTS batch ${batchJobId}: transient failure on ${activeProvider} for paragraph ${index} (attempt ${attempt}/${MAX_ATTEMPTS_PER_PROVIDER}) — ${errorMessage}; retrying`,
@@ -194,7 +231,10 @@ export class TtsBatchProcessor extends WorkerHost {
                 result.value.audioUrl,
               );
             }
-            completedCount++;
+            // A generated paragraph stands in for every duplicate position, so
+            // count each persisted index — otherwise the counters disagree with
+            // the completed/failed sets in Redis whenever duplicates exist.
+            completedCount += allIndices.length;
           } catch (redisErr) {
             this.logger.error(
               `TTS batch ${batchJobId}: Redis write failed for completed paragraph ${paragraphIndex}`,
@@ -222,7 +262,10 @@ export class TtsBatchProcessor extends WorkerHost {
             );
             throw redisErr;
           }
-          failedCount++;
+          // Count every duplicate position this paragraph was persisted under,
+          // mirroring the completed path so the counters stay consistent with
+          // the failed set in Redis.
+          failedCount += allIndices.length;
           failedThisRun.push(chunk[j]);
         }
       }
@@ -243,10 +286,14 @@ export class TtsBatchProcessor extends WorkerHost {
           `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
         );
       } catch (retryErr) {
+        // queueRetryBatch performs Redis TTL writes; if it fails the retry was
+        // NOT safely scheduled. Rethrow so the batch fails loudly instead of
+        // appearing finalized with paragraphs that will never self-heal.
         this.logger.error(
           `TTS batch ${batchJobId}: failed to schedule self-heal retry`,
           retryErr,
         );
+        throw retryErr;
       }
     }
 


### PR DESCRIPTION
Cleanup PR addressing unresolved CodeRabbit review findings on the already-merged PRs #402, #396, and #394. No behavior change beyond the fixes below; not for deploy on its own.

## PR #402 — `src/notification/notification.service.ts`
- **Broadcast fan-out (Major, perf):** `broadcastInAppToAllUsers` now sends each 500-user page concurrently in bounded sub-chunks of 50 (`Promise.all`) instead of a fully sequential loop, keeping the admin request fast without exhausting the DB/provider connection pool. Counters and per-user warnings preserved.

## PR #396 — `src/notification/notification-scheduler.service.ts` (+ registry/payment)
- **Cluster duplicate execution (Major, stability):** every `@Cron` now runs under a Redis `SET NX EX` lock (`runExclusive`) so only one PM2 cluster worker dispatches each reminder; the lock expires via TTL rather than being released, preventing late/skewed re-runs.
- **Pagination beyond 500 (Major):** subscription reminders now cursor-paginate by `id`; incomplete-story reminders offset-paginate over the `distinct: ['userId']` result set (userId isn't a standalone unique key, so cursor pagination isn't available). WeMissYou / DailyListening were already paginated.
- **Plan display name:** subscription reminders send `PLANS[sub.plan]?.display ?? sub.plan`.
- **Security logging:** failure logs mask user ids to the first 8 chars.
- **Soft-deleted progress:** WeMissYou inactivity query filters `userStoryProgress` on `isDeleted: false` in both the positive and `NOT` recent-activity conditions.
- **Currency (PaymentSuccess contract):** `notification.registry.ts` now requires and renders `currency`; `payment.service.ts` passes `transaction.currency` in the payload (single-line addition).

## PR #394 — `src/voice/queue/`
- **Transient-only retry (Major):** new `isTransientError` classifier; same-provider retries only for transient errors (network/timeout/5xx/429). Permanent 4xx (auth/validation/unsupported input) cascade immediately with no backoff.
- **Duplicate-outcome counting (Major):** `completedCount`/`failedCount` increment by `allIndices.length` so counters agree with the Redis completed/failed sets when duplicates exist.
- **Self-heal propagation (Major):** a failing `queueRetryBatch` now rethrows so the batch fails loudly instead of appearing finalized.
- **BullMQ job id:** retry job id uses `-` instead of the reserved `:` separator (BullMQ >=5.61 rejects colons).

## Tests
Added `*.spec.ts` for the scheduler (lock, pagination >500, plan display, id masking, soft-delete filter), registry (currency validate/render), TTS processor (transient-only retry, duplicate counting, self-heal propagation), and queue service (colon-free job id). Relevant suites pass.

## Verification
- `pnpm build`: clean
- `pnpm lint`: changed files clean (pre-existing false-positive `prefer-const` on `src/main.ts` from the reverted deps bump on `develop-v1.2.0` is unrelated and would break the code if "fixed").
- `pnpm test -- src/notification src/voice`: green (58 tests).