### PR TITLE
fix(notifications): env-scoped FCM broadcast topic (stop dev→prod push bleed)

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -2573,10 +2573,11 @@ export class AdminController {
   @ApiQuery({
     name: 'topic',
     required: false,
-    example: 'all_users_production',
     description:
-      'Defaults to the environment-scoped topic all_users_<NODE_ENV>. Omit ' +
-      'after a deploy to re-seed existing devices onto this environment topic.',
+      "Normally omitted: defaults to this deployment's environment-scoped topic " +
+      '(all_users_<NODE_ENV>) to re-seed existing devices after a deploy. If ' +
+      'supplied it must exactly match the current environment topic; legacy ' +
+      '`all_users` and other environments’ topics are rejected (400).',
   })
   @ApiCreatedResponse({ description: 'Topic seed initiated' })
   @HttpCode(HttpStatus.CREATED)

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -2570,7 +2570,14 @@ export class AdminController {
   @ApiOperation({
     summary: 'Subscribe all existing devices to a topic (one-time seed)',
   })
-  @ApiQuery({ name: 'topic', required: false, example: 'all_users' })
+  @ApiQuery({
+    name: 'topic',
+    required: false,
+    example: 'all_users_production',
+    description:
+      'Defaults to the environment-scoped topic all_users_<NODE_ENV>. Omit ' +
+      'after a deploy to re-seed existing devices onto this environment topic.',
+  })
   @ApiCreatedResponse({ description: 'Topic seed initiated' })
   @HttpCode(HttpStatus.CREATED)
   async seedTopicSubscriptions(@Query('topic') topic?: string) {

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -2748,7 +2748,10 @@ export class AdminService {
   async broadcastNotification(
     dto: BroadcastNotificationDto,
   ): Promise<{ sent: boolean; topic: string; inAppDelivered: number }> {
-    const topic = dto.topic ?? 'all_users';
+    // Default to the env-scoped broadcast topic (all_users_<NODE_ENV>) resolved
+    // by NotificationService, so we never fan out to the global `all_users`
+    // topic that would bleed across dev/staging/prod (shared Firebase project).
+    const topic = dto.topic ?? this.notificationService.getBroadcastTopic();
 
     await this.eventEmitter.emitAsync('notification.broadcast', {
       topic,
@@ -2822,10 +2825,12 @@ export class AdminService {
 
   /**
    * Seed all existing device tokens to a topic.
+   * Defaults to the env-scoped broadcast topic (all_users_<NODE_ENV>) so that,
+   * after deploy, existing devices re-subscribe to their environment's topic.
    * Emits a 'notification.seed-topic' event.
    */
   async seedTopicSubscriptions(
-    topic: string = 'all_users',
+    topic: string = this.notificationService.getBroadcastTopic(),
   ): Promise<{ emitted: boolean }> {
     if (!/^[a-zA-Z0-9\-_.~%]+$/.test(topic)) {
       throw new BadRequestException(

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -2748,10 +2748,22 @@ export class AdminService {
   async broadcastNotification(
     dto: BroadcastNotificationDto,
   ): Promise<{ sent: boolean; topic: string; inAppDelivered: number }> {
-    // Default to the env-scoped broadcast topic (all_users_<NODE_ENV>) resolved
-    // by NotificationService, so we never fan out to the global `all_users`
-    // topic that would bleed across dev/staging/prod (shared Firebase project).
-    const topic = dto.topic ?? this.notificationService.getBroadcastTopic();
+    // The env-scoped broadcast topic (all_users_<NODE_ENV>) for THIS backend.
+    const scopedTopic = this.notificationService.getBroadcastTopic();
+
+    // Isolation guard: an admin may omit `topic` (uses the env-scoped default),
+    // but may NOT target the legacy global `all_users` or another environment's
+    // `all_users_<env>` topic — the Firebase project is shared, so that would
+    // bleed the broadcast across dev/staging/prod. Only this env's topic is
+    // permitted; anything else is rejected rather than silently coerced.
+    if (dto.topic && dto.topic !== scopedTopic) {
+      throw new BadRequestException(
+        `Broadcast topic "${dto.topic}" is not allowed. Omit "topic" to use this ` +
+          `environment's topic ("${scopedTopic}"); cross-environment and legacy ` +
+          `topics are blocked to prevent cross-environment push bleed.`,
+      );
+    }
+    const topic = scopedTopic;
 
     await this.eventEmitter.emitAsync('notification.broadcast', {
       topic,
@@ -2835,6 +2847,17 @@ export class AdminService {
     if (!/^[a-zA-Z0-9\-_.~%]+$/.test(topic)) {
       throw new BadRequestException(
         'Invalid topic name: must contain only valid FCM topic characters',
+      );
+    }
+    // Isolation guard (mirrors broadcast): only this environment's topic may be
+    // seeded, so an admin can't re-subscribe every device back onto the legacy
+    // global `all_users` (or another env's topic) and re-open the bleed.
+    const scopedTopic = this.notificationService.getBroadcastTopic();
+    if (topic !== scopedTopic) {
+      throw new BadRequestException(
+        `Seed topic "${topic}" is not allowed. Omit "topic" to seed this ` +
+          `environment's topic ("${scopedTopic}"); cross-environment and legacy ` +
+          `topics are blocked.`,
       );
     }
     try {

--- a/src/admin/dto/broadcast-notification.dto.ts
+++ b/src/admin/dto/broadcast-notification.dto.ts
@@ -28,8 +28,9 @@ export class BroadcastNotificationDto {
     description:
       'FCM topic to broadcast to. Defaults to the environment-scoped topic ' +
       '`all_users_<NODE_ENV>` (e.g. all_users_production) so broadcasts never ' +
-      'bleed across environments that share a Firebase project. Provide a value ' +
-      'only to override the default.',
+      'bleed across environments that share a Firebase project. Omit this field ' +
+      "in normal use; if provided it MUST equal this environment's topic — " +
+      'legacy `all_users` and other environments’ topics are rejected (400).',
   })
   @IsOptional()
   @IsString()

--- a/src/admin/dto/broadcast-notification.dto.ts
+++ b/src/admin/dto/broadcast-notification.dto.ts
@@ -24,8 +24,12 @@ export class BroadcastNotificationDto {
   body: string;
 
   @ApiPropertyOptional({
-    example: 'all_users',
-    description: 'FCM topic to broadcast to (defaults to all_users)',
+    example: 'all_users_production',
+    description:
+      'FCM topic to broadcast to. Defaults to the environment-scoped topic ' +
+      '`all_users_<NODE_ENV>` (e.g. all_users_production) so broadcasts never ' +
+      'bleed across environments that share a Firebase project. Provide a value ' +
+      'only to override the default.',
   })
   @IsOptional()
   @IsString()

--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -172,19 +172,32 @@ describe('AdminService', () => {
       );
     });
 
-    it('respects an explicit topic override', async () => {
+    it('rejects a cross-environment / legacy topic override', async () => {
+      // getBroadcastTopic() is mocked to 'all_users_production'; any other topic
+      // (legacy all_users, another env's topic, or an arbitrary one) is blocked.
+      await expect(
+        service.broadcastNotification({
+          title: 'Hello',
+          body: 'World',
+          topic: 'all_users',
+        }),
+      ).rejects.toThrow(/not allowed/i);
+
+      expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+    });
+
+    it('accepts an explicit topic equal to this environment topic', async () => {
       const result = await service.broadcastNotification({
         title: 'Hello',
         body: 'World',
-        topic: 'custom_topic',
+        topic: 'all_users_production',
       });
 
-      expect(mockNotificationService.getBroadcastTopic).not.toHaveBeenCalled();
       expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
         'notification.broadcast',
-        expect.objectContaining({ topic: 'custom_topic' }),
+        expect.objectContaining({ topic: 'all_users_production' }),
       );
-      expect(result.topic).toBe('custom_topic');
+      expect(result.topic).toBe('all_users_production');
     });
   });
 

--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -25,6 +25,13 @@ const mockElevenLabsProvider = {
 // Mock EventEmitter2
 const mockEventEmitter = {
   emit: jest.fn(),
+  emitAsync: jest.fn().mockResolvedValue([]),
+};
+
+// Mock NotificationService (env-scoped broadcast topic + in-app fan-out)
+const mockNotificationService = {
+  getBroadcastTopic: jest.fn().mockReturnValue('all_users_production'),
+  broadcastInAppToAllUsers: jest.fn().mockResolvedValue({ delivered: 0 }),
 };
 
 // Mock CouponService
@@ -131,7 +138,7 @@ describe('AdminService', () => {
         },
         {
           provide: NotificationService,
-          useValue: { broadcastInAppToAllUsers: jest.fn() },
+          useValue: mockNotificationService,
         },
       ],
     }).compile();
@@ -143,6 +150,42 @@ describe('AdminService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('broadcastNotification', () => {
+    it('defaults to the env-scoped topic from NotificationService when no topic is provided', async () => {
+      const result = await service.broadcastNotification({
+        title: 'Hello',
+        body: 'World',
+      });
+
+      expect(mockNotificationService.getBroadcastTopic).toHaveBeenCalled();
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'all_users_production' }),
+      );
+      expect(result.topic).toBe('all_users_production');
+      // Must never fan out to the unscoped global topic.
+      expect(mockEventEmitter.emitAsync).not.toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'all_users' }),
+      );
+    });
+
+    it('respects an explicit topic override', async () => {
+      const result = await service.broadcastNotification({
+        title: 'Hello',
+        body: 'World',
+        topic: 'custom_topic',
+      });
+
+      expect(mockNotificationService.getBroadcastTopic).not.toHaveBeenCalled();
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'custom_topic' }),
+      );
+      expect(result.topic).toBe('custom_topic');
+    });
   });
 
   describe('getDashboardStats', () => {

--- a/src/notification/notification.service.spec.ts
+++ b/src/notification/notification.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NotificationService } from './notification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { InAppProvider } from './providers/in-app.provider';
+import { EmailProvider } from './providers/email.provider';
+import { PushProvider } from './providers/push.provider';
+import { EmailQueueService } from './queue/email-queue.service';
+import { PushQueueService } from './queue/push-queue.service';
+import { DevicePlatform } from './dto/device-token.dto';
+
+/**
+ * Build a NotificationService whose ConfigService reports the given NODE_ENV.
+ * All other constructor deps are mocked. Returns the service plus the shared
+ * mocks that the individual tests assert against.
+ */
+async function buildService(nodeEnv: string | undefined) {
+  const configValues: Record<string, unknown> = {
+    NODE_ENV: nodeEnv,
+    SMTP_HOST: 'smtp.example.com',
+    SMTP_PORT: 587,
+    SMTP_SECURE: false,
+    SMTP_USER: 'user@example.com',
+    SMTP_PASS: 'secret',
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => configValues[key]),
+  };
+
+  const mockPrisma = {
+    deviceToken: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  const mockPushProvider = {
+    subscribeToTopic: jest.fn().mockResolvedValue(undefined),
+    unsubscribeFromTopic: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      NotificationService,
+      { provide: ConfigService, useValue: mockConfigService },
+      { provide: PrismaService, useValue: mockPrisma },
+      { provide: InAppProvider, useValue: {} },
+      { provide: EmailProvider, useValue: {} },
+      { provide: EmailQueueService, useValue: {} },
+      { provide: PushProvider, useValue: mockPushProvider },
+      { provide: PushQueueService, useValue: {} },
+    ],
+  }).compile();
+
+  const service = module.get<NotificationService>(NotificationService);
+  return { service, mockPrisma, mockPushProvider };
+}
+
+describe('NotificationService - env-scoped broadcast topic', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getBroadcastTopic', () => {
+    it('resolves to all_users_production when NODE_ENV=production', async () => {
+      const { service } = await buildService('production');
+      expect(service.getBroadcastTopic()).toBe('all_users_production');
+    });
+
+    it('resolves to all_users_staging when NODE_ENV=staging', async () => {
+      const { service } = await buildService('staging');
+      expect(service.getBroadcastTopic()).toBe('all_users_staging');
+    });
+
+    it('resolves to all_users_development when NODE_ENV=development', async () => {
+      const { service } = await buildService('development');
+      expect(service.getBroadcastTopic()).toBe('all_users_development');
+    });
+
+    it('falls back to all_users_development when NODE_ENV is unset', async () => {
+      const { service } = await buildService(undefined);
+      expect(service.getBroadcastTopic()).toBe('all_users_development');
+    });
+
+    it('never produces the unscoped global "all_users" topic', async () => {
+      for (const env of ['production', 'staging', 'development', undefined]) {
+        const { service } = await buildService(env);
+        expect(service.getBroadcastTopic()).not.toBe('all_users');
+      }
+    });
+  });
+
+  describe('registerDeviceToken', () => {
+    it('subscribes a newly registered token to the env-scoped topic', async () => {
+      const { service, mockPrisma, mockPushProvider } =
+        await buildService('production');
+
+      mockPrisma.deviceToken.findUnique.mockResolvedValue(null);
+      mockPrisma.$transaction.mockImplementation(async (cb: any) =>
+        cb({
+          deviceToken: {
+            updateMany: jest.fn(),
+            create: jest.fn().mockResolvedValue({
+              id: 'dt-1',
+              userId: 'user-1',
+              token: 'token-abc',
+              platform: DevicePlatform.IOS,
+              deviceName: null,
+              isActive: true,
+              isDeleted: false,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            }),
+          },
+        }),
+      );
+
+      await service.registerDeviceToken(
+        'user-1',
+        'token-abc',
+        DevicePlatform.IOS,
+      );
+
+      expect(mockPushProvider.subscribeToTopic).toHaveBeenCalledWith(
+        ['token-abc'],
+        'all_users_production',
+      );
+      expect(mockPushProvider.subscribeToTopic).not.toHaveBeenCalledWith(
+        ['token-abc'],
+        'all_users',
+      );
+    });
+  });
+
+  describe('subscribeAllExistingDevicesToTopic', () => {
+    it('defaults to the env-scoped topic when no topic is provided', async () => {
+      const { service, mockPrisma, mockPushProvider } =
+        await buildService('staging');
+
+      mockPrisma.deviceToken.findMany
+        .mockResolvedValueOnce([{ id: 'dt-1', token: 'token-1' }])
+        .mockResolvedValueOnce([]);
+
+      await service.subscribeAllExistingDevicesToTopic();
+
+      expect(mockPushProvider.subscribeToTopic).toHaveBeenCalledWith(
+        ['token-1'],
+        'all_users_staging',
+      );
+    });
+  });
+});

