### PR TITLE
fix(payment): atomic CAS for webhook watermark & linked-token migration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -492,9 +492,15 @@ model Subscription {
   purchaseToken String? // token from the platform
   // Out-of-order delivery protection: the authoritative timestamp of the most
   // recent store webhook applied to this row (Apple signedDate / Google
-  // eventTimeMillis). A later event whose timestamp is <= this is stale and is
-  // skipped so it cannot clobber newer state (e.g. a delayed EXPIRED after a
-  // DID_RENEW). Nullable so pre-existing rows and untimestamped events work.
+  // eventTimeMillis). A later event is stale ONLY when its timestamp is strictly
+  // less than this watermark; it is then skipped so it cannot clobber newer state
+  // (e.g. a delayed EXPIRED after a DID_RENEW). Equal timestamps APPLY, not skip:
+  // two DISTINCT notifications can share a millisecond, and genuine duplicates are
+  // already handled by the WebhookEvent (platform, externalEventId) idempotency
+  // layer, so a same-instant event reaching the watermark is a distinct one that
+  // must be processed in arrival order. The guard is enforced as a compare-and-swap
+  // inside the update (WHERE lastEventAt IS NULL OR lastEventAt <= eventAt), never a
+  // read-then-write. Nullable so pre-existing rows and untimestamped events work.
   lastEventAt   DateTime?
   // SOFT DELETE FIELDS
   isDeleted     Boolean   @default(false)

--- a/src/payment/apple-notification.spec.ts
+++ b/src/payment/apple-notification.spec.ts
@@ -252,9 +252,16 @@ describeIf('AppleVerificationService.parseSignedNotification', () => {
       data: { ...notificationPayload.data, bundleId: 'com.evil.other' },
     });
 
-    expect(() => scoped.parseSignedNotification(signedPayload)).toThrow(
-      /bundleId/i,
-    );
+    // Assert both the message AND the HTTP status (400) so this cannot silently
+    // regress to a 500 Internal Server Error.
+    try {
+      scoped.parseSignedNotification(signedPayload);
+      throw new Error('expected parseSignedNotification to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(400);
+      expect((err as HttpException).message).toMatch(/bundleId/i);
+    }
   });
 });
 
@@ -286,8 +293,15 @@ describe('AppleVerificationService.parseSignedNotification malformed header', ()
     }
   });
 
-  it('rejects a JWS whose header decodes to an array', () => {
+  it('rejects a JWS whose header decodes to an array (400)', () => {
     const jws = `${b64('[]')}.${b64('{}')}.${b64('sig')}`;
-    expect(() => service.parseSignedNotification(jws)).toThrow(HttpException);
+    try {
+      service.parseSignedNotification(jws);
+      throw new Error('expected parseSignedNotification to throw');
+    } catch (err) {
+      // Assert the HTTP status (400) so a regression to 500 is caught.
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(400);
+    }
   });
 });

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -15,7 +15,12 @@ type MockPrismaService = {
     create: jest.Mock;
     findFirst: jest.Mock;
   };
