### PR TITLE
release: batched broadcast → staging (for tonight's prod deploy)

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -39,6 +39,7 @@ import {
   RedeemCouponDto,
 } from './dto/coupon.dto';
 import { BroadcastNotificationDto } from './dto/broadcast-notification.dto';
+import { BatchedBroadcastNotificationDto } from './dto/batched-broadcast-notification.dto';
 import { ActivateSubscriptionDto } from './dto/activate-subscription.dto';
 import { GuestActivityFilterDto } from './dto/guest-stats.dto';
 import { VerifyPurchaseDto } from '../payment/dto/verify-purchase.dto';
@@ -2485,6 +2486,26 @@ export class AdminController {
     return {
       statusCode: 201,
       message: 'Broadcast notification queued',
+      data,
+    };
+  }
+
+  @Post('notifications/broadcast/batched')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Broadcast push to all device tokens in staggered batches (<= 500/batch)',
+  })
+  @ApiBody({ type: BatchedBroadcastNotificationDto })
+  @ApiCreatedResponse({ description: 'Batched broadcast queued' })
+  @HttpCode(HttpStatus.CREATED)
+  async broadcastNotificationBatched(
+    @Body() dto: BatchedBroadcastNotificationDto,
+  ) {
+    const data = await this.adminService.broadcastNotificationBatched(dto);
+    return {
+      statusCode: 201,
+      message: 'Batched broadcast notification queued',
       data,
     };
   }

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
   ConflictException,
+  InternalServerErrorException,
   Logger,
   Inject,
 } from '@nestjs/common';
@@ -56,7 +57,11 @@ import {
 } from '@/shared/constants/cache-keys.constants';
 import { DashboardUtil } from './utils/dashboard.util';
 import { BroadcastNotificationDto } from './dto/broadcast-notification.dto';
-import { NotificationService } from '../notification/notification.service';
+import {
+  NotificationService,
+  BatchedBroadcastSummary,
+} from '../notification/notification.service';
+import { BatchedBroadcastNotificationDto } from './dto/batched-broadcast-notification.dto';
 import { CreateAdminTicketDto } from './dto/create-admin-ticket.dto';
 import { ResetQuotaDto } from './dto/reset-quota.dto';
 import { GuestStatsDto, GuestActivityFilterDto } from './dto/guest-stats.dto';
@@ -2772,6 +2777,47 @@ export class AdminService {
     }
 
     return { sent: true, topic, inAppDelivered };
