### PR TITLE
fix: address CodeRabbit findings from the P3 PRs

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -144,9 +144,6 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/storytime_test
       REDIS_URL: redis://localhost:6379
-      # Mapped from the secret so the upload step can gate on its presence
-      # (secrets aren't allowed directly in step-level `if:`). Unset => no-op.
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     services:
       postgres:
@@ -217,13 +214,23 @@ jobs:
         continue-on-error: true
         run: pnpm test --coverage
 
+      # Detect the secret's presence WITHOUT exposing its value to the job env
+      # (which would leak it to install/test/dependency steps). This step only
+      # emits a boolean; the token itself is passed solely to the upload step.
+      - name: Check for Codecov token
+        id: codecov_token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: echo "present=${CODECOV_TOKEN:+true}" >> "$GITHUB_OUTPUT"
+
       - name: Upload coverage to Codecov
         # No-op until CODECOV_TOKEN is set (see repo secrets); never fails CI.
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: steps.codecov_token.outputs.present == 'true'
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          disable_search: true
           flags: unittests
           fail_ci_if_error: false
 

--- a/src/payment/google-pubsub-verifier.service.spec.ts
+++ b/src/payment/google-pubsub-verifier.service.spec.ts
@@ -158,6 +158,25 @@ describe('GooglePubSubVerifierService', () => {
     });
   });
 