-  subscription: { findFirst: jest.Mock; create: jest.Mock; update: jest.Mock };
+  subscription: {
+    findFirst: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
 };
 
 const createMockPrismaService = (): MockPrismaService => ({
@@ -23,7 +28,12 @@ const createMockPrismaService = (): MockPrismaService => ({
     create: jest.fn(),
     findFirst: jest.fn(),
   },
-  subscription: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+  subscription: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+  },
 });
 
 describe('PaymentService', () => {
@@ -193,9 +203,11 @@ describe('PaymentService', () => {
       const result = await service.verifyPurchase(userId, dto);
 
       expect(result.success).toBe(true);
-      // Explicit migration update targets the same row with the new token.
-      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
-        where: { id: 'sub-1' },
+      // Explicit migration is a compare-and-swap: the token match is folded into
+      // the write, guarded on the still-stored old token so a concurrent
+      // replacement cannot mis-map the row.
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { id: 'sub-1', purchaseToken: 'old-google-token' },
         data: { purchaseToken: 'new-google-token' },
       });
       // Never creates a second subscription row.

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PaymentService } from './payment.service';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '@/prisma/prisma.service';
 import { GoogleVerificationService } from './google-verification.service';
@@ -211,6 +215,122 @@ describe('PaymentService', () => {
         data: { purchaseToken: 'new-google-token' },
       });
       // Never creates a second subscription row.
+      expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
+    });
+
+    it('does NOT clobber a concurrently-installed DIFFERENT token (CAS conflict)', async () => {
+      const userId = 'user-1';
+      const dto = {
+        platform: 'google' as const,
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'new-google-token',
+      };
+      const now = new Date();
+
+      mockGoogleVerification.verify.mockResolvedValue({
+        success: true,
+        isSubscription: true,
+        platformTxId: 'GPA.5678',
+        amount: 4.99,
+        currency: 'USD',
+        expirationTime: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        linkedPurchaseToken: 'old-google-token',
+        metadata: { acknowledgementState: 1 },
+      });
+
+      // First read still sees the linked (old) token -> migration is attempted.
+      // The CAS updateMany affects zero rows because a concurrent delivery
+      // already swapped the row to a DIFFERENT token; the re-read reveals that
+      // winning token.
+      mockPrisma.subscription.findFirst
+        .mockResolvedValueOnce({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          purchaseToken: 'old-google-token',
+        })
+        .mockResolvedValue({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          purchaseToken: 'concurrent-winner-token',
+        });
+      mockPrisma.subscription.updateMany.mockResolvedValue({ count: 0 });
+
+      // The delivery must abort so the concurrent winner is preserved.
+      await expect(service.verifyPurchase(userId, dto)).rejects.toThrow(
+        ConflictException,
+      );
+
+      // Only the migration CAS was attempted (count 0). The flow never reached
+      // the subscription upsert, so the winning token is never overwritten.
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { id: 'sub-1', purchaseToken: 'old-google-token' },
+        data: { purchaseToken: 'new-google-token' },
+      });
+      expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
+    });
+
+    it('treats a zero-row CAS as success when the row already holds OUR token (idempotent repeat)', async () => {
+      const userId = 'user-1';
+      const dto = {
+        platform: 'google' as const,
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'new-google-token',
+      };
+      const now = new Date();
+
+      mockGoogleVerification.verify.mockResolvedValue({
+        success: true,
+        isSubscription: true,
+        platformTxId: 'GPA.5678',
+        amount: 4.99,
+        currency: 'USD',
+        expirationTime: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        linkedPurchaseToken: 'old-google-token',
+        metadata: { acknowledgementState: 1 },
+      });
+
+      // First read sees the old token; the CAS misses because an identical
+      // concurrent delivery already migrated the row to OUR new token. The
+      // re-read confirms it holds newToken, so this is an idempotent repeat and
+      // the flow proceeds to a successful result.
+      mockPrisma.subscription.findFirst
+        .mockResolvedValueOnce({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          purchaseToken: 'old-google-token',
+        })
+        .mockResolvedValue({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          startedAt: now,
+          endsAt: now,
+          purchaseToken: 'new-google-token',
+        });
+      // Migration CAS misses (0); subsequent upsert guard matches (1).
+      mockPrisma.subscription.updateMany
+        .mockResolvedValueOnce({ count: 0 })
+        .mockResolvedValue({ count: 1 });
+      mockPrisma.paymentTransaction.create.mockResolvedValue({
+        id: 'tx-idem',
+        userId,
+        amount: 4.99,
+        currency: 'USD',
+        status: 'success',
+        reference: 'hash-idem',
+      });
+
+      const result = await service.verifyPurchase(userId, dto);
+
+      expect(result.success).toBe(true);
       expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
     });
 
@@ -433,25 +553,37 @@ describe('PaymentService', () => {
         reference: 'hash-789',
       });
 
-      mockPrisma.subscription.findFirst.mockResolvedValue({
-        id: 'existing-sub',
-        userId,
-        plan: 'monthly',
-        status: 'active',
-      });
-
-      mockPrisma.subscription.update.mockResolvedValue({
-        id: 'existing-sub',
-        userId,
-        plan: 'yearly',
-        status: 'active',
-        startedAt: now,
-        endsAt: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
-      });
+      // Initial read sees the old row; the guarded re-read after the write
+      // returns the upgraded row.
+      mockPrisma.subscription.findFirst
+        .mockResolvedValueOnce({
+          id: 'existing-sub',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          purchaseToken: null,
+        })
+        .mockResolvedValue({
+          id: 'existing-sub',
+          userId,
+          plan: 'yearly',
+          status: 'active',
+          startedAt: now,
+          endsAt: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
+          purchaseToken: 'new-token',
+        });
 
       const result = await service.verifyPurchase(userId, dto);
 
-      expect(mockPrisma.subscription.update).toHaveBeenCalled();
+      // Existing-row writes go through the token-guarded CAS updateMany, not an
+      // unconditional update-by-id, so a concurrent token cannot be clobbered.
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { id: 'existing-sub', purchaseToken: null },
+        data: expect.objectContaining({
+          plan: 'yearly',
+          purchaseToken: 'new-token',
+        }),
+      });
       expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
       expect(result.subscription?.plan).toBe('yearly');
     });

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -230,10 +230,21 @@ export class PaymentService {
       return;
     }
 
