### PR TITLE
ci(staging): fix health-check port (3600, not 3500)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -381,10 +381,13 @@ jobs:
             # probe would pass a crash-loop that happens to be up at second 60, so
             # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
             # window; a crash-loop keeps resetting the streak and fails the gate.
+            # NOTE: staging listens on :3600 (dev/prod use :3500). This curled
+            # :3500 before, so the streak never incremented and every staging
+            # deploy failed the gate even when the app was healthy.
             streak=0
             for i in $(seq 1 12); do
               sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+              if curl -sf http://localhost:3600/api/v1/health > /dev/null 2>&1; then
                 streak=$((streak + 1))
               else
                 streak=0


### PR DESCRIPTION
Staging Verify step curled :3500 but the app listens on :3600, so every staging deploy failed the streak gate (false 'crash-loop') despite a healthy app. One-line port fix; streak logic unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staging deployment health checks to use the correct service port.
  * Improved deployment verification reliability without changing the existing health-check criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->