### PR TITLE
feat(security): strict global CSP + Swagger-scoped relaxation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { HttpExceptionFilter } from './shared/filters/http-exception.filter';
 import { PrismaExceptionFilter } from './shared/filters/prisma-exception.filter';
 import { SentryExceptionFilter } from './shared/filters/sentry-exception.filter';
 import { requestLogger } from './shared/middleware/request-logger.middleware';
+import { swaggerCspDirectives } from './shared/config/security.config';
 import { WinstonModule } from 'nest-winston';
 import { winstonConfig } from './shared/config/logger.config';
 
@@ -82,7 +83,15 @@ async function bootstrap() {
   app.use(json({ limit: '10mb' }));
   app.use(urlencoded({ extended: true, limit: '10mb' }));
 
+  // Strict default CSP (script-src 'self', object-src 'none', …) for the whole API.
   app.use(helmet());
+  // Swagger UI (/docs) injects inline scripts/styles the strict CSP would block,
+  // so relax the CSP ONLY for /docs. Registered AFTER the global helmet so it
+  // overwrites the CSP header for /docs requests; all other routes stay strict.
+  app.use(
+    '/docs',
+    helmet({ contentSecurityPolicy: { directives: swaggerCspDirectives } }),
+  );
   app.use(requestLogger);
   app.enableCors({
     origin: (

--- a/src/shared/config/security.config.spec.ts
+++ b/src/shared/config/security.config.spec.ts
@@ -1,0 +1,29 @@
+import { swaggerCspDirectives } from './security.config';
+
+describe('swaggerCspDirectives', () => {
+  it('allows swagger-ui inline scripts but keeps self', () => {
+    expect(swaggerCspDirectives.scriptSrc).toEqual(
+      expect.arrayContaining(["'self'", "'unsafe-inline'"]),
+    );
+  });
+
+  it('never allows unsafe-eval', () => {
+    for (const values of Object.values(swaggerCspDirectives)) {
+      expect(values).not.toContain("'unsafe-eval'");
+    }
+  });
+
+  it('allows data: images (swagger-ui embeds inline images)', () => {
+    expect(swaggerCspDirectives.imgSrc).toContain('data:');
+  });
+
+  it('only relaxes script/style/img — not default-src, object-src, or base-uri', () => {
+    // Those stay at Helmet's strict defaults via useDefaults; overriding them
+    // here would silently weaken the global-equivalent baseline for /docs.
+    expect(Object.keys(swaggerCspDirectives).sort()).toEqual([
+      'imgSrc',
+      'scriptSrc',
+      'styleSrc',
+    ]);
+  });
+});

--- a/src/shared/config/security.config.ts
+++ b/src/shared/config/security.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Content-Security-Policy directives scoped to the Swagger UI route (`/docs`).
+ *
+ * The API applies Helmet's strict default CSP globally (`script-src 'self'`,
+ * which blocks inline scripts). Swagger UI (swagger-ui-express) injects an
+ * inline init script plus inline styles, so under the strict default CSP the
+ * `/docs` page is CSP-broken. Rather than weaken the CSP for the whole API,
+ * these directives relax ONLY what swagger-ui needs and are mounted scoped to
+ * `/docs` (see `main.ts`), leaving every other route on the strict default.
+ *
+ * Deliberately NOT relaxed: `'unsafe-eval'` (swagger-ui does not need it),
+ * `default-src`, `object-src`, `base-uri` — those stay at Helmet's strict
+ * defaults via `useDefaults` (unspecified directives are not overridden).
+ */
+export const swaggerCspDirectives: Record<string, string[]> = {
+  scriptSrc: ["'self'", "'unsafe-inline'"],
+  styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+  imgSrc: ["'self'", 'data:', 'https:'],
+};


### PR DESCRIPTION
Honest equivalent of the audit's "CSP nonce for inline scripts" (the API renders no HTML of its own, so a per-request nonce would be dead config).

## Change
- Keep Helmet's **strict default CSP globally** (`script-src 'self'`, `object-src 'none'`, …).
- Relax the CSP **only for `/docs`** (scoped helmet mounted after the global one) so swagger-ui's inline init script/styles work — previously they were silently CSP-blocked.
- Directives extracted to `src/shared/config/security.config.ts` + unit test (scriptSrc allows `'unsafe-inline'` for swagger but **never** `'unsafe-eval'`; only script/style/img relaxed).

## Verify
Unit test passes; `tsc --noEmit` clean. Post-deploy: `GET /docs` returns a `content-security-policy` header with `'unsafe-inline'` in script-src; any other route returns the strict one without it.