--- a/src/notification/notification.service.spec.ts
+++ b/src/notification/notification.service.spec.ts
@@ -151,5 +151,35 @@ describe('NotificationService - env-scoped broadcast topic', () => {
         'all_users_staging',
       );
     });
+
+    it('also unsubscribes the batch from the legacy all_users topic', async () => {
+      const { service, mockPrisma, mockPushProvider } =
+        await buildService('staging');
+
+      mockPrisma.deviceToken.findMany
+        .mockResolvedValueOnce([{ id: 'dt-1', token: 'token-1' }])
+        .mockResolvedValueOnce([]);
+
+      await service.subscribeAllExistingDevicesToTopic();
+
+      // Migration cleanup: same batch is removed from the legacy global topic.
+      expect(mockPushProvider.unsubscribeFromTopic).toHaveBeenCalledWith(
+        ['token-1'],
+        'all_users',
+      );
+    });
+
+    it('does NOT unsubscribe when deliberately re-seeding all_users itself', async () => {
+      const { service, mockPrisma, mockPushProvider } =
+        await buildService('staging');
+
+      mockPrisma.deviceToken.findMany
+        .mockResolvedValueOnce([{ id: 'dt-1', token: 'token-1' }])
+        .mockResolvedValueOnce([]);
+
+      await service.subscribeAllExistingDevicesToTopic('all_users');
+
+      expect(mockPushProvider.unsubscribeFromTopic).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -93,6 +93,14 @@ export class NotificationService {
    */
   private readonly broadcastTopic: string;
 
+  /**
+   * The legacy, un-scoped topic every device was historically subscribed to.
+   * We no longer subscribe or broadcast to it; the re-seed migration also
+   * unsubscribes existing devices from it so a manual override broadcast to
+   * `all_users` can't reach cross-environment subscribers.
+   */
+  private readonly legacyBroadcastTopic = 'all_users';
+
   constructor(
     private readonly configService: ConfigService<EnvConfig, true>,
     private readonly prisma: PrismaService,
@@ -1255,12 +1263,35 @@ export class NotificationService {
 
       const tokens = devices.map((d) => d.token);
       await this.pushProvider.subscribeToTopic(tokens, topic);
+
+      // Migration cleanup: also unsubscribe this batch from the legacy global
+      // `all_users` topic, so a manual broadcast that overrides
+      // `topic: 'all_users'` can no longer reach stale cross-environment
+      // subscribers. Skip if we're deliberately (re)seeding `all_users` itself.
+      // Best-effort: a legacy-unsubscribe failure must not abort the re-seed.
+      if (topic !== this.legacyBroadcastTopic) {
+        try {
+          await this.pushProvider.unsubscribeFromTopic(
+            tokens,
+            this.legacyBroadcastTopic,
+          );
+        } catch (err) {
+          this.logger.warn(
+            `Failed to unsubscribe batch ${batches + 1} from legacy topic ` +
+              `${this.legacyBroadcastTopic}: ${(err as Error).message}`,
+          );
+        }
+      }
+
       batches++;
       total += tokens.length;
       cursor = devices[devices.length - 1].id;
 
       this.logger.log(
-        `Subscribed batch ${batches} (${tokens.length} tokens) to topic: ${topic}`,
+        `Subscribed batch ${batches} (${tokens.length} tokens) to topic: ${topic}` +
+          (topic !== this.legacyBroadcastTopic
+            ? ` and unsubscribed from ${this.legacyBroadcastTopic}`
+            : ''),
       );
 
       if (devices.length < BATCH_SIZE) break;

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -80,6 +80,19 @@ export class NotificationService {
   private transporter: nodemailer.Transporter;
   private providers: Map<string, INotificationProvider>;
 
+  /**
+   * Single source of truth for the environment-scoped FCM broadcast topic.
+   *
+   * dev/staging/prod share ONE Firebase project, and FCM topics are global to
+   * the project. A hardcoded `all_users` topic therefore bleeds broadcasts
+   * across environments (a dev broadcast reaches prod-subscribed devices).
+   * Scoping the topic per environment (`all_users_<NODE_ENV>`) guarantees each
+   * backend only ever subscribes/broadcasts to its OWN environment's topic.
+   * `all_users_<env>` stays within the valid FCM topic charset
+   * (`[a-zA-Z0-9-_.~%]+`).
+   */
+  private readonly broadcastTopic: string;
+
   constructor(
     private readonly configService: ConfigService<EnvConfig, true>,
     private readonly prisma: PrismaService,
@@ -108,6 +121,21 @@ export class NotificationService {
     this.providers.set('email', this.emailProvider);
     this.providers.set('in_app', this.inAppProvider);
     this.providers.set('push', this.pushProvider);
+
+    // Compute the environment-scoped broadcast topic once. Fall back to
+    // 'development' when NODE_ENV is unset/empty, matching the env-validation
+    // default so the topic is never `all_users_` (an invalid, unscoped value).
+    const nodeEnv = this.configService.get('NODE_ENV') || 'development';
+    this.broadcastTopic = `all_users_${nodeEnv}`;
+  }
+
+  /**
+   * The environment-scoped FCM topic this backend broadcasts to and subscribes
+   * devices to (e.g. `all_users_production`). Exposed so other modules (e.g.
+   * AdminService) can default to it without duplicating the topic string.
+   */
+  getBroadcastTopic(): string {
+    return this.broadcastTopic;
   }
 
   /**
@@ -982,12 +1010,12 @@ export class NotificationService {
           },
         });
         this.logger.log(`Updated device token for user ${userId}`);
-        // Re-subscribe to all_users topic (best-effort; don't fail token save on FCM side effects)
+        // Re-subscribe to the env-scoped broadcast topic (best-effort; don't fail token save on FCM side effects)
         this.pushProvider
-          .subscribeToTopic([token], 'all_users')
+          .subscribeToTopic([token], this.broadcastTopic)
           .catch((err) =>
             this.logger.warn(
-              `Failed to subscribe updated token to all_users: ${(err as Error).message}`,
+              `Failed to subscribe updated token to ${this.broadcastTopic}: ${(err as Error).message}`,
             ),
           );
         return this.toDeviceTokenResponse(updated);
@@ -1008,12 +1036,12 @@ export class NotificationService {
       this.logger.log(
         `Reassigned device token from user ${existingToken.userId} to ${userId}`,
       );
-      // Subscribe reassigned token to all_users topic (best-effort)
+      // Subscribe reassigned token to the env-scoped broadcast topic (best-effort)
       this.pushProvider
-        .subscribeToTopic([token], 'all_users')
+        .subscribeToTopic([token], this.broadcastTopic)
         .catch((err) =>
           this.logger.warn(
-            `Failed to subscribe reassigned token to all_users: ${(err as Error).message}`,
+            `Failed to subscribe reassigned token to ${this.broadcastTopic}: ${(err as Error).message}`,
           ),
         );
       return this.toDeviceTokenResponse(updated);
@@ -1063,20 +1091,20 @@ export class NotificationService {
     // Best-effort unsubscribe old tokens from broadcast topic
     if (oldTokenStrings.length > 0) {
       this.pushProvider
-        .unsubscribeFromTopic(oldTokenStrings, 'all_users')
+        .unsubscribeFromTopic(oldTokenStrings, this.broadcastTopic)
         .catch((err) =>
           this.logger.warn(
-            `Failed to unsubscribe old tokens from all_users: ${(err as Error).message}`,
+            `Failed to unsubscribe old tokens from ${this.broadcastTopic}: ${(err as Error).message}`,
           ),
         );
     }
 
-    // Subscribe the new token to the all_users topic (best-effort; don't fail registration on FCM side effects)
+    // Subscribe the new token to the env-scoped broadcast topic (best-effort; don't fail registration on FCM side effects)
     this.pushProvider
-      .subscribeToTopic([token], 'all_users')
+      .subscribeToTopic([token], this.broadcastTopic)
       .catch((err) =>
         this.logger.warn(
-          `Failed to subscribe new token to all_users: ${(err as Error).message}`,
+          `Failed to subscribe new token to ${this.broadcastTopic}: ${(err as Error).message}`,
         ),
       );
 
@@ -1129,10 +1157,10 @@ export class NotificationService {
 
     // Best-effort unsubscribe from broadcast topic
     this.pushProvider
-      .unsubscribeFromTopic([token], 'all_users')
+      .unsubscribeFromTopic([token], this.broadcastTopic)
       .catch((err) =>
         this.logger.warn(
-          `Failed to unsubscribe token from all_users: ${(err as Error).message}`,
+          `Failed to unsubscribe token from ${this.broadcastTopic}: ${(err as Error).message}`,
         ),
       );
 
@@ -1202,11 +1230,12 @@ export class NotificationService {
   }
 
   /**
-   * Subscribe all existing active device tokens to the all_users topic.
+   * Subscribe all existing active device tokens to the broadcast topic.
+   * Defaults to the env-scoped topic (`all_users_<NODE_ENV>`); overridable.
    * Run once to seed existing devices. Processes in batches of 1000 (Firebase limit).
    */
   async subscribeAllExistingDevicesToTopic(
-    topic: string = 'all_users',
+    topic: string = this.broadcastTopic,
   ): Promise<{ total: number; batches: number }> {
     const BATCH_SIZE = 1000;
     let cursor: string | undefined;


### PR DESCRIPTION
## Problem
dev/staging/prod share one Firebase project (`storytimeapp-29aea`), and FCM topics are **global to the project**. The broadcast topic was hardcoded `all_users`, so a **dev broadcast reaches prod-subscribed devices** (cross-env push bleed).

## Fix
- Scope the topic per env: `all_users` → **`all_users_${NODE_ENV}`** (single source of truth in `NotificationService`, exposed via `getBroadcastTopic()`; NODE_ENV unset → `development`). All 5 subscribe/unsubscribe call sites + the admin broadcast/seed defaults now use it. Token-based **batched** broadcast is untouched (already DB/env-isolated).
- **Re-seed now also unsubscribes from legacy `all_users`**: `subscribeAllExistingDevicesToTopic` unsubscribes each batch from the old global topic (skipped when seeding `all_users` itself; best-effort). Closes the manual-override gap.

## Migration (after each env deploys)
Run the re-seed once per env (subscribes existing devices to `all_users_<env>` **and** unsubscribes them from `all_users`):
```
POST /admin/notifications/seed-topic   # topic omitted → all_users_<env>
```
Until re-seeded, existing devices won't RECEIVE the new env-scoped broadcasts, but the **bleed stops immediately on deploy** (nothing broadcasts to global `all_users` anymore).

## Validation
`pnpm build` ✅ · notification specs **9 passed** (incl. 2 new legacy-unsubscribe tests) · admin specs green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now use environment-specific broadcast topics to prevent cross-environment delivery.
  * Device registrations and notification broadcasts automatically use the current environment’s topic.
  * Existing device subscriptions are migrated away from the legacy shared topic.

* **Bug Fixes**
  * Rejected broadcast or topic-seeding requests targeting legacy or other environments’ topics.
  * Updated API documentation to clarify topic defaults and validation behavior.

* **Tests**
  * Added coverage for environment-specific topics, device subscriptions, migration cleanup, and invalid topic rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->