### PR TITLE
fix(cache): make Redis cache resilient to socket drops (stop dev crash-loop)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -76,7 +76,9 @@ import { BullBoardConfigModule } from './admin/bull-board.module';
         });
         redisStore.client.on('error', (err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
-          logger.warn(`Redis cache connection error (reconnecting): ${message}`);
+          logger.warn(
+            `Redis cache connection error (reconnecting): ${message}`,
+          );
         });
         const redisKeyv = new Keyv({ store: redisStore });
         redisKeyv.on('error', (err: unknown) => {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { BullModule } from '@nestjs/bullmq';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -52,24 +52,52 @@ import { BullBoardConfigModule } from './admin/bull-board.module';
     }),
     CacheModule.registerAsync({
       isGlobal: true,
-      useFactory: async () => ({
-        ttl: 4 * 60 * 60 * 1000, // 4 hours in milliseconds (for categories)
-        stores: [
-          // Primary: In-memory cache (fastest)
-          new Keyv({
-            store: new CacheableMemory({
-              ttl: 4 * 60 * 60 * 1000,
-              lruSize: 5000,
+      useFactory: async () => {
+        const logger = new Logger('RedisCache');
+        // Build a resilient Redis store. node-redis (@redis/client) does NOT
+        // attach a default 'error' listener, so a dropped socket
+        // ("Socket closed unexpectedly") is emitted as an unhandled 'error'
+        // event and crashes the whole process (observed on the dev box:
+        // hundreds of PM2 restarts). Three defenses:
+        //   1. pingInterval keeps the connection alive so idle sockets aren't
+        //      closed under us.
+        //   2. reconnectStrategy reconnects forever with capped backoff.
+        //   3. an 'error' handler turns a transient drop into a log line
+        //      instead of a fatal unhandled event; cache-manager still falls
+        //      through to the in-memory store while Redis reconnects.
+        const redisStore = new KeyvRedis({
+          url: process.env.REDIS_URL || 'redis://localhost:6379',
+          pingInterval: 30_000,
+          socket: {
+            connectTimeout: 10_000,
+            reconnectStrategy: (retries: number) =>
+              Math.min(retries * 200, 5_000),
+          },
+        });
+        redisStore.client.on('error', (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`Redis cache connection error (reconnecting): ${message}`);
+        });
+        const redisKeyv = new Keyv({ store: redisStore });
+        redisKeyv.on('error', (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`Redis cache keyv error: ${message}`);
+        });
+        return {
+          ttl: 4 * 60 * 60 * 1000, // 4 hours in milliseconds (for categories)
+          stores: [
+            // Primary: In-memory cache (fastest)
+            new Keyv({
+              store: new CacheableMemory({
+                ttl: 4 * 60 * 60 * 1000,
+                lruSize: 5000,
+              }),
             }),
-          }),
-          // Secondary: Redis cache (persistent)
-          new Keyv({
-            store: new KeyvRedis(
-              process.env.REDIS_URL || 'redis://localhost:6379',
-            ),
-          }),
-        ],
-      }),
+            // Secondary: Redis cache (persistent, resilient to socket drops)
+            redisKeyv,
+          ],
+        };
+      },
     }),
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],


### PR DESCRIPTION
## Problem
Both dev backends were crash-looping (green-dev ~237, blue ~507 PM2 restarts; staging 6). With `Socket closed unexpectedly` filtered out, the error log was otherwise empty — so that **@redis/client** socket error was the sole crash cause.

## Root cause
The cache store is `new KeyvRedis(process.env.REDIS_URL)` with **no error handler and no socket/reconnect config**. node-redis attaches no default `error` listener, so a dropped socket is emitted as an unhandled `error` event → `uncaughtException` → process exit → PM2 restart → brief nginx 502.

## Fix (`src/app.module.ts`)
- `pingInterval: 30s` — keep the connection alive so idle sockets aren't closed.
- `socket.reconnectStrategy` — reconnect forever with capped backoff.
- `error` handler on both the redis client and the Keyv wrapper — a transient drop becomes a warn log + reconnect instead of a crash; cache-manager falls through to the in-memory store while Redis reconnects.

BullMQ (ioredis) is a separate connection and unaffected.

## Verification
Builds clean. Real-world check: after deploy, the dev PM2 restart counts should stop climbing. Needs porting to green (`develop-v1.2.0`) too — same crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability by maintaining Redis connections more consistently.
  * Added safer reconnection handling to prevent temporary Redis outages from disrupting the application.
  * Improved error handling and logging for cache connection failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->