### PR TITLE
docs(readme): wire live Codecov graph token into coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
 # Storytime Backend API
 
-<!--
-  Coverage badge. One-time setup to make it live:
-    1. Enable this repo on https://app.codecov.io (org: Bolt-Silverfox).
-    2. Add repo secret CODECOV_TOKEN (Codecov → repo → Settings → General).
-    3. Copy the graph token from Codecov → Settings → Badges & Graphs and
-       replace CODECOV_GRAPH_TOKEN below with it.
-  Until then the CI upload step no-ops and the badge shows "unknown".
--->
 [![Dev CI/CD](https://github.com/Bolt-Silverfox/storytime_be/actions/workflows/dev-deploy.yml/badge.svg?branch=develop-v1.3.0)](https://github.com/Bolt-Silverfox/storytime_be/actions/workflows/dev-deploy.yml)
-[![codecov](https://codecov.io/gh/Bolt-Silverfox/storytime_be/branch/develop-v1.3.0/graph/badge.svg?token=CODECOV_GRAPH_TOKEN)](https://codecov.io/gh/Bolt-Silverfox/storytime_be)
+[![codecov](https://codecov.io/gh/Bolt-Silverfox/storytime_be/branch/develop-v1.3.0/graph/badge.svg?token=RXX71BBC0S)](https://codecov.io/gh/Bolt-Silverfox/storytime_be)
 [![License](https://img.shields.io/badge/license-Proprietary-red.svg)](#license)
 
 [![NestJS](https://img.shields.io/badge/NestJS-11-E0234E?logo=nestjs&logoColor=white)](https://nestjs.com/)

--- a/src/user/services/user-data-export.service.spec.ts
+++ b/src/user/services/user-data-export.service.spec.ts
@@ -25,9 +25,9 @@ describe('UserDataExportService', () => {
 
   it('throws NotFoundException when the user does not exist', async () => {
     findUserForExport.mockResolvedValue(null);
-    await expect(service.exportUserData('missing', EXPORTED_AT)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
+    await expect(
+      service.exportUserData('missing', EXPORTED_AT),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('strips passwordHash and pinHash from the export', async () => {


### PR DESCRIPTION
Codecov is now set up: repo enabled on the Bolt-Silverfox org, `CODECOV_TOKEN` secret added. This replaces the `CODECOV_GRAPH_TOKEN` placeholder in the README coverage badge with the real read-only graph token; the badge populates once CI uploads the first coverage report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Codecov coverage badge in the project documentation to use a fixed token value.
  * Simplified the badge section by removing the previous one-time setup instructions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->