### PR TITLE
chore(ci): Codecov coverage upload + README badge

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -144,6 +144,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/storytime_test
       REDIS_URL: redis://localhost:6379
+      # Mapped from the secret so the upload step can gate on its presence
+      # (secrets aren't allowed directly in step-level `if:`). Unset => no-op.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     services:
       postgres:
@@ -213,6 +216,16 @@ jobs:
       - name: Run tests with coverage
         continue-on-error: true
         run: pnpm test --coverage
+
+      - name: Upload coverage to Codecov
+        # No-op until CODECOV_TOKEN is set (see repo secrets); never fails CI.
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          fail_ci_if_error: false
 
       - name: Cleanup sensitive files
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Storytime Backend API
 
+<!--
+  Coverage badge. One-time setup to make it live:
+    1. Enable this repo on https://app.codecov.io (org: Bolt-Silverfox).
+    2. Add repo secret CODECOV_TOKEN (Codecov → repo → Settings → General).
+    3. Copy the graph token from Codecov → Settings → Badges & Graphs and
+       replace CODECOV_GRAPH_TOKEN below with it.
+  Until then the CI upload step no-ops and the badge shows "unknown".
+-->
+[![codecov](https://codecov.io/gh/Bolt-Silverfox/storytime_be/branch/develop-v1.3.0/graph/badge.svg?token=CODECOV_GRAPH_TOKEN)](https://codecov.io/gh/Bolt-Silverfox/storytime_be)
+
 A NestJS-based backend API for the Storytime application, providing interactive storytelling experiences for children with AI-powered story generation, user management, and content delivery.
 
 ## Features


### PR DESCRIPTION
## What
- Gated **codecov-action@v5** upload step in the `develop-v*` Test job (which already runs `pnpm test --coverage`). Maps `CODECOV_TOKEN` secret → env and only uploads when set, so CI **never breaks** before setup.
- **Coverage badge** in README (points at `develop-v1.3.0`).

## One-time setup to make the badge live (free)
1. Enable this repo on https://app.codecov.io (org `Bolt-Silverfox`).
2. Add repo secret **`CODECOV_TOKEN`**.
3. Replace `CODECOV_GRAPH_TOKEN` in the README badge URL with the graph token from Codecov → Settings → Badges & Graphs.

Until then the upload no-ops and the badge shows "unknown". Coverage populates on the next PR merge into `develop-v1.3.0` (post-merge Test run).