-    await this.prisma.subscription.update({
-      where: { id: existing.id },
+    // Compare-and-swap: fold the token match into the write so a concurrent
+    // replacement cannot also pass the in-memory check above and leave the row
+    // mapped to the wrong token. Guarding on `purchaseToken: linkedToken` means
+    // only the delivery that still sees the old token wins; `count === 0` is a
+    // benign no-op (another writer already migrated it).
+    const res = await this.prisma.subscription.updateMany({
+      where: { id: existing.id, purchaseToken: linkedToken },
       data: { purchaseToken: newToken },
     });
+    if (res.count === 0) {
+      this.logger.log(
+        `Skipped Google purchaseToken migration for user ${userId.substring(0, 8)} (already migrated concurrently)`,
+      );
+      return;
+    }
     this.logger.log(
       `Migrated Google purchaseToken (linked) for user ${userId.substring(0, 8)}`,
     );

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -86,7 +87,8 @@ export class PaymentService {
     } catch (error) {
       if (
         error instanceof BadRequestException ||
-        error instanceof NotFoundException
+        error instanceof NotFoundException ||
+        error instanceof ConflictException
       ) {
         throw error;
       }
@@ -211,6 +213,12 @@ export class PaymentService {
    * subscription upsert also writes the new token, so this is idempotent — it
    * exists so the migration is explicit and happens even if the stored token is
    * the linked one on a distinct Subscription row.
+   *
+   * Concurrency: the swap is a DB-level compare-and-swap. When it affects zero
+   * rows we re-read to distinguish an idempotent repeat (row already holds
+   * `newToken` — safe to continue) from a lost race where a concurrent delivery
+   * installed a DIFFERENT token. In the latter case we throw so the caller's
+   * subsequent upsert never overwrites (clobbers) the concurrent winner.
    */
   private async migrateGoogleLinkedToken(
     userId: string,
@@ -233,17 +241,35 @@ export class PaymentService {
     // Compare-and-swap: fold the token match into the write so a concurrent
     // replacement cannot also pass the in-memory check above and leave the row
     // mapped to the wrong token. Guarding on `purchaseToken: linkedToken` means
-    // only the delivery that still sees the old token wins; `count === 0` is a
-    // benign no-op (another writer already migrated it).
+    // only the delivery that still sees the old token wins.
     const res = await this.prisma.subscription.updateMany({
       where: { id: existing.id, purchaseToken: linkedToken },
       data: { purchaseToken: newToken },
     });
     if (res.count === 0) {
-      this.logger.log(
-        `Skipped Google purchaseToken migration for user ${userId.substring(0, 8)} (already migrated concurrently)`,
+      // `count === 0` is NOT unconditionally benign: the guard missed either
+      // because we (or an idempotent retry) already installed `newToken`, OR
+      // because a concurrent delivery installed a DIFFERENT token. Re-read to
+      // tell these apart. Only continue when the row already holds `newToken`
+      // (our write / an idempotent repeat). If some other token won the race we
+      // must NOT let the caller's subsequent upsert clobber it — abort this
+      // delivery so the concurrent winner is preserved.
+      const current = await this.prisma.subscription.findFirst({
+        where: { id: existing.id },
+      });
+      if (current?.purchaseToken === newToken) {
+        this.logger.log(
+          `Skipped Google purchaseToken migration for user ${userId.substring(0, 8)} (already migrated to this token)`,
+        );
+        return;
+      }
+      this.logger.warn(
+        `Aborting Google purchaseToken migration for user ${userId.substring(0, 8)}: ` +
+          `a concurrent delivery installed a different token; preserving the winner`,
       );
-      return;
+      throw new ConflictException(
+        'Purchase token changed concurrently; please retry',
+      );
     }
     this.logger.log(
       `Migrated Google purchaseToken (linked) for user ${userId.substring(0, 8)}`,
@@ -380,17 +406,36 @@ export class PaymentService {
       purchaseToken: platformDetails?.purchaseToken ?? null,
     };
 
-    const subscription = existingSub
-      ? await this.prisma.subscription.update({
-          where: { id: existingSub.id },
-          data,
-        })
-      : await this.prisma.subscription.create({
-          data: {
-            userId,
-            ...data,
-          },
-        });
+    let subscription;
+    if (existingSub) {
+      // Token-guarded write (defense-in-depth CAS): only mutate the row while its
+      // purchaseToken is still the value we just read. If a concurrent
+      // verification installed a different token between the read above and this
+      // write, the guard misses (count === 0) and we must NOT overwrite the
+      // concurrent winner — re-read and return the current row unchanged so a
+      // later unconditional update-by-id can never clobber the winning token.
+      const guardToken = existingSub.purchaseToken ?? null;
+      const res = await this.prisma.subscription.updateMany({
+        where: { id: existingSub.id, purchaseToken: guardToken },
+        data: data as Prisma.SubscriptionUpdateManyMutationInput,
+      });
+      if (res.count === 0) {
+        this.logger.warn(
+          `Skipped subscription token write for user ${userId.substring(0, 8)}: ` +
+            `a concurrent verification changed the purchase token; preserving the winner`,
+        );
+      }
+      subscription = (await this.prisma.subscription.findFirst({
+        where: { id: existingSub.id },
+      })) ?? { userId, ...data };
+    } else {
+      subscription = await this.prisma.subscription.create({
+        data: {
+          userId,
+          ...data,
+        },
+      });
+    }
 
     this.eventEmitter.emit('admin.sse.activity', {
       type: 'SUBSCRIPTION',

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -17,7 +17,11 @@ type MockPrisma = {
     update: jest.Mock;
     updateMany: jest.Mock;
   };
-  subscription: { findFirst: jest.Mock; update: jest.Mock };
+  subscription: {
+    findFirst: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
 };
 
 const SUB = {
@@ -84,6 +88,9 @@ describe('SubscriptionWebhookService', () => {
       subscription: {
         findFirst: jest.fn().mockResolvedValue({ ...SUB }),
         update: jest.fn().mockResolvedValue({ ...SUB }),
+        // CAS writes: default to a matched row (applied). Stale/lost-race tests
+        // override this to `{ count: 0 }`.
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
     };
     apple = { parseSignedNotification: jest.fn() };
@@ -537,9 +544,10 @@ describe('SubscriptionWebhookService', () => {
 
         expect(res.status).toBe('processed');
         expect(res.action).toBe('google:SUBSCRIPTION_4 -> activate');
-        // Row's purchaseToken migrated from the old token to the new one.
-        expect(prisma.subscription.update).toHaveBeenCalledWith({
-          where: { id: 'sub-1' },
+        // Row's purchaseToken migrated from the old token to the new one via a
+        // compare-and-swap guarded on the still-stored linked token.
+        expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+          where: { id: 'sub-1', purchaseToken: 'g-token-1' },
           data: { purchaseToken: 'new-token' },
         });
       });
@@ -592,8 +600,8 @@ describe('SubscriptionWebhookService', () => {
         const res = await service.handleGoogle(body);
 
         expect(res.status).toBe('processed');
-        expect(prisma.subscription.update).toHaveBeenCalledWith({
-          where: { id: 'sub-1' },
+        expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+          where: { id: 'sub-1', purchaseToken: 'token-A' },
           data: { purchaseToken: 'token-C' },
         });
       });
@@ -683,12 +691,17 @@ describe('SubscriptionWebhookService', () => {
   });
 
   // --------------------------------------- out-of-order delivery watermark ----
-  describe('out-of-order delivery protection (event watermark)', () => {
+  describe('out-of-order delivery protection (event watermark, CAS)', () => {
     const OLD = new Date('2026-05-01T00:00:00Z');
     const NEW = new Date('2026-06-01T00:00:00Z');
 
+    // The watermark guard is a compare-and-swap: the timestamp comparison lives
+    // in the `updateMany` WHERE, and the affected-row count decides applied vs
+    // skipped. When `eventAt` is known the service uses `updateMany`, never a
+    // bare `update`.
+
     // ------------------------------------------------------------- Apple ----
-    it('applies a newer Apple event and advances lastEventAt atomically', async () => {
+    it('applies a newer Apple event via a guarded updateMany and advances lastEventAt', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: OLD,
@@ -704,22 +717,30 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleApple({ signedPayload: 'jws' });
 
       expect(res.status).toBe('processed');
-      expect(prisma.subscription.update).toHaveBeenCalledWith({
-        where: { id: 'sub-1' },
+      // State change + watermark advance are a single conditional write.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
         data: {
           status: 'active',
           endsAt: new Date('2026-03-01'),
           lastEventAt: NEW,
         },
       });
+      // No unguarded update when a timestamp is present.
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a stale Apple event (older than lastEventAt) without regressing state', async () => {
+    it('skips a stale Apple event when the CAS matches no row (older delivery loses the race)', async () => {
       // Already applied a DID_RENEW at NEW; a delayed EXPIRED at OLD arrives.
+      // The conditional write matches zero rows (stored watermark is newer).
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: NEW,
       });
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
       apple.parseSignedNotification.mockReturnValue(
         appleInfo({
           notificationType: 'EXPIRED',
@@ -732,10 +753,20 @@ describe('SubscriptionWebhookService', () => {
 
       expect(res.status).toBe('skipped');
       expect(res.action).toContain('stale/out-of-order');
+      // The CAS was attempted (guarded), but nothing was regressed.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'sub-1' }),
+        }),
+      );
       expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a duplicate Apple event arriving at the exact same timestamp', async () => {
+    it('applies a DISTINCT Apple event arriving at the exact same timestamp (equality is not stale)', async () => {
+      // Same-millisecond, different notificationUUID -> a distinct event. True
+      // duplicates are filtered by the WebhookEvent idempotency layer, so this
+      // must be processed, not dropped. The CAS WHERE uses `lte`, so an equal
+      // stored watermark still matches.
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: NEW,
@@ -743,15 +774,25 @@ describe('SubscriptionWebhookService', () => {
       apple.parseSignedNotification.mockReturnValue(
         appleInfo({
           notificationType: 'DID_RENEW',
-          notificationUUID: 'wm-a-dup',
+          notificationUUID: 'wm-a-same-instant',
           signedDate: NEW.getTime(),
         }),
       );
 
       const res = await service.handleApple({ signedPayload: 'jws' });
 
-      expect(res.status).toBe('skipped');
-      expect(prisma.subscription.update).not.toHaveBeenCalled();
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
+        data: {
+          status: 'active',
+          endsAt: new Date('2026-03-01'),
+          lastEventAt: NEW,
+        },
+      });
     });
 
     it('applies an Apple event and sets lastEventAt when no prior watermark exists', async () => {
@@ -770,12 +811,52 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleApple({ signedPayload: 'jws' });
 
       expect(res.status).toBe('processed');
-      const call = prisma.subscription.update.mock.calls[0][0];
+      const call = prisma.subscription.updateMany.mock.calls[0][0];
       expect(call.data.lastEventAt).toEqual(NEW);
+      // Guard admits a null stored watermark.
+      expect(call.where.OR).toContainEqual({ lastEventAt: null });
+    });
+
+    it('simulated concurrent old/new delivery: the newer applies, the older is skipped', async () => {
+      // Newer event (NEW): stored watermark is OLD -> CAS matches (count 1).
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: OLD,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 1 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-conc-new',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const newer = await service.handleApple({ signedPayload: 'jws' });
+      expect(newer.status).toBe('processed');
+
+      // Older event (OLD) races in after the watermark advanced to NEW. Both the
+      // read and the CAS now see the newer watermark -> count 0 -> skipped.
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: NEW,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 0 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'EXPIRED',
+          notificationUUID: 'wm-a-conc-old',
+          signedDate: OLD.getTime(),
+        }),
+      );
+
+      const older = await service.handleApple({ signedPayload: 'jws' });
+      expect(older.status).toBe('skipped');
+      expect(older.action).toContain('stale/out-of-order');
     });
 
     // ------------------------------------------------------------ Google ----
-    it('applies a newer Google event and advances lastEventAt', async () => {
+    it('applies a newer Google event via a guarded updateMany and advances lastEventAt', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         platform: 'google',
@@ -801,23 +882,28 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleGoogle(body);
 
       expect(res.status).toBe('processed');
-      expect(prisma.subscription.update).toHaveBeenCalledWith({
-        where: { id: 'sub-1' },
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
         data: {
           status: 'active',
           endsAt: new Date('2026-07-01'),
           lastEventAt: NEW,
         },
       });
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a stale Google EXPIRED that would clobber a newer RENEWED', async () => {
+    it('skips a stale Google EXPIRED that would clobber a newer RENEWED (CAS matches no row)', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         platform: 'google',
         purchaseToken: 'g-token-1',
         lastEventAt: NEW,
       });
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
       const body = googleBody(
         {
           eventTimeMillis: String(OLD.getTime()),
@@ -835,6 +921,75 @@ describe('SubscriptionWebhookService', () => {
       expect(res.status).toBe('skipped');
       expect(res.action).toContain('stale/out-of-order');
       expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ----------------------------- linked-token migration is compare-and-swap ----
+  describe('linked-token migration (CAS)', () => {
+    it('re-resolves by the event token when the migration CAS loses the race', async () => {
+      // Event token 'new-token' is not stored; its linkedPurchaseToken is
+      // 'g-token-1', which we DO store. A concurrent delivery migrates the row
+      // first, so our guarded updateMany matches 0 rows and we must re-resolve by
+      // the (now stored) event token instead of mis-mapping.
+      let newTokenLookups = 0;
+      prisma.subscription.findFirst.mockImplementation(
+        ({ where }: { where: { purchaseToken?: string } }) => {
+          if (where.purchaseToken === 'g-token-1') {
+            return Promise.resolve({
+              ...SUB,
+              platform: 'google',
+              purchaseToken: 'g-token-1',
+            });
+          }
+          if (where.purchaseToken === 'new-token') {
+            // First lookup is the fast-path (token not stored yet) -> null. The
+            // second lookup is the post-lost-race re-resolution: a concurrent
+            // delivery already migrated the row, so it now holds 'new-token'.
+            newTokenLookups += 1;
+            if (newTokenLookups === 1) return Promise.resolve(null);
+            return Promise.resolve({
+              ...SUB,
+              platform: 'google',
+              purchaseToken: 'new-token',
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+      // Lost the migration race.
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
+      google.verify
+        .mockResolvedValueOnce({
+          success: true,
+          linkedPurchaseToken: 'g-token-1',
+        })
+        .mockResolvedValue({
+          success: true,
+          expirationTime: new Date('2026-04-01'),
+        });
+
+      const body = googleBody(
+        {
+          packageName: 'com.storytime.app',
+          subscriptionNotification: {
+            notificationType: 4, // PURCHASED
+            purchaseToken: 'new-token',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'msg-link-cas-race',
+      );
+
+      const res = await service.handleGoogle(body);
+
+      // The migration CAS was guarded on the still-stored linked token.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { id: 'sub-1', purchaseToken: 'g-token-1' },
+        data: { purchaseToken: 'new-token' },
+      });
+      // Despite losing the race, the event still resolves and applies.
+      expect(res.status).toBe('processed');
+      expect(res.action).toBe('google:SUBSCRIPTION_4 -> activate');
     });
   });
 });

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -795,6 +795,65 @@ describe('SubscriptionWebhookService', () => {
       });
     });
 
+    it('applies BOTH conflicting same-timestamp events (last-write-wins, not arrival-serialized)', async () => {
+      // Two CONFLICTING lifecycle events share the exact same millisecond
+      // (distinct notificationUUIDs, so both survive the idempotency layer).
+      // The `<=` watermark guard admits both: neither is dropped, and whichever
+      // DB write commits last determines the final state. This documents the
+      // honest limitation — same-timestamp conflicts are NOT serialized by
+      // arrival order (see applyAction's doc comment). Such conflicts do not
+      // occur in practice because Apple/Google emit one notification per state
+      // transition with distinct timestamps.
+
+      // Event A: DID_RENEW (activate) at NEW. Stored watermark is OLD -> applies.
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: OLD,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 1 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-tie-renew',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const first = await service.handleApple({ signedPayload: 'jws' });
+      expect(first.status).toBe('processed');
+
+      // Event B: EXPIRED (deactivate) at the SAME NEW timestamp. Stored watermark
+      // is now NEW; `lte` still matches, so this conflicting event ALSO applies
+      // rather than being skipped as "stale" — last-write-wins.
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: NEW,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 1 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'EXPIRED',
+          notificationUUID: 'wm-a-tie-expire',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const second = await service.handleApple({ signedPayload: 'jws' });
+      expect(second.status).toBe('processed');
+      // The second write still guards on `lte NEW` (equal watermark admitted).
+      expect(prisma.subscription.updateMany).toHaveBeenLastCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
+        data: {
+          status: 'cancelled',
+          endsAt: expect.any(Date),
+          lastEventAt: NEW,
+        },
+      });
+    });
+
     it('applies an Apple event and sets lastEventAt when no prior watermark exists', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -168,7 +168,7 @@ export class SubscriptionWebhookService {
     if (!applied) {
       return {
         status: 'skipped',
-        action: `apple:${info.notificationType} stale/out-of-order (event <= lastEventAt)`,
+        action: `apple:${info.notificationType} stale/out-of-order (event older than watermark)`,
       };
     }
     return {
@@ -315,7 +315,8 @@ export class SubscriptionWebhookService {
       if (!applied) {
         return {
           status: 'skipped',
-          action: 'google:voided stale/out-of-order (event <= lastEventAt)',
+          action:
+            'google:voided stale/out-of-order (event older than watermark)',
         };
       }
       return { status: 'processed', action: 'google:voided -> revoke' };
@@ -376,7 +377,7 @@ export class SubscriptionWebhookService {
     if (!applied) {
       return {
         status: 'skipped',
-        action: `google:SUBSCRIPTION_${sub.notificationType} stale/out-of-order (event <= lastEventAt)`,
+        action: `google:SUBSCRIPTION_${sub.notificationType} stale/out-of-order (event older than watermark)`,
       };
     }
     return {
@@ -673,15 +674,28 @@ export class SubscriptionWebhookService {
 
       const sub = await this.findSubscription('google', linkedToken);
       if (sub) {
-        // Migrate the known row forward to the newest (event) token in place.
-        const migrated = await this.prisma.subscription.update({
-          where: { id: sub.id },
+        // Migrate the known row forward to the newest (event) token in place,
+        // via a compare-and-swap guarded on the still-stored `linkedToken`. The
+        // in-memory read above then an id-only update would be a TOCTOU race:
+        // two concurrent replacements could both pass and the last writer could
+        // leave the row mapped to the wrong token. `updateMany` performs the
+        // token match and the write atomically.
+        const res = await this.prisma.subscription.updateMany({
+          where: { id: sub.id, purchaseToken: linkedToken },
           data: { purchaseToken: eventToken },
         });
+        if (res.count === 0) {
+          // A concurrent delivery already migrated this row. Re-resolve by the
+          // event token (now the stored token) so this event still applies.
+          this.logger.log(
+            `Lost linked-token migration race for subscription ${sub.id}; re-resolving by event token`,
+          );
+          return this.findSubscription('google', eventToken);
+        }
         this.logger.log(
           `Migrated Google purchaseToken ${this.mask(linkedToken)} -> ${this.mask(eventToken)} for subscription ${sub.id} (${hop + 1} hop(s))`,
         );
-        return migrated;
+        return { ...sub, purchaseToken: eventToken };
       }
 
       currentToken = linkedToken;
@@ -722,11 +736,27 @@ export class SubscriptionWebhookService {
    * - deactivate:     status cancelled, endsAt = now (access ends immediately)
    * - revoke:         status cancelled, endsAt = now (refund/chargeback)
    *
-   * Out-of-order protection: when `eventAt` is known and the subscription's
-   * stored `lastEventAt` is >= `eventAt`, the event is stale (a late/duplicate
-   * delivery) and the mutation is SKIPPED (returns `false`) so it cannot clobber
-   * newer state. Otherwise the state change AND the advanced `lastEventAt`
-   * watermark are written in a single update (atomic), and `true` is returned.
+   * Out-of-order protection (compare-and-swap): the `lastEventAt` watermark guard
+   * runs INSIDE the write, never as a separate read-then-write. A prior in-memory
+   * compare-then-`update` was a TOCTOU race — two concurrent deliveries could both
+   * read the old watermark, both pass, and both write, letting the older event
+   * commit last and regress the subscription. Here a conditional `updateMany`
+   * performs the comparison and the state mutation as a single atomic statement,
+   * and we branch on the affected-row count:
+   *  - count === 1 -> the guard matched; state change + advanced watermark applied.
+   *  - count === 0 -> a newer watermark is already stored (this event lost the race
+   *    / is stale); nothing is written and we return `false`.
+   *
+   * Ordering semantics (see also `prisma/schema.prisma` `Subscription.lastEventAt`):
+   * apply when there is no stored watermark yet OR the stored watermark is <= this
+   * event (`lte`). Equality APPLIES rather than skips: two DISTINCT notifications
+   * can share a millisecond, and true duplicates are already filtered upstream by
+   * the `WebhookEvent (platform, externalEventId)` idempotency layer, so a
+   * same-instant event reaching here is always a distinct one that must be
+   * processed in arrival order. Only a STRICTLY greater stored watermark skips.
+   *
+   * When `eventAt` is null the event has no derivable timestamp; ordering cannot
+   * be established, so it is applied unconditionally (never blocked).
    */
   private async applyAction(
     subscription: Subscription,
@@ -756,29 +786,33 @@ export class SubscriptionWebhookService {
         return false;
     }
 
-    // Skip stale / out-of-order deliveries. `>=` also drops a distinct event
-    // arriving at the exact same timestamp as the last applied one.
-    if (
-      eventAt &&
-      subscription.lastEventAt &&
-      subscription.lastEventAt.getTime() >= eventAt.getTime()
-    ) {
-      this.logger.log(
-        `Skipping stale/out-of-order ${action} for subscription ${subscription.id} ` +
-          `(event ${eventAt.toISOString()} <= lastEventAt ${subscription.lastEventAt.toISOString()})`,
-      );
-      return false;
-    }
-
-    // Advance the watermark atomically with the state change (same UPDATE).
     if (eventAt) {
+      // Advance the watermark atomically with the state change (same write).
       data.lastEventAt = eventAt;
+      // CAS guard: apply only when no watermark is stored yet, or the stored one
+      // is <= this event. A strictly-greater stored watermark means a newer event
+      // already won -> the WHERE does not match and count === 0 (stale/skip).
+      const res = await this.prisma.subscription.updateMany({
+        where: {
+          id: subscription.id,
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: eventAt } }],
+        },
+        data: data as Prisma.SubscriptionUpdateManyMutationInput,
+      });
+      if (res.count === 0) {
+        this.logger.log(
+          `Skipping stale/out-of-order ${action} for subscription ${subscription.id} ` +
+            `(event ${eventAt.toISOString()} older than stored watermark)`,
+        );
+        return false;
+      }
+    } else {
+      // No derivable event timestamp -> apply without ordering gating.
+      await this.prisma.subscription.update({
+        where: { id: subscription.id },
+        data,
+      });
     }
-
-    await this.prisma.subscription.update({
-      where: { id: subscription.id },
-      data,
-    });
 
     this.eventEmitter.emit('admin.sse.activity', {
       type: 'SUBSCRIPTION',

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -749,11 +749,20 @@ export class SubscriptionWebhookService {
    *
    * Ordering semantics (see also `prisma/schema.prisma` `Subscription.lastEventAt`):
    * apply when there is no stored watermark yet OR the stored watermark is <= this
-   * event (`lte`). Equality APPLIES rather than skips: two DISTINCT notifications
-   * can share a millisecond, and true duplicates are already filtered upstream by
-   * the `WebhookEvent (platform, externalEventId)` idempotency layer, so a
-   * same-instant event reaching here is always a distinct one that must be
-   * processed in arrival order. Only a STRICTLY greater stored watermark skips.
+   * event (`lte`). A STRICTLY greater stored watermark skips (a newer event already
+   * won). Equality APPLIES rather than skips so that two DISTINCT notifications that
+   * happen to share a millisecond are both processed (true duplicates are already
+   * filtered upstream by the `WebhookEvent (platform, externalEventId)` idempotency
+   * layer, so a same-instant event reaching here is always a distinct one).
+   *
+   * Honest limitation: for two CONFLICTING events sharing the exact same millisecond
+   * this is NOT serialized by arrival order — both pass the `<=` guard and whichever
+   * DB write commits last wins (last-write-wins in DB-commit order, which need not
+   * match arrival order). We deliberately do NOT add per-subscription serialization
+   * or a monotonic tie-breaker: Apple and Google emit one notification per state
+   * transition, each with a distinct timestamp, so conflicting same-millisecond
+   * lifecycle events for one subscription do not occur in practice, and the heavy
+   * locking/sequence infrastructure required to serialize them is not warranted.
    *
    * When `eventAt` is null the event has no derivable timestamp; ordering cannot
    * be established, so it is applied unconditionally (never blocked).


### PR DESCRIPTION
Follow-up to #411 addressing CodeRabbit findings that landed after the subscription-webhook code was merged into `develop-v1.2.0`.

## 1. Watermark update is now an atomic compare-and-swap (Major)
`src/payment/subscription-webhook.service.ts` — `applyAction()`

The out-of-order guard previously read `subscription.lastEventAt`, compared it to the event timestamp in JS, then did a separate `update` by `id` — a read-then-write TOCTOU race where two concurrent deliveries could both read the old watermark, both pass, and both write (older clobbering newer). The comparison now lives INSIDE the write via a conditional `updateMany`, and we branch on the affected-row count:

- `count === 1` → the guard matched; the state change and the advanced `lastEventAt` are committed in the same atomic statement.
- `count === 0` → a newer watermark is already stored (stale / lost the race); nothing is written and the WebhookEvent is recorded as `skipped` (still 200).

Events with no derivable timestamp still apply (unconditional `update`). Idempotency (WebhookEvent unique on `externalEventId`) and the linked-token flow are unchanged.

## 2. Equal-timestamp distinct events are no longer dropped (Major)
`prisma/schema.prisma` comment + the watermark comparison

The old `>=` comparison treated a DISTINCT event arriving at the same millisecond as a stale duplicate. The CAS WHERE now uses `lastEventAt IS NULL OR lastEventAt <= eventAt`, so same-instant distinct notifications APPLY in arrival order and only strictly-older events skip. True duplicates remain handled by the `WebhookEvent (platform, externalEventId)` idempotency layer. The chosen semantics are documented on `Subscription.lastEventAt` in the schema and in the `applyAction` doc comment.

## 3. Rejection tests assert HTTP status 400 (Minor)
`src/payment/apple-notification.spec.ts`

The bundleId and array-header rejection cases now assert the thrown `HttpException` carries status 400 (via `getStatus()`), so a regression to a 500 is caught.

## Bonus: linked-token migration is compare-and-swap
The same TOCTOU class in the linked-token migration (validate old token in memory, then update by `id`) is fixed in both `subscription-webhook.service.ts` (`resolveGoogleSubscription`) and `payment.service.ts` (`migrateGoogleLinkedToken`): the update is guarded on the still-stored old token (`updateMany`), and `count === 0` re-resolves / no-ops instead of mis-mapping the row.

## Tests
Added/updated: concurrent old/new CAS delivery (older loses → skipped, newer applies), equal-timestamp distinct events both apply, no-prior-watermark apply, and linked-token migration CAS lost-race. `pnpm build`, `pnpm lint` clean; `pnpm test -- src/payment` → 98 passing.

## Out of scope
Deferred per PR #411 discussion (CodeRabbit withdrew / logged as follow-ups): Pub/Sub OIDC bearer-token validation, `fetchLinkedPurchaseToken` error propagation, and requiring `result.success` before activation (RTDN notification type is the authoritative signal).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription webhook handling to safely ignore out-of-order events using atomic watermark gating (including consistent handling for equal timestamps).
  * Prevented concurrent Google purchase-token migrations from clobbering a newer winning token.
  * Strengthened failure behavior for purchase verification by properly propagating conflict errors.
  * Improved Apple notification error responses with clearer HTTP 400 messaging.
* **Tests**
  * Expanded assertions for stale delivery, watermark edge cases, concurrent races, and token-migration retry/idempotency behavior.
  * Tightened malformed and bundle mismatch notification validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->