### PR TITLE
fix(prisma): switch to in-process library engine (stop orphaned query-engines exhausting shared RDS)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,12 @@
 generator client {
   provider      = "prisma-client-js"
-  engineType    = "binary"
+  // Use the in-process library (Node-API) engine, not the binary engine.
+  // The binary engine spawns a separate `query-engine` subprocess that owns
+  // the DB connection pool; on a non-graceful shutdown (SIGKILL / crash /
+  // Ctrl-C) that subprocess is orphaned to init and keeps its connections
+  // open, exhausting the shared RDS. The library engine runs in-process, so
+  // connections always die with the Node process — nothing to orphan.
+  engineType    = "library"
   binaryTargets = ["native"]
 }
 

--- a/src/achievement-progress/repositories/daily-challenge-assignment.repository.interface.ts
+++ b/src/achievement-progress/repositories/daily-challenge-assignment.repository.interface.ts
@@ -7,10 +7,7 @@ export interface IDailyChallengeAssignmentRepository {
 
   // Mark matching daily challenge assignments as completed
   // (updateMany since there's no unique constraint)
-  markCompleted(
-    kidId: string,
-    challengeId: string,
-  ): Promise<{ count: number }>;
+  markCompleted(kidId: string, challengeId: string): Promise<{ count: number }>;
 
   // Find the first daily challenge assignment for a kid and challenge
   findFirstByKidAndChallenge(

--- a/src/achievement-progress/repositories/prisma-story-progress.repository.ts
+++ b/src/achievement-progress/repositories/prisma-story-progress.repository.ts
@@ -3,9 +3,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import type { IStoryProgressRepository } from './story-progress.repository.interface';
 
 @Injectable()
-export class PrismaStoryProgressRepository
-  implements IStoryProgressRepository
-{
+export class PrismaStoryProgressRepository implements IStoryProgressRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async countCompletedForKids(kidIds: string[]): Promise<number> {

--- a/src/admin/admin-revenue-analytics.service.ts
+++ b/src/admin/admin-revenue-analytics.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, BadRequestException, Logger, Inject } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  Logger,
+  Inject,
+} from '@nestjs/common';
 import { AiProviders } from '@/shared/constants/ai-providers.constants';
 import {
   SubscriptionAnalyticsDto,

--- a/src/admin/tests/admin.controller.spec.ts
+++ b/src/admin/tests/admin.controller.spec.ts
@@ -192,11 +192,16 @@ describe('AdminController', () => {
       const result = (await systemController.getSubscriptions('active')) as any;
 
       expect(result.data).toEqual(mockSubs);
-      expect(adminSystemService.getSubscriptions).toHaveBeenCalledWith('active');
+      expect(adminSystemService.getSubscriptions).toHaveBeenCalledWith(
+        'active',
+      );
     });
 
     it('createBackup: should delegate to the system service', () => {
-      const mockBackup = { message: 'Backup created successfully', timestamp: new Date() };
+      const mockBackup = {
+        message: 'Backup created successfully',
+        timestamp: new Date(),
+      };
       adminSystemService.createBackup.mockReturnValue(mockBackup);
 
       const result = systemController.createBackup() as any;

--- a/src/help-support/help-support.service.ts
+++ b/src/help-support/help-support.service.ts
@@ -1,9 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ErrorHandler } from '@/shared/utils/error-handler.util';
 import { ConfigService } from '@nestjs/config';
 import { render } from '@react-email/render';

--- a/src/help-support/repositories/support-ticket.repository.interface.ts
+++ b/src/help-support/repositories/support-ticket.repository.interface.ts
@@ -3,7 +3,9 @@ import type { SupportTicket, Prisma } from '@prisma/client';
 // ==================== Repository Interface ====================
 export interface ISupportTicketRepository {
   // Create a support ticket
-  create(data: Prisma.SupportTicketUncheckedCreateInput): Promise<SupportTicket>;
+  create(
+    data: Prisma.SupportTicketUncheckedCreateInput,
+  ): Promise<SupportTicket>;
 
   // Find all support tickets for a user, ordered by createdAt desc
   findManyByUser(userId: string): Promise<SupportTicket[]>;

--- a/src/notification/repositories/prisma-device-token.repository.ts
+++ b/src/notification/repositories/prisma-device-token.repository.ts
@@ -65,9 +65,7 @@ export class PrismaDeviceTokenRepository implements IDeviceTokenRepository {
     });
   }
 
-  async findActiveMobileTokens(
-    userId: string,
-  ): Promise<{ token: string }[]> {
+  async findActiveMobileTokens(userId: string): Promise<{ token: string }[]> {
     return this.prisma.deviceToken.findMany({
       where: {
         userId,

--- a/src/notification/repositories/prisma-user.repository.ts
+++ b/src/notification/repositories/prisma-user.repository.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import type {
-  IUserRepository,
-  UserContact,
-} from './user.repository.interface';
+import type { IUserRepository, UserContact } from './user.repository.interface';
 
 @Injectable()
 export class PrismaUserRepository implements IUserRepository {

--- a/src/notification/services/device-token.service.spec.ts
+++ b/src/notification/services/device-token.service.spec.ts
@@ -217,9 +217,12 @@ describe('DeviceTokenService', () => {
       );
 
       expect(result).toEqual({ success: true });
-      expect(repository.updateByToken).toHaveBeenCalledWith('device-token-abc', {
-        isActive: false,
-      });
+      expect(repository.updateByToken).toHaveBeenCalledWith(
+        'device-token-abc',
+        {
+          isActive: false,
+        },
+      );
     });
 
     it('should throw NotFoundException when token does not exist', async () => {

--- a/src/notification/services/device-token.service.ts
+++ b/src/notification/services/device-token.service.ts
@@ -178,8 +178,7 @@ export class DeviceTokenService {
    * Check if user has web token registered (for SSE preference)
    */
   async hasActiveWebToken(userId: string): Promise<boolean> {
-    const count =
-      await this.deviceTokenRepository.countActiveWebTokens(userId);
+    const count = await this.deviceTokenRepository.countActiveWebTokens(userId);
 
     return count > 0;
   }

--- a/src/notification/services/fcm.service.ts
+++ b/src/notification/services/fcm.service.ts
@@ -84,9 +84,7 @@ export class FcmService implements OnModuleInit {
     try {
       // Get user's active device tokens (excluding web - web uses SSE)
       const deviceTokens =
-        await this.deviceTokenRepository.findActiveMobileTokens(
-          payload.userId,
-        );
+        await this.deviceTokenRepository.findActiveMobileTokens(payload.userId);
 
       if (deviceTokens.length === 0) {
         this.logger.debug(

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -423,9 +423,9 @@ describe('PaymentService', () => {
         currency: 'USD',
       });
       expect(mockSubscriptionRepo.findFirstByUser).toHaveBeenCalledWith('u1');
-      expect(
-        mockPaymentTxRepo.findLatestSuccessfulByUser,
-      ).toHaveBeenCalledWith('u1');
+      expect(mockPaymentTxRepo.findLatestSuccessfulByUser).toHaveBeenCalledWith(
+        'u1',
+      );
     });
 
     it('should return null if no subscription exists', async () => {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -196,8 +196,7 @@ export class PaymentService {
   ): Promise<void> {
     if (!linkedToken || linkedToken === newToken) return;
 
-    const existing =
-      await this.subscriptionRepository.findFirstByUser(userId);
+    const existing = await this.subscriptionRepository.findFirstByUser(userId);
     if (
       !existing ||
       existing.purchaseToken === newToken ||
@@ -372,7 +371,9 @@ export class PaymentService {
     if (!subscription) return null;
 
     const latestTransaction =
-      await this.paymentTransactionRepository.findLatestSuccessfulByUser(userId);
+      await this.paymentTransactionRepository.findLatestSuccessfulByUser(
+        userId,
+      );
 
     const planDef = PLANS[subscription.plan];
     const price = latestTransaction?.amount ?? planDef?.amount ?? 0;
@@ -391,8 +392,7 @@ export class PaymentService {
   }
 
   async cancelSubscription(userId: string) {
-    const existing =
-      await this.subscriptionRepository.findFirstByUser(userId);
+    const existing = await this.subscriptionRepository.findFirstByUser(userId);
     if (!existing) throw new NotFoundException('No subscription to cancel');
 
     // Cancel on Google Play if this is a Google subscription with stored tokens

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -96,8 +96,7 @@ export class ReportsService {
    * Get weekly overview for all kids of a parent
    */
   async getWeeklyOverview(parentId: string): Promise<WeeklyReportDto> {
-    const kids =
-      await this.kidRepository.findKidsByParentWithAvatar(parentId);
+    const kids = await this.kidRepository.findKidsByParentWithAvatar(parentId);
 
     // Get start and end of current week (Monday to Sunday)
     const now = new Date();
@@ -137,12 +136,11 @@ export class ReportsService {
           );
 
         // Badges earned (reward redemptions)
-        const badgesEarned =
-          await this.rewardRedemptionRepository.countInRange(
-            kid.id,
-            weekStart,
-            weekEnd,
-          );
+        const badgesEarned = await this.rewardRedemptionRepository.countInRange(
+          kid.id,
+          weekStart,
+          weekEnd,
+        );
 
         return {
           kidId: kid.id,
@@ -192,11 +190,10 @@ export class ReportsService {
     }
 
     // Update or create progress record
-    const progress =
-      await this.storyProgressRepository.upsertCompletedProgress(
-        kidId,
-        storyId,
-      );
+    const progress = await this.storyProgressRepository.upsertCompletedProgress(
+      kidId,
+      storyId,
+    );
 
     // Trigger badge progress for story read
     await this.badgeProgressEngine.recordActivity(
@@ -213,8 +210,7 @@ export class ReportsService {
    * Get detailed report for a specific kid
    */
   async getKidDetailedReport(kidId: string): Promise<KidDetailedReportDto> {
-    const kid =
-      await this.kidRepository.findKidWithAvatarAndActivity(kidId);
+    const kid = await this.kidRepository.findKidWithAvatarAndActivity(kidId);
 
     if (!kid) {
       throw new BadRequestException('Kid not found');

--- a/src/reports/repositories/daily-challenge-assignment.repository.interface.ts
+++ b/src/reports/repositories/daily-challenge-assignment.repository.interface.ts
@@ -1,11 +1,7 @@
 // ==================== Repository Interface ====================
 export interface IDailyChallengeAssignmentRepository {
   // Count completed challenge assignments for a kid within a date range (completedAt)
-  countCompletedInRange(
-    kidId: string,
-    gte: Date,
-    lt: Date,
-  ): Promise<number>;
+  countCompletedInRange(kidId: string, gte: Date, lt: Date): Promise<number>;
 
   // Count completed challenge assignments for a kid since a date (completedAt)
   countCompletedSince(kidId: string, gte: Date): Promise<number>;

--- a/src/reports/repositories/prisma-kid.repository.ts
+++ b/src/reports/repositories/prisma-kid.repository.ts
@@ -18,9 +18,7 @@ export class PrismaKidRepository implements IKidRepository {
     });
   }
 
-  async findKidsByParentWithAvatar(
-    parentId: string,
-  ): Promise<KidWithAvatar[]> {
+  async findKidsByParentWithAvatar(parentId: string): Promise<KidWithAvatar[]> {
     return this.prisma.kid.findMany({
       where: { parentId },
       include: {

--- a/src/reports/repositories/prisma-story-progress.repository.ts
+++ b/src/reports/repositories/prisma-story-progress.repository.ts
@@ -4,9 +4,7 @@ import type { IStoryProgressRepository } from './story-progress.repository.inter
 import type { StoryProgress } from '@prisma/client';
 
 @Injectable()
-export class PrismaStoryProgressRepository
-  implements IStoryProgressRepository
-{
+export class PrismaStoryProgressRepository implements IStoryProgressRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async countCompletedInRange(

--- a/src/reports/repositories/question-answer.repository.interface.ts
+++ b/src/reports/repositories/question-answer.repository.interface.ts
@@ -13,10 +13,7 @@ export interface IQuestionAnswerRepository {
   ): Promise<CreatedQuestionAnswer>;
 
   // Find all answers for a kid answered on/after the given date
-  findAnswersByKidSince(
-    kidId: string,
-    since: Date,
-  ): Promise<QuestionAnswer[]>;
+  findAnswersByKidSince(kidId: string, since: Date): Promise<QuestionAnswer[]>;
 }
 
 export const QUESTION_ANSWER_REPOSITORY = Symbol('QUESTION_ANSWER_REPOSITORY');

--- a/src/reports/repositories/story-progress.repository.interface.ts
+++ b/src/reports/repositories/story-progress.repository.interface.ts
@@ -3,11 +3,7 @@ import type { StoryProgress } from '@prisma/client';
 // ==================== Repository Interface ====================
 export interface IStoryProgressRepository {
   // Count completed stories for a kid within a date range (lastAccessed)
-  countCompletedInRange(
-    kidId: string,
-    gte: Date,
-    lt: Date,
-  ): Promise<number>;
+  countCompletedInRange(kidId: string, gte: Date, lt: Date): Promise<number>;
 
   // Count completed stories for a kid since a date (lastAccessed)
   countCompletedSince(kidId: string, gte: Date): Promise<number>;

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -21,7 +21,18 @@ import { CircuitBreakerService } from './services/circuit-breaker.service';
       }),
     }),
   ],
-  providers: [AuthSessionGuard, AdminGuard, CacheMetricsService, CircuitBreakerService],
-  exports: [AuthSessionGuard, AdminGuard, JwtModule, CacheMetricsService, CircuitBreakerService],
+  providers: [
+    AuthSessionGuard,
+    AdminGuard,
+    CacheMetricsService,
+    CircuitBreakerService,
+  ],
+  exports: [
+    AuthSessionGuard,
+    AdminGuard,
+    JwtModule,
+    CacheMetricsService,
+    CircuitBreakerService,
+  ],
 })
 export class SharedModule {}

--- a/src/story-buddy/buddy-selection.service.ts
+++ b/src/story-buddy/buddy-selection.service.ts
@@ -39,9 +39,8 @@ export class BuddySelectionService {
     }
 
     // Verify buddy exists, is active, and not soft deleted
-    const buddy = await this.buddySelectionRepository.findStoryBuddyById(
-      buddyId,
-    );
+    const buddy =
+      await this.buddySelectionRepository.findStoryBuddyById(buddyId);
 
     if (!buddy) {
       throw new NotFoundException('Story buddy not found');

--- a/src/story-buddy/repositories/buddy-selection.repository.interface.ts
+++ b/src/story-buddy/repositories/buddy-selection.repository.interface.ts
@@ -68,14 +68,10 @@ export interface IBuddySelectionRepository {
   ): Promise<KidWithSelectedBuddy>;
 
   // Find kid with a summary of its selected buddy
-  findKidWithSelectedBuddy(
-    kidId: string,
-  ): Promise<KidWithSelectedBuddy | null>;
+  findKidWithSelectedBuddy(kidId: string): Promise<KidWithSelectedBuddy | null>;
 
   // Find kid with a detailed view of its selected buddy
-  findKidWithBuddyDetails(
-    kidId: string,
-  ): Promise<KidWithBuddyDetails | null>;
+  findKidWithBuddyDetails(kidId: string): Promise<KidWithBuddyDetails | null>;
 
   // Create buddy interaction log
   createBuddyInteraction(

--- a/src/story-buddy/story-buddy-public.controller.ts
+++ b/src/story-buddy/story-buddy-public.controller.ts
@@ -1,10 +1,5 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiParam,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { StoryBuddyService } from './story-buddy.service';
 import { AuthSessionGuard } from '@/shared/guards/auth.guard';
 import { Public } from '@/shared/decorators/public.decorator';

--- a/src/story/story-core.controller.ts
+++ b/src/story/story-core.controller.ts
@@ -167,7 +167,10 @@ export class StoryCoreController {
     }
 
     if (kidId) {
-      await this.kidOwnership.getOwnedKidOrThrow(kidId, req.authUserData.userId);
+      await this.kidOwnership.getOwnedKidOrThrow(
+        kidId,
+        req.authUserData.userId,
+      );
     }
 
     const baseFilter = {
@@ -404,7 +407,11 @@ export class StoryCoreController {
     @Param('id') id: string,
     @Query('permanent') permanent: boolean = false,
   ) {
-    await this.kidOwnership.getOwnedStoryOrThrow(id, req.authUserData.userId, true);
+    await this.kidOwnership.getOwnedStoryOrThrow(
+      id,
+      req.authUserData.userId,
+      true,
+    );
     return this.storyService.deleteStory(id, permanent);
   }
 
@@ -434,7 +441,11 @@ export class StoryCoreController {
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
   ) {
-    await this.kidOwnership.getOwnedStoryOrThrow(id, req.authUserData.userId, true);
+    await this.kidOwnership.getOwnedStoryOrThrow(
+      id,
+      req.authUserData.userId,
+      true,
+    );
     return this.storyService.undoDeleteStory(id);
   }
 

--- a/src/story/story-daily-challenge.controller.ts
+++ b/src/story/story-daily-challenge.controller.ts
@@ -70,7 +70,10 @@ export class StoryDailyChallengeController {
     @Req() req: AuthenticatedRequest,
     @Body() dto: AssignDailyChallengeDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(dto.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      dto.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.assignDailyChallenge(dto);
   }
 
@@ -88,7 +91,10 @@ export class StoryDailyChallengeController {
     if (!assignment) {
       throw new NotFoundException('Assignment not found');
     }
-    await this.kidOwnership.getOwnedKidOrThrow(assignment.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      assignment.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.completeDailyChallenge(dto);
   }
 
@@ -116,7 +122,10 @@ export class StoryDailyChallengeController {
     if (!assignment) {
       throw new NotFoundException('Assignment not found');
     }
-    await this.kidOwnership.getOwnedKidOrThrow(assignment.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      assignment.kidId,
+      req.authUserData.userId,
+    );
     return assignment;
   }
 

--- a/src/story/story-favorite.controller.ts
+++ b/src/story/story-favorite.controller.ts
@@ -63,7 +63,10 @@ export class StoryFavoriteController {
     @Req() req: AuthenticatedRequest,
     @Body() body: FavoriteDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(body.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      body.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.addFavorite(body);
   }
 

--- a/src/story/story-favorite.service.ts
+++ b/src/story/story-favorite.service.ts
@@ -56,11 +56,12 @@ export class StoryFavoriteService {
     const useCursor = cursor !== undefined || limit !== undefined;
     const take = limit ?? DEFAULT_CURSOR_LIMIT;
 
-    const records: FavoriteWithStory[] = await this.withCursorErrorHandling(() =>
-      this.favoriteRepository.findFavoritesByKidId(kidId, {
-        take: useCursor ? take + 1 : undefined,
-        cursor,
-      }),
+    const records: FavoriteWithStory[] = await this.withCursorErrorHandling(
+      () =>
+        this.favoriteRepository.findFavoritesByKidId(kidId, {
+          take: useCursor ? take + 1 : undefined,
+          cursor,
+        }),
     );
 
     if (!useCursor) {

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -448,12 +448,11 @@ export class StoryFeedService {
         readStatus: null as 'done' | 'reading' | null,
       }));
 
-    const readProgress = await this.storyRepository.findManyUserStoryProgressRaw(
-      {
+    const readProgress =
+      await this.storyRepository.findManyUserStoryProgressRaw({
         where: { userId, storyId: { in: storyIds }, isDeleted: false },
         select: { storyId: true, completed: true },
-      },
-    );
+      });
     const progressMap = new Map(
       readProgress.map((p) => [p.storyId, p.completed]),
     );

--- a/src/story/story-generate.controller.ts
+++ b/src/story/story-generate.controller.ts
@@ -66,7 +66,10 @@ export class StoryGenerateController {
   ) {
     // If kidId is provided, use the specialized method
     if (body.kidId) {
-      await this.kidOwnership.getOwnedKidOrThrow(body.kidId, req.authUserData.userId);
+      await this.kidOwnership.getOwnedKidOrThrow(
+        body.kidId,
+        req.authUserData.userId,
+      );
       return this.storyService.generateStoryForKid(
         body.kidId,
         body.themes,

--- a/src/story/story-metadata.service.ts
+++ b/src/story/story-metadata.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  Inject,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, Inject, Logger, NotFoundException } from '@nestjs/common';
 import {
   CategoryDto,
   ThemeDto,

--- a/src/story/story-path.controller.ts
+++ b/src/story/story-path.controller.ts
@@ -48,7 +48,10 @@ export class StoryPathController {
     @Req() req: AuthenticatedRequest,
     @Body() dto: StartStoryPathDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(dto.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      dto.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.startStoryPath(dto);
   }
 

--- a/src/story/story-progress.controller.ts
+++ b/src/story/story-progress.controller.ts
@@ -59,7 +59,10 @@ export class StoryProgressController {
     @Req() req: AuthenticatedRequest,
     @Body() body: StoryProgressDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(body.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      body.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.setProgress(body);
   }
 

--- a/src/story/story-recommendation.controller.ts
+++ b/src/story/story-recommendation.controller.ts
@@ -82,7 +82,10 @@ export class StoryRecommendationController {
     @Req() req: AuthenticatedRequest,
     @Body() body: ParentRecommendationDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(body.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      body.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.recommendStoryToKid(req.authUserData.userId, body);
   }
 

--- a/src/story/story-restrict.controller.ts
+++ b/src/story/story-restrict.controller.ts
@@ -8,12 +8,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiBody,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
   AuthSessionGuard,
   AuthenticatedRequest,
@@ -42,7 +37,10 @@ export class StoryRestrictController {
     @Req() req: AuthenticatedRequest,
     @Body() body: RestrictStoryDto,
   ) {
-    await this.kidOwnership.getOwnedKidOrThrow(body.kidId, req.authUserData.userId);
+    await this.kidOwnership.getOwnedKidOrThrow(
+      body.kidId,
+      req.authUserData.userId,
+    );
     return this.storyService.restrictStory({
       ...body,
       userId: req.authUserData.userId,

--- a/src/story/story.controller.spec.ts
+++ b/src/story/story.controller.spec.ts
@@ -73,10 +73,12 @@ describe('StoryController', () => {
       .compile();
 
     coreController = module.get<StoryCoreController>(StoryCoreController);
-    generateController =
-      module.get<StoryGenerateController>(StoryGenerateController);
-    libraryController =
-      module.get<StoryLibraryController>(StoryLibraryController);
+    generateController = module.get<StoryGenerateController>(
+      StoryGenerateController,
+    );
+    libraryController = module.get<StoryLibraryController>(
+      StoryLibraryController,
+    );
     recommendationController = module.get<StoryRecommendationController>(
       StoryRecommendationController,
     );
@@ -95,7 +97,12 @@ describe('StoryController', () => {
       const theme = 'Space';
       const category = 'Adventure';
 
-      await generateController.generateStoryForKid(mockReq, kidId, theme, category);
+      await generateController.generateStoryForKid(
+        mockReq,
+        kidId,
+        theme,
+        category,
+      );
 
       // Verify the controller converts single strings to arrays for the service
       expect(service.generateStoryForKid).toHaveBeenCalledWith(
@@ -204,13 +211,15 @@ describe('StoryController', () => {
   describe('IDOR protection', () => {
     it('should throw NotFoundException when kid does not belong to parent', async () => {
       mockStoryRepository.findKidByIdAndParent.mockResolvedValue(null);
-      await expect(libraryController.getCreated(mockReq, 'kid-999')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        libraryController.getCreated(mockReq, 'kid-999'),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('should throw NotFoundException when story does not exist', async () => {
-      mockStoryRepository.findStoryByIdWithCreatorParent.mockResolvedValue(null);
+      mockStoryRepository.findStoryByIdWithCreatorParent.mockResolvedValue(
+        null,
+      );
       await expect(
         coreController.updateStory(
           mockReq,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -29,10 +29,7 @@ import {
 } from './dto/story.dto';
 
 import { UploadService } from '../upload/upload.service';
-import {
-  DailyChallengeAssignment,
-  DailyChallenge,
-} from '@prisma/client';
+import { DailyChallengeAssignment, DailyChallenge } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import {

--- a/src/user/services/user-deletion.service.spec.ts
+++ b/src/user/services/user-deletion.service.spec.ts
@@ -166,9 +166,7 @@ describe('UserDeletionService', () => {
 
       it('should log failure if session termination fails but continue with deletion', async () => {
         mockRepo.findUserById.mockResolvedValue(mockUser);
-        mockRepo.deleteAllUserSessions.mockRejectedValue(
-          new Error('DB error'),
-        );
+        mockRepo.deleteAllUserSessions.mockRejectedValue(new Error('DB error'));
         mockRepo.createActivityLog.mockResolvedValue({});
         mockRepo.deleteUserPermanently.mockResolvedValue(mockUser);
 

--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -410,9 +410,8 @@ export class VoiceQuotaService {
       // Determine source of locked voice: explicit lock vs user preference
       let lockedVoice: { elevenLabsVoiceId: string | null } | null = null;
       if (lockedUuid === usage?.selectedSecondVoiceId) {
-        lockedVoice = await this.voiceRepository.findElevenLabsIdById(
-          lockedUuid,
-        );
+        lockedVoice =
+          await this.voiceRepository.findElevenLabsIdById(lockedUuid);
       } else if (user?.preferredVoice) {
         lockedVoice = {
           elevenLabsVoiceId: user.preferredVoice.elevenLabsVoiceId,


### PR DESCRIPTION
Ports green's #417 to blue so both lines carry the fix.

## Why
The binary query engine spawns a separate `query-engine` subprocess that owns the DB connection pool. On a non-graceful shutdown (SIGKILL / crash / Ctrl-C) that subprocess is orphaned to init and keeps its DB connections open, exhausting the shared RDS — which is the exact crash-loop blue hits on boot.

The library (Node-API) engine runs in-process, so connections always die with the Node process. Nothing to orphan.

## Change
- `prisma/schema.prisma`: `engineType = "binary"` → `"library"` (with rationale comment).

## Parity
Green (`develop-v1.2.0`) received this via #417; `main` already carries it. This brings blue (`develop-v1.3.0`) in line.

## Deploy note
Requires `prisma generate` + rebuild on the blue host for the engine switch to take effect (a restart alone won't swap engines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added ownership verification when recommending stories, helping prevent unauthorized access to recommendation actions.
  * Improved database connection handling to reduce the risk of lingering processes after unexpected application termination.

* **Refactor**
  * Standardized code, imports, service calls, module declarations, and interface formatting across story, payment, reporting, notification, and support areas.

* **Tests**
  * Updated test formatting and assertions without changing coverage or expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->