### PR TITLE
docs: refresh REMAINING_WORK — blue smoke-test results + accurate status

### DIFF
--- a/REMAINING_WORK.md
+++ b/REMAINING_WORK.md
@@ -1,6 +1,6 @@
 # Remaining Work Summary
 
-**Last Updated:** 2026-07-21
+**Last Updated:** 2026-07-22
 
 This document provides an accurate, up-to-date summary of remaining work after verifying the actual codebase state.
 
@@ -85,8 +85,16 @@ This document provides an accurate, up-to-date summary of remaining work after v
 - ✅ **Alerting rules documented** — ALERTING_RULES.md
 - ✅ **Security audit complete** — SECURITY_AUDIT.md
 - ✅ **Sentry (backend) LIVE** — project `storytime-be` (emerj org); `SENTRY_DSN`
-  wired into green (`:3500`) + blue (`:3601`) live envs, env-gated no-op when unset.
-  Errors report + link to OTel traces. (Grafana Cloud push still pending — see below.)
+  in the `ENV_FILE` secret (durable) + wired into green (`:3500`), staging (`:3600`),
+  and blue (`:3601`) live envs, env-gated no-op when unset. Errors report + link to
+  OTel traces. Issue-alert rule scoped (tag filter `environment` = production|staging)
+  so dev noise never pages.
+- ✅ **Grafana Cloud OTLP LIVE (blue only)** — traces/logs/metrics push to the
+  Grafana Cloud gateway; `storytime-api` dashboard imported. Made durable in
+  `blue-deploy.yml` (PR #437) so a redeploy re-injects the OTLP vars + token.
+  Green/dev intentionally omits it.
+- ✅ **Codecov LIVE** — repo activated, `CODECOV_TOKEN` secret set, coverage badge
+  wired; CI upload gated + scoped to the upload step.
 
 ---
 
@@ -94,22 +102,66 @@ This document provides an accurate, up-to-date summary of remaining work after v
 
 ### Priority 1 (Blue-green validation & promotion)
 
-- [ ] Validate `blue.dev.*` end-to-end (auth, story gen sync+async, payments/subs, SSE)
+- [~] **Validate `blue.dev.*` end-to-end** — backend API smoke test PASSED
+      2026-07-22 (see "Blue smoke-test results" below). Remaining: FE/mobile
+      client validation against blue, and re-test after the TTS fix + a blue
+      redeploy.
 - [ ] Register mobile blue OAuth clients (Google iOS/Android, Firebase apps,
       Apple App ID for `net.emerj.storytime.blue`) and confirm blue backend trusts
-      them — see the OAuth checklist in `docs/DEPLOYMENT_BLUE_GREEN.md`
-- [ ] Promote blue → green once validated (merge `develop-v1.3.0` → `develop-v1.2.0`
-      + matching FE/mobile branches, redeploy green)
+      them — see the OAuth checklist in `docs/DEPLOYMENT_BLUE_GREEN.md`. **This is
+      the one true blocker; requires console access (only the team can do it).**
+- [ ] Promote blue → stable. **Model (decided):** `develop-v1.3.0` *becomes* the
+      new stable branch — there is **NO merge-down** to `develop-v1.2.0`. Cut over
+      green's deploy target to `develop-v1.3.0` (+ matching FE/mobile branches) once
+      validated. (Supersedes the earlier "merge v1.3.0 → v1.2.0" plan.)
+
+#### Blue smoke-test results (2026-07-22, backend API via `blue.dev.api.storytimeapp.me`)
+
+**PASS:**
+- Health/readiness (`/health/ready` 200) — DB up (4ms), Redis up on its own `/3`
+  (22M), BullMQ queues clean, TTS circuit-breakers CLOSED. Swagger `/docs` 200
+  (249 routes).
+- Register → 200 + JWT (parent). Login correctly **blocked until email verified**
+  ("Email not verified").
+- 9 authed reads all 200: `/user/me`, `/stories/{categories,themes,seasons}`,
+  `/stories/user/quota` (10 free), `/stories/homepage/parent`,
+  `/subscription/{plans,me}`, `/payment/status`.
+- **Async story generation** (`POST /stories/generate/async`) → 202 queued →
+  worker processed → **completed in ~75s** → text story persisted
+  ("Foxy's Brave Adventure") and retrievable in `/stories`. Confirms the BullMQ
+  enqueue→worker→progress pipeline on blue's Redis `/3`.
+- **SSE** (`GET /events/jobs`) → `text/event-stream` 200, stream held open.
+
+**Issues found:**
+- ⚠️ **TTS/audio generation fails** — generated story has `audioUrl` empty.
+  Logs: Deepgram TTS timeout → Edge TTS timeout → "Voice generation failed on all
+  providers". `ELEVENLABS_API_KEY` is **unset** on blue (the most reliable
+  provider is missing), leaving only Deepgram + Edge TTS, both of which timed out.
+  Needs: add an ElevenLabs key to blue's env and/or investigate the Deepgram/Edge
+  timeouts. Observed once — confirm whether persistent or transient.
+- ⚠️ **`Error: Socket closed unexpectedly` × ~114** in blue's PM2 error log
+  (ioredis/BullMQ disconnect). Appears **stale** (log mtime predates the test; not
+  spewing during it) — likely deploy/restart churn. Monitor; not currently blocking.
+- ℹ️ **Catalog is empty** on blue (`/stories/categories|themes|seasons` → `[]`) —
+  blue DB is unseeded. Run the seed if the FE needs a populated catalog.
+- ℹ️ **`GET /user/me/export` (GDPR export, PR #432) is 404 on blue** — blue's
+  running build predates that merge. A blue redeploy (`blue-deploy.yml`, manual
+  `workflow_dispatch`) will pick it up along with PR #437's Grafana durability.
+- 🧹 Two throwaway test accounts (`blue-smoke-*@example.com`, `reg-*@example.com`)
+  were created in `storytime_db_blue` during the test; purge if desired.
 
 ### Priority 3 (Low — Optional)
 
 **Infrastructure**
 - [x] **Coverage badges in README** — Codecov upload wired into the `develop-v*`
-      Test job (gated on `CODECOV_TOKEN`, no-ops until set) + README badges (CI,
-      coverage, tech stack, license, tooling). One-time Codecov account/token
-      setup still required to light the coverage badge (steps in README).
-- [ ] Custom Grafana dashboards — blocked on the Grafana Cloud connection (needs
-      account sign-in). Dashboard JSON can be authored ahead of time.
+      Test job (gated on `CODECOV_TOKEN`) + README badges (CI, coverage, tech
+      stack, license, tooling). Codecov account/token setup **done** — repo
+      activated, `CODECOV_TOKEN` secret set, badge graph token in README.
+- [x] **Custom Grafana dashboards** — Grafana Cloud connected (blue OTLP push);
+      `storytime-api` dashboard imported into the Cloud instance. Made durable via
+      `blue-deploy.yml` (PR #437). NOTE: some panels may show "No Data" until the
+      OTLP-converted metric names are reconciled with the dashboard's
+      Prometheus-scrape names (or switch to Application Observability).
 
 **Security (from SECURITY_AUDIT.md)**
 - [x] **CSP hardening** — explicit strict global CSP with an `'unsafe-inline'`
@@ -124,7 +176,12 @@ This document provides an accurate, up-to-date summary of remaining work after v
 - [x] **GDPR data-portability export** — `GET /user/me/export` streams all
       user + kids data as a JSON download (secrets stripped; audit logs and
       payment tokens excluded).
-- [ ] CAPTCHA for registration (~2h) — deferred (no free provider).
+- [ ] CAPTCHA for registration (~2h) — **un-blocked: free providers exist.**
+      Recommended **Cloudflare Turnstile** (free at any scale, no request cap,
+      privacy-friendly, near-drop-in server verify via
+      `POST https://challenges.cloudflare.com/turnstile/v0/siteverify`). hCaptcha
+      and reCAPTCHA v3 also have free tiers. Deferred earlier on the mistaken
+      belief that no free option existed; ready to implement whenever prioritized.
 
 ---
 
@@ -143,4 +200,9 @@ This document provides an accurate, up-to-date summary of remaining work after v
 | **Infrastructure** | ✅ Complete | Health checks, metrics, notifications |
 | **Lint** | ✅ Clean | Zero errors |
 
-**Overall Assessment:** The codebase is in excellent shape. All P0 and P1 items are complete. Remaining work is P2-P3 optimizations and external infrastructure setup.
+**Overall Assessment:** The codebase is in excellent shape. All P0/P1 code items are
+complete. Blue's backend passed an end-to-end API smoke test (2026-07-22) with two
+follow-ups: fix blue TTS/audio (ElevenLabs key unset + Deepgram/Edge timeouts) and
+redeploy blue to pick up the GDPR export + Grafana durability. The remaining true
+blocker for promotion is mobile blue OAuth client registration (console work). Then
+promote by cutting green's deploy target to `develop-v1.3.0` (no merge-down).


### PR DESCRIPTION
Brings `REMAINING_WORK.md` in line with reality:

- **Blue smoke-test results (2026-07-22)** — backend API validated against `blue.dev.api.storytimeapp.me`: health, register, verify-gated login, 9 authed reads, **async story generation** (202 → worker → ~75s → persisted + retrievable), and **SSE** all PASS. Flags: TTS/audio fails (`ELEVENLABS_API_KEY` unset + Deepgram/Edge timeouts), ~114 stale Redis socket errors, empty catalog (unseeded), and `GET /user/me/export` 404 (blue predates #432 — needs redeploy).
- **Promotion model corrected** — `develop-v1.3.0` *becomes* stable; **no merge-down** to `develop-v1.2.0`.
- Marks **Codecov**, **Grafana Cloud OTLP** (blue, #437), and **Sentry alert rule** as done.
- **CAPTCHA un-blocked** — Cloudflare Turnstile is free (earlier deferral was based on a wrong assumption).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and promotion guidance, including the remaining mobile OAuth blocker.
  * Added detailed blue-environment smoke-test findings and follow-up actions.
  * Marked Grafana Cloud OTLP and Codecov setup as completed.
  * Documented CAPTCHA registration options and a recommended verification approach.
  * Refreshed the overall rollout assessment and latest update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->