### PR TITLE
fix(prisma): switch to in-process library engine (stop orphaned query-engines exhausting shared RDS)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,12 @@
 generator client {
   provider      = "prisma-client-js"
-  engineType    = "binary"
+  // Use the in-process library (Node-API) engine, not the binary engine.
+  // The binary engine spawns a separate `query-engine` subprocess that owns
+  // the DB connection pool; on a non-graceful shutdown (SIGKILL / crash /
+  // Ctrl-C) that subprocess is orphaned to init and keeps its connections
+  // open, exhausting the shared RDS. The library engine runs in-process, so
+  // connections always die with the Node process — nothing to orphan.
+  engineType    = "library"
   binaryTargets = ["native"]
 }
 


### PR DESCRIPTION
## Problem

The shared RDS (`emerj-shared-db`, max_connections=401) repeatedly hit connection exhaustion, failing `prisma migrate deploy` on every environment (most recently #416's dev deploy) with:

```
FATAL: remaining connection slots are reserved for roles with privileges of the "rds_reserved" role
```

## Root cause

`prisma/schema.prisma` pinned `engineType = "binary"`. The binary engine spawns a **separate native `query-engine` subprocess** that owns the DB connection pool. On any **non-graceful** shutdown (SIGKILL / crash / Ctrl-C during testing), the Node parent dies but the `query-engine` child is **re-parented to init (ppid=1) and keeps its connections open indefinitely**.

Investigation on the dev box found **58 orphaned `query-engine` processes** from a test deployment's repeated restarts, holding **312 idle connections** — 78% of the entire cluster cap. Prior app-level graceful-shutdown fixes couldn't help: they never touch already-orphaned processes, and there was no `connection_limit` backstop.

## Fix

Switch to the in-process **library (Node-API) engine** — Prisma's default. It runs inside the Node process, so there is **no subprocess to orphan**; connections always die with the app. `binaryTargets = ["native"]` is kept (the server regenerates the client on deploy, so `native` resolves correctly).

## Validation
- `engineType = "library"` is the default engine on Prisma 6.19.0 (the pinned version) — CI's `pnpm install --frozen-lockfile` + `db:generate` + build + tests validate it.
- Paired with a `?connection_limit=5&pool_timeout=20` cap on every env's `DATABASE_URL` (+ GitHub `ENV_FILE` secrets) as a hard backstop.

## Also done (ops, out of band)
- Reaped the 58 orphaned engines → cluster connections 398/401 → 84/401; `storytime_db_blue` 312 → 1 (live app untouched).
- Re-ran #416's dev deploy → now green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling during non-graceful application shutdowns.
  * Reduced the risk of orphaned processes exhausting available database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->