### PR TITLE
chore: enable CodeRabbit auto-review on develop-* branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration.
+# Without this, CodeRabbit auto-reviews ONLY PRs into the default branch (main)
+# and SKIPS everything targeting develop-* — which is where all v1.3.0 work
+# happens. Enable auto-review for the develop-* line (and main) so blue PRs are
+# reviewed like everything else.
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - "develop-.*"


### PR DESCRIPTION
Adds `.coderabbit.yaml`. Root cause of the unreviewed PRs: CodeRabbit only auto-reviews PRs into the **default branch (main)** and skips `develop-*` targets — where all v1.3.0 work happens. This enables auto-review for `main` + `develop-*` so blue PRs get reviewed going forward.