+  // ------------------ production requires BOTH audience and SA email ---------
+  describe('production with audience set but GOOGLE_PUBSUB_SA_EMAIL missing', () => {
+    it('FAILS CLOSED (audience-only would accept any Google SA)', async () => {
+      const service = await buildService({
+        NODE_ENV: 'production',
+        GOOGLE_PUBSUB_AUDIENCE: AUDIENCE,
+      });
+      jest
+        .spyOn(service['logger'], 'error')
+        .mockImplementation(() => undefined);
+
+      await expect(
+        service.verifyPushRequest('Bearer anything'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+
+      expect(mockVerifyIdToken).not.toHaveBeenCalled();
+    });
+  });
+
   // --------------------------------- audience set but SA email unconfigured --
   describe('when audience is set but GOOGLE_PUBSUB_SA_EMAIL is not', () => {
     it('accepts any Google-verified account for the audience (with a warning)', async () => {

--- a/src/payment/google-pubsub-verifier.service.ts
+++ b/src/payment/google-pubsub-verifier.service.ts
@@ -13,14 +13,15 @@ import { OAuth2Client, TokenPayload } from 'google-auth-library';
  * configured push service account.
  *
  * Posture:
- *  - When `GOOGLE_PUBSUB_AUDIENCE` is set, verification is ENFORCED: an
- *    invalid/missing token is rejected (401).
- *  - When it is NOT set:
- *      - in production (`NODE_ENV=production`): FAIL CLOSED — the request is
- *        rejected (401). An unconfigured production must never silently accept
- *        forged RTDN webhooks (the previous behaviour was fail-open).
- *      - otherwise (dev/test): verification is skipped with a warning so local
- *        and unconfigured setups keep working.
+ *  - In production (`NODE_ENV=production`): BOTH `GOOGLE_PUBSUB_AUDIENCE` and
+ *    `GOOGLE_PUBSUB_SA_EMAIL` are required. Missing either => FAIL CLOSED (401),
+ *    so production never accepts a forged, or a merely audience-scoped, RTDN
+ *    webhook (audience-only would accept any Google-verified service account).
+ *  - Non-production, audience set: ENFORCED — an invalid/missing token is
+ *    rejected (401); a missing SA email only downgrades to "any Google SA for
+ *    this audience" with a warning.
+ *  - Non-production, audience unset: verification is skipped with a warning so
+ *    local and unconfigured setups keep working.
  *
  * Required Pub/Sub push-subscription settings (Google Cloud console / gcloud):
  *  - Enable "Enable authentication" on the push subscription.
@@ -59,20 +60,25 @@ export class GooglePubSubVerifierService {
    * invalid/missing/unauthorized token.
    */
   async verifyPushRequest(authorizationHeader?: string): Promise<void> {
+    // Production must have BOTH the audience AND the service-account email so
+    // the webhook is fully locked to our push subscription. Missing either =>
+    // fail CLOSED (never accept an unauthenticated/partially-verified RTDN
+    // webhook). Audience-only would accept any Google-verified service account.
+    if (this.isProduction && (!this.audience || !this.saEmail)) {
+      this.logger.error(
+        'Pub/Sub OIDC verification is incomplete in production - rejecting the ' +
+          'webhook. Configure GOOGLE_PUBSUB_AUDIENCE and GOOGLE_PUBSUB_SA_EMAIL ' +
+          'on the push subscription so /payment/webhooks/google can authenticate ' +
+          'callers.',
+      );
+      throw new UnauthorizedException(
+        'Pub/Sub OIDC verification is not fully configured',
+      );
+    }
+
     if (!this.audience) {
-      if (this.isProduction) {
-        // Fail CLOSED in production: never accept an unauthenticated RTDN
-        // webhook just because the audience wasn't configured.
-        this.logger.error(
-          'GOOGLE_PUBSUB_AUDIENCE is not set in production - rejecting the ' +
-            'Pub/Sub webhook. Configure GOOGLE_PUBSUB_AUDIENCE (and ' +
-            'GOOGLE_PUBSUB_SA_EMAIL) on the push subscription so ' +
-            '/payment/webhooks/google can authenticate callers.',
-        );
-        throw new UnauthorizedException(
-          'Pub/Sub OIDC verification is not configured',
-        );
-      }
+      // Non-production only (production is handled above): skip with a warning
+      // so local/unconfigured setups keep working.
       if (!this.warnedUnconfigured) {
         this.logger.warn(
           'GOOGLE_PUBSUB_AUDIENCE is not set - skipping Pub/Sub OIDC ' +

--- a/src/user/services/user-data-export.service.spec.ts
+++ b/src/user/services/user-data-export.service.spec.ts
@@ -25,9 +25,9 @@ describe('UserDataExportService', () => {
 
   it('throws NotFoundException when the user does not exist', async () => {
     findUserForExport.mockResolvedValue(null);
-    await expect(service.exportUserData('missing', EXPORTED_AT)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
+    await expect(
+      service.exportUserData('missing', EXPORTED_AT),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('strips passwordHash and pinHash from the export', async () => {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -359,6 +359,8 @@ export class UserController {
     const filename = `storytime-data-export-${exportedAt.slice(0, 10)}.json`;
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    // Sensitive personal data — never cache in the browser or intermediaries.
+    res.setHeader('Cache-Control', 'no-store');
     // @Res() opts out of the global SuccessResponseInterceptor, so the body is
     // the raw export document (not the standard { statusCode, data } envelope).
     res.send(JSON.stringify(data, null, 2));


### PR DESCRIPTION
Fixes the 4 valid findings from a **local** CodeRabbit review of the P3 work (those PRs had merged unreviewed because CodeRabbit skips non-default base branches — now fixed by `.coderabbit.yaml` in #434):

1. **GDPR export** — `Cache-Control: no-store` so the sensitive data download isn't cached.
2. **Google Pub/Sub verifier** — production fails closed when **either** audience or SA email is missing (audience-only accepted any Google SA). + doc + new prod test.
3. **CI** — `CODECOV_TOKEN` no longer mapped to job env (dependency-exfil risk); presence checked in a boolean-only step, token passed only to the upload step.
4. **CI** — `disable_search: true` so only `lcov.info` uploads.

Verified: `tsc` clean, verifier spec 12/12, eslint clean. This PR should be the first to get CodeRabbit **auto-review** on `develop-v1.3.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Production payment webhook requests are now rejected when required verification settings are incomplete.
  * Non-production environments continue to support limited verification with appropriate warnings.
  * Personal data exports are marked as non-cacheable to help prevent sensitive information from being stored by browsers or intermediaries.

* **Reliability**
  * Deployment checks now upload coverage reports only when the required security credential is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->