+  }
+
+  /**
+   * Broadcast a push notification to all users by fanning out to every active
+   * device token in staggered batches (<= 500 tokens per FCM multicast call),
+   * instead of a single topic push. Emits a 'notification.broadcast-batched'
+   * event handled by the notification module and returns its summary.
+   */
+  async broadcastNotificationBatched(
+    dto: BatchedBroadcastNotificationDto,
+  ): Promise<BatchedBroadcastSummary> {
+    const results = await this.eventEmitter.emitAsync(
+      'notification.broadcast-batched',
+      {
+        title: dto.title,
+        body: dto.body,
+        data: dto.data,
+        batchSize: dto.batchSize,
+        intervalSeconds: dto.intervalSeconds,
+      },
+    );
+
+    const summary = results.find(
+      (r): r is BatchedBroadcastSummary =>
+        !!r && typeof r === 'object' && 'batches' in r,
+    );
+
+    // The notification module registers exactly one listener for this event; a
+    // missing summary means the listener didn't run (misconfiguration), so fail
+    // loudly rather than reporting a false "0 devices" success.
+    if (!summary) {
+      throw new InternalServerErrorException(
+        'Batched broadcast produced no summary; notification listener may not be registered',
+      );
+    }
+
+    this.logger.log(
+      `Batched broadcast emitted: "${dto.title}" -> ${summary.totalDevices} device(s) in ${summary.batches} batch(es)`,
+    );
+
+    return summary;
   }
 
   /**

--- a/src/admin/dto/batched-broadcast-notification.dto.ts
+++ b/src/admin/dto/batched-broadcast-notification.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/**
+ * Batched broadcast: send a push to every active device token in staggered
+ * chunks (<= 500 tokens per FCM multicast call) instead of a single topic
+ * fan-out. Staggering avoids every user opening the app at the same instant,
+ * which protects the connection-capped production RDS instance.
+ */
+export class BatchedBroadcastNotificationDto {
+  @ApiProperty({ example: 'New Story Available!' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(65)
+  title: string;
+
+  @ApiProperty({
+    example: "Check out 'The Magic Forest' - a new adventure awaits!",
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  body: string;
+
+  @ApiPropertyOptional({
+    example: { storyId: '123e4567-e89b-12d3-a456-426614174000' },
+    description: 'Optional data payload for deep linking',
+  })
+  @IsOptional()
+  @IsObject()
+  data?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    example: 500,
+    minimum: 1,
+    maximum: 500,
+    default: 500,
+    description:
+      'Device tokens per push job. Capped at 500 (FCM multicast hard limit).',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  batchSize?: number = 500;
+
+  @ApiPropertyOptional({
+    example: 120,
+    minimum: 0,
+    maximum: 3600,
+    default: 120,
+    description:
+      'Seconds between batches. Batch i is delayed by i * intervalSeconds.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(3600)
+  intervalSeconds?: number = 120;
+}

--- a/src/notification/notification.batched-broadcast.spec.ts
+++ b/src/notification/notification.batched-broadcast.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NotificationService } from './notification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { InAppProvider } from './providers/in-app.provider';
+import { EmailProvider } from './providers/email.provider';
+import { EmailQueueService } from './queue/email-queue.service';
+import { PushProvider } from './providers/push.provider';
+import { PushQueueService } from './queue/push-queue.service';
+
+/**
+ * Focused unit tests for the batched (staggered) broadcast:
+ * chunking math, per-batch delays, token de-duplication, and empty-device case.
+ */
+describe('NotificationService - broadcastBatchedToAllDevices', () => {
+  let service: NotificationService;
+
+  const mockConfigService = { get: jest.fn().mockReturnValue(undefined) };
+
+  const mockPrismaService = {
+    deviceToken: {
+      findMany: jest.fn(),
+    },
+  };
+
+  const mockPushQueueService = {
+    queueTokenBatch: jest.fn().mockResolvedValue({ queued: true, jobId: 'x' }),
+  };
+
+  const noop = {};
+
+  /**
+   * Configure deviceToken.findMany to page through the given token list using
+   * the same cursor pagination the service uses (DB page size 1000).
+   */
+  function stubDevicePages(tokens: string[]): void {
+    const PAGE = 1000;
+    mockPrismaService.deviceToken.findMany.mockImplementation(
+      (args: { cursor?: { id: string }; take: number }) => {
+        const startIndex = args.cursor
+          ? tokens.findIndex((_, i) => `id-${i}` === args.cursor!.id) + 1
+          : 0;
+        const page = tokens
+          .slice(startIndex, startIndex + PAGE)
+          .map((token, offset) => ({ id: `id-${startIndex + offset}`, token }));
+        return Promise.resolve(page);
+      },
+    );
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: InAppProvider, useValue: noop },
+        { provide: EmailProvider, useValue: noop },
+        { provide: EmailQueueService, useValue: noop },
+        { provide: PushProvider, useValue: noop },
+        { provide: PushQueueService, useValue: mockPushQueueService },
+      ],
+    }).compile();
+
+    service = module.get<NotificationService>(NotificationService);
+    jest.clearAllMocks();
+    mockPushQueueService.queueTokenBatch.mockResolvedValue({
+      queued: true,
+      jobId: 'x',
+    });
+  });
+
+  it('splits 1250 tokens into 3 batches with delays 0, interval, 2*interval', async () => {
+    const tokens = Array.from({ length: 1250 }, (_, i) => `token-${i}`);
+    stubDevicePages(tokens);
+
+    const result = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+      batchSize: 500,
+      intervalSeconds: 120,
+    });
+
+    expect(result).toEqual({
+      totalDevices: 1250,
+      batches: 3,
+      succeededBatches: 3,
+      failedBatches: 0,
+      batchSize: 500,
+      estimatedDurationSeconds: 240, // (3 - 1) * 120
+    });
+
+    expect(mockPushQueueService.queueTokenBatch).toHaveBeenCalledTimes(3);
+
+    const calls = mockPushQueueService.queueTokenBatch.mock.calls;
+    // Chunk sizes: 500, 500, 250
+    expect(calls[0][0]).toHaveLength(500);
+    expect(calls[1][0]).toHaveLength(500);
+    expect(calls[2][0]).toHaveLength(250);
+
+    // Delay is the 5th positional arg (tokens, title, body, data, delay).
+    const delays = calls.map((c) => c[4] as number).sort((a, b) => a - b);
+    expect(delays).toEqual([0, 120_000, 240_000]);
+
+    // Every token is delivered exactly once, no gaps/overlaps.
+    const delivered = calls.flatMap((c) => c[0] as string[]);
+    expect(delivered).toHaveLength(1250);
+    expect(new Set(delivered).size).toBe(1250);
+  });
+
+  it('de-duplicates tokens before chunking', async () => {
+    // 600 unique tokens, each duplicated once -> 1200 rows, but only 600 pushes.
+    const unique = Array.from({ length: 600 }, (_, i) => `dup-${i}`);
+    const withDupes = [...unique, ...unique];
+    stubDevicePages(withDupes);
+
+    const result = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+      batchSize: 500,
+      intervalSeconds: 60,
+    });
+
+    expect(result.totalDevices).toBe(600);
+    expect(result.batches).toBe(2); // ceil(600 / 500)
+
+    const delivered = mockPushQueueService.queueTokenBatch.mock.calls.flatMap(
+      (c) => c[0] as string[],
+    );
+    expect(delivered).toHaveLength(600);
+    expect(new Set(delivered).size).toBe(600);
+  });
+
+  it('returns batches:0 and queues nothing when there are no devices', async () => {
+    stubDevicePages([]);
+    const warnSpy = jest
+      .spyOn(service['logger'], 'warn')
+      .mockImplementation(() => undefined);
+
+    const result = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+    });
+
+    expect(result).toEqual({
+      totalDevices: 0,
+      batches: 0,
+      succeededBatches: 0,
+      failedBatches: 0,
+      batchSize: 500,
+      estimatedDurationSeconds: 0,
+    });
+    expect(mockPushQueueService.queueTokenBatch).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT throw on partial enqueue failure — returns counts and warns', async () => {
+    const tokens = Array.from({ length: 600 }, (_, i) => `t-${i}`);
+    stubDevicePages(tokens);
+    const warnSpy = jest
+      .spyOn(service['logger'], 'warn')
+      .mockImplementation(() => undefined);
+    mockPushQueueService.queueTokenBatch
+      .mockResolvedValueOnce({ queued: true, jobId: 'a' })
+      .mockResolvedValueOnce({
+        queued: false,
+        jobId: 'b',
+        error: 'redis down',
+      });
+
+    const summary = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+      batchSize: 500,
+      intervalSeconds: 0,
+    });
+
+    // Successful batch is already queued, so we must NOT throw (a retry would
+    // double-deliver). Surface the split instead.
+    expect(summary.batches).toBe(2);
+    expect(summary.succeededBatches).toBe(1);
+    expect(summary.failedBatches).toBe(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('throws when ALL batches fail to enqueue (nothing queued — retry is safe)', async () => {
+    const tokens = Array.from({ length: 600 }, (_, i) => `t-${i}`);
+    stubDevicePages(tokens);
+    mockPushQueueService.queueTokenBatch
+      .mockResolvedValueOnce({ queued: false, jobId: 'a', error: 'redis down' })
+      .mockResolvedValueOnce({
+        queued: false,
+        jobId: 'b',
+        error: 'redis down',
+      });
+
+    await expect(
+      service.broadcastBatchedToAllDevices({
+        title: 'Hi',
+        body: 'There',
+        batchSize: 500,
+        intervalSeconds: 0,
+      }),
+    ).rejects.toThrow(/failed to enqueue all/i);
+  });
+
+  it('falls back to defaults for non-finite inputs', async () => {
+    const tokens = Array.from({ length: 10 }, (_, i) => `t-${i}`);
+    stubDevicePages(tokens);
+
+    const result = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+      batchSize: Number.NaN,
+      intervalSeconds: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.batchSize).toBe(500);
+    expect(result.batches).toBe(1);
+    expect(result.estimatedDurationSeconds).toBe(0);
+  });
+
+  it('clamps batchSize to the 500 FCM multicast limit', async () => {
+    const tokens = Array.from({ length: 600 }, (_, i) => `t-${i}`);
+    stubDevicePages(tokens);
+
+    const result = await service.broadcastBatchedToAllDevices({
+      title: 'Hi',
+      body: 'There',
+      batchSize: 100_000, // absurd, must clamp to 500
+      intervalSeconds: 0,
+    });
+
+    expect(result.batchSize).toBe(500);
+    expect(result.batches).toBe(2);
+    expect(result.estimatedDurationSeconds).toBe(0);
+    // All delays are 0 when interval is 0.
+    const delays = mockPushQueueService.queueTokenBatch.mock.calls.map(
+      (c) => c[4] as number,
+    );
+    expect(delays).toEqual([0, 0]);
+  });
+});

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -53,6 +53,27 @@ const USER_CONFIGURABLE_CATEGORIES: PrismaCategory[] = [
   PrismaCategory.SUBSCRIPTION_REMINDER,
 ];
 
