### PR TITLE
docs: tooling badges + P3 tracker updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Node](https://img.shields.io/badge/Node-%E2%89%A520-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 
+[![Redis](https://img.shields.io/badge/Redis-cache-DC382D?logo=redis&logoColor=white)](https://redis.io/)
+[![BullMQ](https://img.shields.io/badge/BullMQ-queues-E10098)](https://docs.bullmq.io/)
+[![API docs: Swagger](https://img.shields.io/badge/API_docs-Swagger-85EA2D?logo=swagger&logoColor=black)](https://swagger.io/)
+[![Tests: Jest](https://img.shields.io/badge/tests-Jest-C21325?logo=jest&logoColor=white)](https://jestjs.io/)
+[![Code style: Prettier](https://img.shields.io/badge/code_style-Prettier-F7B93E?logo=prettier&logoColor=white)](https://prettier.io/)
+[![Conventional Commits](https://img.shields.io/badge/Conventional_Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://www.conventionalcommits.org/)
+
 A NestJS-based backend API for the Storytime application, providing interactive storytelling experiences for children with AI-powered story generation, user management, and content delivery.
 
 ## Features

--- a/REMAINING_WORK.md
+++ b/REMAINING_WORK.md
@@ -1,6 +1,6 @@
 # Remaining Work Summary
 
-**Last Updated:** 2026-07-19
+**Last Updated:** 2026-07-21
 
 This document provides an accurate, up-to-date summary of remaining work after verifying the actual codebase state.
 
@@ -104,14 +104,27 @@ This document provides an accurate, up-to-date summary of remaining work after v
 ### Priority 3 (Low — Optional)
 
 **Infrastructure**
-- [ ] Custom Grafana dashboards (community dashboards already available)
-- [ ] Coverage badges in README (requires Codecov CI integration)
+- [x] **Coverage badges in README** — Codecov upload wired into the `develop-v*`
+      Test job (gated on `CODECOV_TOKEN`, no-ops until set) + README badges (CI,
+      coverage, tech stack, license, tooling). One-time Codecov account/token
+      setup still required to light the coverage badge (steps in README).
+- [ ] Custom Grafana dashboards — blocked on the Grafana Cloud connection (needs
+      account sign-in). Dashboard JSON can be authored ahead of time.
 
 **Security (from SECURITY_AUDIT.md)**
-- [ ] CSP nonce for inline scripts (~2h)
-- [ ] Request signing for webhooks (~4h)
-- [ ] CAPTCHA for registration (~2h)
-- [ ] GDPR data portability export (~4h)
+- [x] **CSP hardening** — explicit strict global CSP with an `'unsafe-inline'`
+      relaxation scoped to `/docs` only. (Honest form of "CSP nonce": the API
+      renders no HTML of its own, so a per-request nonce would be dead config;
+      the real gain is a strict CSP + a minimal scoped exception for Swagger UI.)
+- [x] **Webhook authenticity** — the Google Pub/Sub verifier now **fails closed
+      in production** (rejects when `GOOGLE_PUBSUB_AUDIENCE` is unset). Both
+      webhooks already verify with platform-native crypto (Apple ASSN v2 JWS,
+      Google OIDC) stronger than HMAC, so the real gap was this fail-open, not
+      missing signing.
+- [x] **GDPR data-portability export** — `GET /user/me/export` streams all
+      user + kids data as a JSON download (secrets stripped; audit logs and
+      payment tokens excluded).
+- [ ] CAPTCHA for registration (~2h) — deferred (no free provider).
 
 ---
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -221,11 +221,11 @@ Logger configured to exclude:
 
 ### 9.2 Future Improvements
 
-| Priority | Recommendation | Effort |
-|----------|---------------|--------|
-| Low | Add CSP nonce for inline scripts | 2h |
-| Low | Implement request signing for webhooks | 4h |
-| Low | Add CAPTCHA for registration | 2h |
+| Priority | Recommendation | Effort | Status |
+|----------|---------------|--------|--------|
+| Low | ~~Add CSP nonce for inline scripts~~ → explicit strict CSP + `/docs`-scoped relaxation | 2h | ✅ Done (API renders no HTML; a nonce would be dead config — strict CSP + scoped Swagger exception shipped instead) |
+| Low | ~~Implement request signing for webhooks~~ → Google Pub/Sub verifier fails closed in prod | 4h | ✅ Done (both webhooks already verify with platform-native crypto stronger than HMAC; closed the fail-open gap) |
+| Low | Add CAPTCHA for registration | 2h | ⏸️ Deferred (no free provider) |
 
 ---
 
@@ -244,7 +244,7 @@ Logger configured to exclude:
 | Requirement | Status |
 |-------------|--------|
 | Right to erasure | ✅ Account deletion |
-| Data portability | ⚠️ Not implemented |
+| Data portability | ✅ `GET /user/me/export` (JSON download of all user + kids data) |
 | Consent management | ✅ Notification preferences |
 
 ---


### PR DESCRIPTION
- README: Redis / BullMQ / Swagger / Jest / Prettier / Conventional Commits badges (static shields, render on private repo, no account needed).
- REMAINING_WORK.md & SECURITY_AUDIT.md: reflect the shipped P3 work (coverage badges, CSP hardening, webhook fail-closed, GDPR export); Grafana dashboards noted as blocked on the Grafana Cloud connection; CAPTCHA deferred.