### PR TITLE
feat(gdpr): data-portability export endpoint (GET /user/me/export)

### DIFF
--- a/src/user/repositories/prisma-user.repository.ts
+++ b/src/user/repositories/prisma-user.repository.ts
@@ -16,6 +16,8 @@ import {
   UserWithProfileAndAvatar,
   UserWithProfileAvatarAndCategories,
   UserWithAvatar,
+  UserDataExport,
+  USER_EXPORT_INCLUDE,
 } from './user.repository.interface';
 
 @Injectable()
@@ -42,6 +44,13 @@ export class PrismaUserRepository implements IUserRepository {
         avatar: true,
         subscription: true,
       },
+    });
+  }
+
+  async findUserForExport(id: string): Promise<UserDataExport | null> {
+    return this.prisma.user.findUnique({
+      where: { id, isDeleted: false },
+      include: USER_EXPORT_INCLUDE,
     });
   }
 

--- a/src/user/repositories/user.repository.interface.ts
+++ b/src/user/repositories/user.repository.interface.ts
@@ -49,6 +49,60 @@ export interface SafeUser extends Omit<User, 'passwordHash' | 'pinHash'> {
   numberOfKids?: number;
 }
 
+// ==================== GDPR Data Export ====================
+// The set of relations a "download all my data" (data-portability) export
+// gathers. Kept as a typed constant so `Prisma.UserGetPayload` can derive the
+// return type AND so `satisfies Prisma.UserInclude` compile-checks every
+// relation name. Deliberately excluded: activityLogs / userIps (internal
+// audit/security data, not user-provided) and paymentMethods (gateway tokens).
+// Kids' `createdStories` use a light `select` (no heavy images/branches/audio
+// caches) so the payload stays bounded.
+export const USER_EXPORT_INCLUDE = {
+  profile: true,
+  avatar: true,
+  subscription: true,
+  paymentTransactions: true,
+  notifications: true,
+  notificationPreferences: true,
+  parentFavorites: true,
+  userStoryProgress: true,
+  learningExpectations: true,
+  couponRedemptions: true,
+  voices: true,
+  badges: true,
+  supportTickets: true,
+  preferredCategories: true,
+  kids: {
+    include: {
+      favorites: true,
+      progresses: true,
+      rewards: true,
+      rewardRedemptions: true,
+      downloadedStories: true,
+      questionAnswers: true,
+      notificationPreferences: true,
+      createdStories: {
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          language: true,
+          coverImageUrl: true,
+          audioUrl: true,
+          textContent: true,
+          isInteractive: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.UserInclude;
+
+export type UserDataExport = Prisma.UserGetPayload<{
+  include: typeof USER_EXPORT_INCLUDE;
+}>;
+
 // ==================== Repository Interface ====================
 export interface IUserRepository {
   // User read operations
@@ -59,6 +113,8 @@ export interface IUserRepository {
   ): Promise<UserWithRelations | null>;
   findAllUsers(): Promise<UserWithProfileAndAvatar[]>;
   findActiveUsers(): Promise<UserWithProfileAndAvatar[]>;
+  /** All of a user's portable data (self + kids) for a GDPR export. */
+  findUserForExport(id: string): Promise<UserDataExport | null>;
 
   // User write operations
   updateUserSimple(

--- a/src/user/services/user-data-export.service.spec.ts
+++ b/src/user/services/user-data-export.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import {
+  UserDataExportService,
+  USER_DATA_EXPORT_FORMAT,
+} from './user-data-export.service';
+import { USER_REPOSITORY } from '../repositories/user.repository.interface';
+
+describe('UserDataExportService', () => {
+  let service: UserDataExportService;
+  const findUserForExport = jest.fn();
+
+  beforeEach(async () => {
+    findUserForExport.mockReset();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserDataExportService,
+        { provide: USER_REPOSITORY, useValue: { findUserForExport } },
+      ],
+    }).compile();
+    service = module.get(UserDataExportService);
+  });
+
+  const EXPORTED_AT = '2026-07-21T00:00:00.000Z';
+
+  it('throws NotFoundException when the user does not exist', async () => {
+    findUserForExport.mockResolvedValue(null);
+    await expect(service.exportUserData('missing', EXPORTED_AT)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('strips passwordHash and pinHash from the export', async () => {
+    findUserForExport.mockResolvedValue({
+      id: 'u1',
+      email: 'p@example.com',
+      passwordHash: 'SECRET_HASH',
+      pinHash: 'SECRET_PIN',
+      name: 'Parent',
+      kids: [{ id: 'k1', name: 'Kid', createdStories: [] }],
+      profile: { country: 'NG' },
+    });
+
+    const result = await service.exportUserData('u1', EXPORTED_AT);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain('SECRET_HASH');
+    expect(serialized).not.toContain('SECRET_PIN');
+    expect(result.account).not.toHaveProperty('passwordHash');
+    expect(result.account).not.toHaveProperty('pinHash');
+  });
+
+  it('produces a self-describing envelope with the user id and format', async () => {
+    findUserForExport.mockResolvedValue({
+      id: 'u1',
+      email: 'p@example.com',
+      passwordHash: 'x',
+      pinHash: null,
+      kids: [],
+    });
+
+    const result = await service.exportUserData('u1', EXPORTED_AT);
+
+    expect(result.meta).toEqual({
+      format: USER_DATA_EXPORT_FORMAT,
+      exportedAt: EXPORTED_AT,
+      userId: 'u1',
+    });
+    // account keeps non-secret scalars and separates relations to the top level.
+    expect(result.account).toMatchObject({ id: 'u1', email: 'p@example.com' });
+    expect(result.kids).toEqual([]);
+  });
+});

--- a/src/user/services/user-data-export.service.ts
+++ b/src/user/services/user-data-export.service.ts
@@ -1,0 +1,109 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../repositories/user.repository.interface';
+
+/** Shape of the GDPR data-portability export (a self-describing JSON document). */
+export interface UserDataExportResult {
+  meta: {
+    format: string;
+    exportedAt: string;
+    userId: string;
+  };
+  account: Record<string, unknown>;
+  profile: unknown;
+  avatar: unknown;
+  subscription: unknown;
+  paymentTransactions: unknown;
+  notifications: unknown;
+  notificationPreferences: unknown;
+  parentFavorites: unknown;
+  userStoryProgress: unknown;
+  learningExpectations: unknown;
+  couponRedemptions: unknown;
+  voices: unknown;
+  badges: unknown;
+  supportTickets: unknown;
+  preferredCategories: unknown;
+  kids: unknown;
+}
+
+export const USER_DATA_EXPORT_FORMAT = 'storytime-data-export-v1';
+
+/**
+ * GDPR "right to data portability": assembles all of a user's own data (and
+ * their kids') into a single downloadable JSON document. Secrets
+ * (`passwordHash`, `pinHash`) are stripped; internal audit/security logs and
+ * payment-gateway tokens are intentionally out of scope (see USER_EXPORT_INCLUDE).
+ */
+@Injectable()
+export class UserDataExportService {
+  private readonly logger = new Logger(UserDataExportService.name);
+
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async exportUserData(
+    userId: string,
+    exportedAt: string,
+  ): Promise<UserDataExportResult> {
+    const data = await this.userRepository.findUserForExport(userId);
+    if (!data) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Split the top-level relations out of the scalar account fields.
+    const {
+      profile,
+      avatar,
+      subscription,
+      paymentTransactions,
+      notifications,
+      notificationPreferences,
+      parentFavorites,
+      userStoryProgress,
+      learningExpectations,
+      couponRedemptions,
+      voices,
+      badges,
+      supportTickets,
+      preferredCategories,
+      kids,
+      ...accountFields
+    } = data;
+
+    // Strip secrets from the scalar account fields.
+    const account = { ...accountFields } as Record<string, unknown>;
+    delete account.passwordHash;
+    delete account.pinHash;
+
+    this.logger.log(`Generated GDPR data export for user ${userId}`);
+
+    return {
+      meta: {
+        format: USER_DATA_EXPORT_FORMAT,
+        exportedAt,
+        userId,
+      },
+      account,
+      profile,
+      avatar,
+      subscription,
+      paymentTransactions,
+      notifications,
+      notificationPreferences,
+      parentFavorites,
+      userStoryProgress,
+      learningExpectations,
+      couponRedemptions,
+      voices,
+      badges,
+      supportTickets,
+      preferredCategories,
+      kids,
+    };
+  }
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,7 +17,9 @@ import {
   Logger,
   UploadedFile,
   UseInterceptors,
+  Res,
 } from '@nestjs/common';
+import { Response } from 'express';
 import {
   ApiTags,
   ApiOperation,
@@ -51,6 +53,7 @@ import {
   ResetPinWithOtpDto,
   ValidatePinResetOtpDto,
 } from './dto/pin-reset-otp.dto';
+import { UserDataExportService } from './services/user-data-export.service';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -70,6 +73,7 @@ export class UserController {
   constructor(
     private readonly userService: UserService,
     private readonly uploadService: UploadService,
+    private readonly userDataExportService: UserDataExportService,
   ) {}
   // ============================================================
   //                 SELF / PARENT PROFILE ENDPOINTS
@@ -327,6 +331,37 @@ export class UserController {
       body.otp,
       body.newPin,
     );
+  }
+
+  @Get('me/export')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Export all of my personal data (GDPR data portability)',
+    description:
+      'Returns a downloadable JSON document containing the authenticated ' +
+      "user's account, profile, subscription, payments, and their kids' data. " +
+      'Secrets and internal audit logs are excluded.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'A JSON file download (application/json) of the user data.',
+  })
+  async exportMyData(
+    @Req() req: AuthenticatedRequest,
+    @Res() res: Response,
+  ): Promise<void> {
+    const exportedAt = new Date().toISOString();
+    const data = await this.userDataExportService.exportUserData(
+      req.authUserData.userId,
+      exportedAt,
+    );
+    const filename = `storytime-data-export-${exportedAt.slice(0, 10)}.json`;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    // @Res() opts out of the global SuccessResponseInterceptor, so the body is
+    // the raw export document (not the standard { statusCode, data } envelope).
+    res.send(JSON.stringify(data, null, 2));
   }
 
   @Delete('me')

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -7,12 +7,14 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { UploadModule } from '@/upload/upload.module';
 import { USER_REPOSITORY } from './repositories';
 import { PrismaUserRepository } from './repositories/prisma-user.repository';
+import { UserDataExportService } from './services/user-data-export.service';
 
 @Module({
   imports: [AuthModule, NotificationModule, PrismaModule, UploadModule],
   controllers: [UserController],
   providers: [
     UserService,
+    UserDataExportService,
     {
       provide: USER_REPOSITORY,
       useClass: PrismaUserRepository,


### PR DESCRIPTION
Closes the audit's one outstanding GDPR requirement: **data portability** (erasure and consent are already done).

## What
`GET /user/me/export` (auth-guarded) streams a JSON download with all of the user's own and their kids' data — account, profile, subscription, payment transactions, notifications + preferences, favorites, story progress, rewards, voices, badges, support tickets, and per-kid data incl. their created stories.

## How
- New `UserDataExportService` aggregates via the repository (repo pattern — no direct Prisma in the service).
- `findUserForExport` uses a typed `USER_EXPORT_INCLUDE` (`satisfies Prisma.UserInclude`, so every relation name is **compile-checked**; `Prisma.UserGetPayload` derives the return type).
- Streams via `@Res` (bypasses the success-response envelope) with `Content-Disposition: attachment`.

## Scoping decisions
- **Stripped:** `passwordHash`, `pinHash`.
- **Excluded:** `activityLogs`/`userIps` (internal audit/security, not user-provided) and `paymentMethods` (gateway tokens).
- **Bounded:** kids' `createdStories` use a light `select` (title/description/text/urls) — no heavy images/branches/audio-cache graphs.

## Verify
- Unit tests (secret-stripping, not-found, envelope shape) — 3/3 pass; full user-module suite 59/59.
- `tsc --noEmit` and `eslint` clean.
- Post-deploy: `GET /api/v1/user/me/export` with a bearer token returns a JSON attachment; body contains no `passwordHash`/`pinHash`.

Note: synchronous streamed export — fine for typical accounts; an async/job-based export can follow if very large accounts time out.