+/** Summary returned by a batched (staggered) broadcast run. */
+export interface BatchedBroadcastSummary {
+  /** Total de-duplicated active device tokens targeted. */
+  totalDevices: number;
+  /** Number of push jobs enqueued (one per chunk of <= batchSize tokens). */
+  batches: number;
+  /** Batches successfully enqueued to BullMQ (these WILL deliver). */
+  succeededBatches: number;
+  /**
+   * Batches that failed to enqueue. When this is > 0 but succeededBatches is
+   * also > 0, the succeeded batches are already queued and will still fire —
+   * do NOT blindly re-run the full broadcast, or the already-queued cohort is
+   * double-delivered. Re-target only the failed cohort instead.
+   */
+  failedBatches: number;
+  /** Effective chunk size after clamping to [1, 500]. */
+  batchSize: number;
+  /** Delay (seconds) before the final batch fires: (batches - 1) * intervalSeconds. */
+  estimatedDurationSeconds: number;
+}
+
 @Injectable()
 export class NotificationService {
   private readonly logger = new Logger(NotificationService.name);
@@ -1227,9 +1248,166 @@ export class NotificationService {
     return { total, batches };
   }
 
+  /**
+   * Broadcast a push to ALL active device tokens in staggered batches of
+   * <= 500 tokens (the FCM multicast hard limit), instead of a single topic
+   * fan-out. Batch i is delayed by `i * intervalSeconds` so users don't all
+   * receive the push (and open the app) simultaneously — this protects the
+   * connection-capped production RDS instance.
+   *
+   * Token reads reuse the exact same cursor pagination and active-token filter
+   * (`isActive: true, isDeleted: false`) as `subscribeAllExistingDevicesToTopic`.
+   * Tokens are de-duplicated before chunking so a token never gets two pushes.
+   */
+  async broadcastBatchedToAllDevices(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    // Clamp to safe bounds; fall back to defaults for non-finite inputs (NaN /
+    // Infinity) so a direct programmatic call can't produce NaN chunk sizes.
+    const batchSize = Number.isFinite(payload.batchSize)
+      ? Math.min(Math.max(payload.batchSize as number, 1), 500)
+      : 500;
+    const intervalSeconds = Number.isFinite(payload.intervalSeconds)
+      ? Math.max(payload.intervalSeconds as number, 0)
+      : 120;
+
+    // Page ALL active device tokens using the same batching approach as
+    // subscribeAllExistingDevicesToTopic (DB page size of 1000).
+    const DB_PAGE_SIZE = 1000;
+    let cursor: string | undefined;
+    const uniqueTokens = new Set<string>();
+
+    while (true) {
+      const devices = await this.prisma.deviceToken.findMany({
+        where: { isActive: true, isDeleted: false },
+        select: { id: true, token: true },
+        take: DB_PAGE_SIZE,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+        orderBy: { id: 'asc' },
+      });
+
+      if (devices.length === 0) break;
+
+      // De-duplicate tokens across pages so a token appearing twice (e.g. shared
+      // across rows) is only pushed once.
+      for (const device of devices) {
+        uniqueTokens.add(device.token);
+      }
+      cursor = devices[devices.length - 1].id;
+
+      if (devices.length < DB_PAGE_SIZE) break;
+    }
+
+    const tokens = Array.from(uniqueTokens);
+    const totalDevices = tokens.length;
+
+    if (totalDevices === 0) {
+      this.logger.warn(
+        'Batched broadcast requested but no active device tokens were found; nothing queued',
+      );
+      return {
+        totalDevices: 0,
+        batches: 0,
+        succeededBatches: 0,
+        failedBatches: 0,
+        batchSize,
+        estimatedDurationSeconds: 0,
+      };
+    }
+
+    // Split tokens into chunks of <= batchSize.
+    const chunks: string[][] = [];
+    for (let i = 0; i < tokens.length; i += batchSize) {
+      chunks.push(tokens.slice(i, i + batchSize));
+    }
+
+    // The last batch fires after (batches - 1) intervals.
+    const estimatedDurationSeconds = (chunks.length - 1) * intervalSeconds;
+
+    this.logger.log(
+      `Batched broadcast: ${totalDevices} device(s) -> ${chunks.length} batch(es) of <= ${batchSize} ` +
+        `at ${intervalSeconds}s intervals (estimated duration ${estimatedDurationSeconds}s)`,
+    );
+
+    // One job per chunk, staggered: batch i is delayed by i * intervalSeconds.
+    const enqueueResults = await Promise.all(
+      chunks.map((chunk, index) =>
+        this.pushQueueService.queueTokenBatch(
+          chunk,
+          payload.title,
+          payload.body,
+          payload.data,
+          index * intervalSeconds * 1000,
+        ),
+      ),
+    );
+
+    // Partial-failure handling. queueTokenBatch never rejects — it returns
+    // { queued: false } on error — so by the time we're here every SUCCEEDED
+    // chunk is already enqueued in BullMQ and WILL fire. If we threw on any
+    // failure (as before), the caller would see a generic error with no idea
+    // how many batches already went out, and a blind full re-run would
+    // double-deliver to the already-queued cohort. So:
+    //   - all batches failed  -> nothing queued, a full retry is safe -> throw.
+    //   - some batches failed  -> surface counts + warn; do NOT throw.
+    const failed = enqueueResults.filter((r) => !r.queued);
+    const failedBatches = failed.length;
+    const succeededBatches = enqueueResults.length - failedBatches;
+
+    if (failedBatches > 0) {
+      const errs = failed.map((f) => f.error ?? 'unknown error').join('; ');
+      if (succeededBatches === 0) {
+        // Nothing was enqueued — safe to fail loudly so the caller can retry.
+        throw new Error(
+          `Batched broadcast failed to enqueue all ${failedBatches} batch(es): ${errs}`,
+        );
+      }
+      // Partial success: some batches are already queued and will deliver.
+      this.logger.warn(
+        `Batched broadcast PARTIAL failure: ${succeededBatches}/${enqueueResults.length} batch(es) ` +
+          `enqueued and WILL deliver; ${failedBatches} failed (${errs}). Do NOT re-run the full ` +
+          `broadcast — that double-delivers to the already-queued cohort. Re-target only the failed batches.`,
+      );
+    }
+
+    return {
+      totalDevices,
+      batches: chunks.length,
+      succeededBatches,
+      failedBatches,
+      batchSize,
+      estimatedDurationSeconds,
+    };
+  }
+
   // ============================================
   // Event Listeners (cross-module communication)
   // ============================================
+
+  @OnEvent('notification.broadcast-batched')
+  async handleBatchedBroadcastNotification(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    this.logger.log(`Handling batched broadcast event: "${payload.title}"`);
+    try {
+      return await this.broadcastBatchedToAllDevices(payload);
+    } catch (err) {
+      this.logger.error(
+        `Failed to run batched broadcast for "${payload.title}": ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+      // Re-throw so emitAsync in the admin service can detect failure.
+      throw err;
+    }
+  }
 
   @OnEvent('notification.broadcast')
   async handleBroadcastNotification(payload: {

--- a/src/notification/queue/push-queue.service.ts
+++ b/src/notification/queue/push-queue.service.ts
@@ -144,6 +144,62 @@ export class PushQueueService {
   }
 
   /**
+   * Queue a single push job targeting a specific chunk of device tokens.
+   *
+   * Reuses the existing SEND_PUSH job path, which sends via
+   * `sendToTokens`/`sendEachForMulticast` when a `tokens[]` array is present
+   * (bypassing the per-user lookup). Used by the batched broadcast to stagger
+   * delivery over time via the BullMQ `delay` option.
+   *
+   * @param tokens Device tokens for this chunk (must be <= 500 for FCM multicast)
+   * @param delay Delay in milliseconds before this job becomes active
+   */
+  async queueTokenBatch(
+    tokens: string[],
+    title: string,
+    body: string,
+    data?: Record<string, string>,
+    delay?: number,
+    category: NotificationCategory = NotificationCategory.SYSTEM_ALERT,
+  ): Promise<QueuedPushResult> {
+    const jobId = randomUUID();
+
+    try {
+      const jobData: PushJobData = {
+        jobId,
+        // Sentinel user id: this job targets explicit tokens, not a user lookup.
+        userId: 'broadcast-batched',
+        category,
+        title,
+        body,
+        data,
+        tokens,
+      };
+
+      await this.pushQueue.add(PUSH_JOB_NAMES.SEND_PUSH, jobData, {
+        ...PUSH_QUEUE_DEFAULT_OPTIONS,
+        priority: PushPriority.NORMAL,
+        delay,
+        jobId,
+      });
+
+      this.logger.log(
+        `Token batch push queued: ${jobId} (${tokens.length} token(s), delay ${delay ?? 0}ms)`,
+      );
+
+      return { queued: true, jobId };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `Failed to queue token batch ${jobId}: ${errorMessage}`,
+      );
+
+      return { queued: false, jobId, error: errorMessage };
+    }
+  }
+
+  /**
    * Queue multiple push notifications (batch)
    */
   async queueBatch(


### PR DESCRIPTION
Promotes `develop-v1.2.0` to staging (`release-v1.2.0`) so the **batched broadcast** feature (#420) is included in tonight's 23:03 UTC scheduled prod deploy.

#420 adds `POST /admin/notifications/broadcast/batched` (staggered per-token send, load-safe) with the partial-failure handling CodeRabbit flagged. Build + tests green on develop.