### PR TITLE
feat: close green→blue parity gaps (notifications, payment CAS, infra, story, TTS)

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,6 +3,14 @@ const os = require('os');
 const cpus = os.cpus().length;
 const prodInstances = Math.max(2, cpus - 1);
 
+// Blue: single-instance v1.3.0 candidate (see the app entry below).
+const blueInstances = 1;
+
+// Single-instance apps run in fork mode; a lone cluster instance just spawns a
+// wasteful cluster master + worker pair (and was a source of leaked Prisma
+// query-engine processes on crash-loops). Only cluster when scaled past 1.
+const execModeFor = (instances) => (instances > 1 ? 'cluster' : 'fork');
+
 const baseConfig = {
   script: 'dist/main.js',
   instances: 'max',
@@ -10,6 +18,12 @@ const baseConfig = {
   autorestart: true,
   watch: false,
   max_memory_restart: '1G',
+  // Stop infinite crash-loops: the app must stay up `min_uptime` to count as a
+  // successful boot; after `max_restarts` rapid failures pm2 marks the process
+  // `errored` and stops restarting it (instead of thrashing the CPU forever).
+  min_uptime: '15s',
+  max_restarts: 10,
+  restart_delay: 4000,
 };
 
 module.exports = {
@@ -43,7 +57,8 @@ module.exports = {
       // .env) so it can't starve the shared RDS / green on the same box.
       ...baseConfig,
       name: 'storytime-api-blue',
-      instances: 1,
+      instances: blueInstances,
+      exec_mode: execModeFor(blueInstances),
       env: {
         NODE_ENV: 'development',
         PORT: 3601,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -500,9 +500,15 @@ model Subscription {
   purchaseToken String? // token from the platform
   // Out-of-order delivery protection: the authoritative timestamp of the most
   // recent store webhook applied to this row (Apple signedDate / Google
-  // eventTimeMillis). A later event whose timestamp is <= this is stale and is
-  // skipped so it cannot clobber newer state (e.g. a delayed EXPIRED after a
-  // DID_RENEW). Nullable so pre-existing rows and untimestamped events work.
+  // eventTimeMillis). A later event is stale ONLY when its timestamp is strictly
+  // less than this watermark; it is then skipped so it cannot clobber newer state
+  // (e.g. a delayed EXPIRED after a DID_RENEW). Equal timestamps APPLY, not skip:
+  // two DISTINCT notifications can share a millisecond, and genuine duplicates are
+  // already handled by the WebhookEvent (platform, externalEventId) idempotency
+  // layer, so a same-instant event reaching the watermark is a distinct one that
+  // must be processed in arrival order. The guard is enforced as a compare-and-swap
+  // inside the update (WHERE lastEventAt IS NULL OR lastEventAt <= eventAt), never a
+  // read-then-write. Nullable so pre-existing rows and untimestamped events work.
   lastEventAt   DateTime?
   // SOFT DELETE FIELDS
   isDeleted     Boolean   @default(false)

--- a/src/admin/admin-system.controller.ts
+++ b/src/admin/admin-system.controller.ts
@@ -11,6 +11,7 @@ import { AdminService } from './admin.service';
 import { AdminSystemService } from './admin-system.service';
 import { Admin } from './decorators/admin.decorator';
 import { BroadcastNotificationDto } from './dto/broadcast-notification.dto';
+import { BatchedBroadcastNotificationDto } from './dto/batched-broadcast-notification.dto';
 import { GuestActivityFilterDto } from './dto/guest-stats.dto';
 import { PaginationUtil } from '../shared/utils/pagination.util';
 import {
@@ -269,12 +270,40 @@ export class AdminSystemController {
     };
   }
 
+  @Post('notifications/broadcast/batched')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Broadcast push to all device tokens in staggered batches (<= 500/batch)',
+  })
+  @ApiBody({ type: BatchedBroadcastNotificationDto })
+  @ApiCreatedResponse({ description: 'Batched broadcast queued' })
+  @HttpCode(HttpStatus.CREATED)
+  async broadcastNotificationBatched(
+    @Body() dto: BatchedBroadcastNotificationDto,
+  ) {
+    const data = await this.adminService.broadcastNotificationBatched(dto);
+    return {
+      statusCode: 201,
+      message: 'Batched broadcast notification queued',
+      data,
+    };
+  }
+
   @Post('notifications/seed-topic')
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Subscribe all existing devices to a topic (one-time seed)',
   })
-  @ApiQuery({ name: 'topic', required: false, example: 'all_users' })
+  @ApiQuery({
+    name: 'topic',
+    required: false,
+    description:
+      "Normally omitted: defaults to this deployment's environment-scoped topic " +
+      '(all_users_<NODE_ENV>) to re-seed existing devices after a deploy. If ' +
+      'supplied it must exactly match the current environment topic; legacy ' +
+      '`all_users` and other environments topics are rejected (400).',
+  })
   @ApiCreatedResponse({ description: 'Topic seed initiated' })
   @HttpCode(HttpStatus.CREATED)
   async seedTopicSubscriptions(@Query('topic') topic?: string) {

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  InternalServerErrorException,
   Logger,
   Inject,
 } from '@nestjs/common';
@@ -39,6 +40,11 @@ import {
   STORY_INVALIDATION_KEYS,
 } from '@/shared/constants/cache-keys.constants';
 import { BroadcastNotificationDto } from './dto/broadcast-notification.dto';
+import { BatchedBroadcastNotificationDto } from './dto/batched-broadcast-notification.dto';
+import {
+  NotificationService,
+  BatchedBroadcastSummary,
+} from '../notification/notification.service';
 import { ResetQuotaDto } from './dto/reset-quota.dto';
 import { ActivateSubscriptionDto } from './dto/activate-subscription.dto';
 import { GuestStatsDto, GuestActivityFilterDto } from './dto/guest-stats.dto';
@@ -74,6 +80,8 @@ export class AdminService {
     private readonly couponService: AdminCouponService,
     private readonly exportService: AdminExportService,
     private readonly subscriptionOpsService: AdminSubscriptionOpsService,
+    // NotificationModule is @Global, so no admin.module import change is needed.
+    private readonly notificationService: NotificationService,
     @Inject(ADMIN_STORY_REPOSITORY)
     private readonly storyRepo: IAdminStoryRepository,
     @Inject(ADMIN_CONTENT_REPOSITORY)
@@ -390,8 +398,23 @@ export class AdminService {
    */
   async broadcastNotification(
     dto: BroadcastNotificationDto,
-  ): Promise<{ sent: boolean; topic: string }> {
-    const topic = dto.topic ?? 'all_users';
+  ): Promise<{ sent: boolean; topic: string; inAppDelivered: number }> {
+    // The env-scoped broadcast topic (all_users_<NODE_ENV>) for THIS backend.
+    const scopedTopic = this.notificationService.getBroadcastTopic();
+
+    // Isolation guard: an admin may omit `topic` (uses the env-scoped default),
+    // but may NOT target the legacy global `all_users` or another environment's
+    // `all_users_<env>` topic — the Firebase project is shared, so that would
+    // bleed the broadcast across dev/staging/prod. Only this env's topic is
+    // permitted; anything else is rejected rather than silently coerced.
+    if (dto.topic && dto.topic !== scopedTopic) {
+      throw new BadRequestException(
+        `Broadcast topic "${dto.topic}" is not allowed. Omit "topic" to use this ` +
+          `environment's topic ("${scopedTopic}"); cross-environment and legacy ` +
+          `topics are blocked to prevent cross-environment push bleed.`,
+      );
+    }
+    const topic = scopedTopic;
 
     await this.eventEmitter.emitAsync('notification.broadcast', {
       topic,
@@ -402,7 +425,65 @@ export class AdminService {
     this.logger.log(
       `Broadcast notification emitted to topic "${topic}": "${dto.title}"`,
     );
-    return { sent: true, topic };
+
+    // Also write an in-app inbox entry for every user so the broadcast shows in
+    // the app's notification list, not just as an ephemeral push.
+    let inAppDelivered = 0;
+    try {
+      const inApp = await this.notificationService.broadcastInAppToAllUsers(
+        dto.title,
+        dto.body,
+        dto.data,
+      );
+      inAppDelivered = inApp.delivered;
+    } catch (error) {
+      this.logger.error(
+        `In-app broadcast failed for "${dto.title}": ${(error as Error).message}`,
+      );
+    }
+
+    return { sent: true, topic, inAppDelivered };
+  }
+
+  /**
+   * Broadcast a push notification to all users by fanning out to every active
+   * device token in staggered batches (<= 500 tokens per FCM multicast call),
+   * instead of a single topic push. Emits a 'notification.broadcast-batched'
+   * event handled by the notification module and returns its summary.
+   */
+  async broadcastNotificationBatched(
+    dto: BatchedBroadcastNotificationDto,
+  ): Promise<BatchedBroadcastSummary> {
+    const results = await this.eventEmitter.emitAsync(
+      'notification.broadcast-batched',
+      {
+        title: dto.title,
+        body: dto.body,
+        data: dto.data,
+        batchSize: dto.batchSize,
+        intervalSeconds: dto.intervalSeconds,
+      },
+    );
+
+    const summary = results.find(
+      (r): r is BatchedBroadcastSummary =>
+        !!r && typeof r === 'object' && 'batches' in r,
+    );
+
+    // The notification module registers exactly one listener for this event; a
+    // missing summary means the listener didn't run (misconfiguration), so fail
+    // loudly rather than reporting a false "0 devices" success.
+    if (!summary) {
+      throw new InternalServerErrorException(
+        'Batched broadcast produced no summary; notification listener may not be registered',
+      );
+    }
+
+    this.logger.log(
+      `Batched broadcast emitted: "${dto.title}" -> ${summary.totalDevices} device(s) in ${summary.batches} batch(es)`,
+    );
+
+    return summary;
   }
 
   /**
@@ -410,11 +491,22 @@ export class AdminService {
    * Emits a 'notification.seed-topic' event.
    */
   async seedTopicSubscriptions(
-    topic: string = 'all_users',
+    topic: string = this.notificationService.getBroadcastTopic(),
   ): Promise<{ emitted: boolean }> {
     if (!/^[a-zA-Z0-9\-_.~%]+$/.test(topic)) {
       throw new BadRequestException(
         'Invalid topic name: must contain only valid FCM topic characters',
+      );
+    }
+    // Isolation guard (mirrors broadcast): only this environment's topic may be
+    // seeded, so an admin can't re-subscribe every device back onto the legacy
+    // global `all_users` (or another env's topic) and re-open the bleed.
+    const scopedTopic = this.notificationService.getBroadcastTopic();
+    if (topic !== scopedTopic) {
+      throw new BadRequestException(
+        `Seed topic "${topic}" is not allowed. Omit "topic" to seed this ` +
+          `environment's topic ("${scopedTopic}"); cross-environment and legacy ` +
+          `topics are blocked.`,
       );
     }
     try {

--- a/src/admin/dto/batched-broadcast-notification.dto.ts
+++ b/src/admin/dto/batched-broadcast-notification.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/**
+ * Batched broadcast: send a push to every active device token in staggered
+ * chunks (<= 500 tokens per FCM multicast call) instead of a single topic
+ * fan-out. Staggering avoids every user opening the app at the same instant,
+ * which protects the connection-capped production RDS instance.
+ */
+export class BatchedBroadcastNotificationDto {
+  @ApiProperty({ example: 'New Story Available!' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(65)
+  title: string;
+
+  @ApiProperty({
+    example: "Check out 'The Magic Forest' - a new adventure awaits!",
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  body: string;
+
+  @ApiPropertyOptional({
+    example: { storyId: '123e4567-e89b-12d3-a456-426614174000' },
+    description: 'Optional data payload for deep linking',
+  })
+  @IsOptional()
+  @IsObject()
+  data?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    example: 500,
+    minimum: 1,
+    maximum: 500,
+    default: 500,
+    description:
+      'Device tokens per push job. Capped at 500 (FCM multicast hard limit).',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  batchSize?: number = 500;
+
+  @ApiPropertyOptional({
+    example: 120,
+    minimum: 0,
+    maximum: 3600,
+    default: 120,
+    description:
+      'Seconds between batches. Batch i is delayed by i * intervalSeconds.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(3600)
+  intervalSeconds?: number = 120;
+}

--- a/src/admin/dto/broadcast-notification.dto.ts
+++ b/src/admin/dto/broadcast-notification.dto.ts
@@ -24,8 +24,13 @@ export class BroadcastNotificationDto {
   body: string;
 
   @ApiPropertyOptional({
-    example: 'all_users',
-    description: 'FCM topic to broadcast to (defaults to all_users)',
+    example: 'all_users_production',
+    description:
+      'FCM topic to broadcast to. Defaults to the environment-scoped topic ' +
+      '`all_users_<NODE_ENV>` (e.g. all_users_production) so broadcasts never ' +
+      'bleed across environments that share a Firebase project. Omit this field ' +
+      "in normal use; if provided it MUST equal this environment's topic — " +
+      'legacy `all_users` and other environments topics are rejected (400).',
   })
   @IsOptional()
   @IsString()

--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -15,6 +15,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CouponService } from '../../coupon/coupon.service';
 import { GoogleVerificationService } from '../../payment/google-verification.service';
 import { AppleVerificationService } from '../../payment/apple-verification.service';
+import { NotificationService } from '../../notification/notification.service';
 import {
   ADMIN_STORY_REPOSITORY,
   PrismaAdminStoryRepository,
@@ -49,6 +50,13 @@ const mockCacheManager = {
 // Mock EventEmitter2
 const mockEventEmitter = {
   emit: jest.fn(),
+  emitAsync: jest.fn().mockResolvedValue([]),
+};
+
+// Mock NotificationService (env-scoped broadcast topic + in-app fan-out)
+const mockNotificationService = {
+  getBroadcastTopic: jest.fn().mockReturnValue('all_users_production'),
+  broadcastInAppToAllUsers: jest.fn().mockResolvedValue({ delivered: 0 }),
 };
 
 // Mock CouponService
@@ -202,6 +210,10 @@ describe('AdminService', () => {
           provide: AppleVerificationService,
           useValue: mockAppleVerificationService,
         },
+        {
+          provide: NotificationService,
+          useValue: mockNotificationService,
+        },
       ],
     }).compile();
 
@@ -212,6 +224,53 @@ describe('AdminService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('broadcastNotification', () => {
+    it('defaults to the env-scoped topic from NotificationService when no topic is provided', async () => {
+      const result = await service.broadcastNotification({
+        title: 'Hello',
+        body: 'World',
+      });
+
+      expect(mockNotificationService.getBroadcastTopic).toHaveBeenCalled();
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'all_users_production' }),
+      );
+      expect(result.topic).toBe('all_users_production');
+      // Must never fan out to the unscoped global topic.
+      expect(mockEventEmitter.emitAsync).not.toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'all_users' }),
+      );
+    });
+
+    it('rejects a cross-environment / legacy topic override', async () => {
+      await expect(
+        service.broadcastNotification({
+          title: 'Hello',
+          body: 'World',
+          topic: 'all_users',
+        }),
+      ).rejects.toThrow(/not allowed/i);
+
+      expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+    });
+
+    it('accepts an explicit topic equal to this environment topic', async () => {
+      const result = await service.broadcastNotification({
+        title: 'Hello',
+        body: 'World',
+        topic: 'all_users_production',
+      });
+
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        'notification.broadcast',
+        expect.objectContaining({ topic: 'all_users_production' }),
+      );
+      expect(result.topic).toBe('all_users_production');
+    });
   });
 
   describe('getDashboardStats', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { json, urlencoded } from 'express';
 
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { INestApplication, Logger, ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
@@ -24,10 +24,39 @@ import { winstonConfig } from './shared/config/logger.config';
 const bootstrapLogger = new Logger('Bootstrap');
 const isProduction = process.env.NODE_ENV === 'production';
 
+// Populated once bootstrap() creates the Nest app, so the process-signal and
+// error handlers below can close it before the process exits.
+let app: INestApplication | undefined;
+let shuttingDown = false;
+
+// Close the Nest app (which runs onModuleDestroy on every provider — e.g.
+// PrismaService.$disconnect() and BullMQ teardown) BEFORE the process exits.
+// A bare process.exit() bypasses enableShutdownHooks and orphans the open
+// database connections; in dev's restart-on-save loop those leaked connections
+// pile up until Postgres refuses new ones. A short unref'd timeout guarantees
+// we still exit even if close() hangs.
+const shutdown = async (code: number, reason: string): Promise<void> => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  bootstrapLogger.log(`Shutting down (${reason})`);
+  const force = setTimeout(() => process.exit(code), 8000);
+  force.unref();
+  try {
+    await app?.close();
+  } catch (err) {
+    bootstrapLogger.error('Error during graceful shutdown', err as Error);
+  } finally {
+    clearTimeout(force);
+    process.exit(code);
+  }
+};
+
 process.on('uncaughtException', (error: Error) => {
   captureException(error);
   bootstrapLogger.error(`Uncaught Exception: ${error.message}`, error.stack);
-  setTimeout(() => process.exit(1), 1000);
+  void shutdown(1, 'uncaughtException');
 });
 
 process.on('unhandledRejection', (reason: unknown) => {
@@ -37,25 +66,29 @@ process.on('unhandledRejection', (reason: unknown) => {
     reason instanceof Error ? reason.stack : undefined,
   );
   if (isProduction) {
-    setTimeout(() => process.exit(1), 1000);
+    void shutdown(1, 'unhandledRejection');
   }
 });
 
 process.on('SIGTERM', () => {
   bootstrapLogger.log('SIGTERM received. Graceful shutdown initiated...');
-  process.exit(0);
+  void shutdown(0, 'SIGTERM');
 });
 
 process.on('SIGINT', () => {
   bootstrapLogger.log('SIGINT received. Graceful shutdown initiated...');
-  process.exit(0);
+  void shutdown(0, 'SIGINT');
 });
 
 async function bootstrap() {
   const logger = new Logger('Main');
-  const app = await NestFactory.create(AppModule, {
+  app = await NestFactory.create(AppModule, {
     logger: WinstonModule.createLogger(winstonConfig),
   });
+
+  // Run every provider's onModuleDestroy (PrismaService.$disconnect(), BullMQ
+  // teardown, …) on SIGTERM/SIGINT and on the explicit app.close() in shutdown().
+  app.enableShutdownHooks();
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT', 3000);

--- a/src/notification/listeners/engagement-event.listener.ts
+++ b/src/notification/listeners/engagement-event.listener.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { PrismaService } from '@/prisma/prisma.service';
+import { NotificationService } from '../notification.service';
+
+/**
+ * Bridges the achievement module's `notification.badge_unlock` event (emitted by
+ * BadgeProgressEngine after a badge unlocks) to an engagement notification for
+ * the kid's parent.
+ *
+ * Adapts green's direct-call badge notification (which injected NotificationService
+ * into BadgeService) to blue's event-listener architecture: BadgeService already
+ * emits `badge.unlocked`, which BadgeProgressEngine forwards as
+ * `notification.badge_unlock` for exactly this purpose.
+ *
+ * - `special` badges       -> AchievementUnlocked
+ * - all other badge types  -> BadgeEarned
+ *
+ * Only fires when a kidId is present (per-kid unlock) so the kid's name can be
+ * resolved and the parent-level aggregate record is not double-notified.
+ * Best-effort: never throws (that would bubble back into the emitter).
+ */
+@Injectable()
+export class EngagementEventListener {
+  private readonly logger = new Logger(EngagementEventListener.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  @OnEvent('notification.badge_unlock')
+  async handleBadgeUnlock(payload: {
+    userId: string;
+    kidId?: string | null;
+    badgeId: string;
+    timestamp?: Date;
+    type?: string;
+  }): Promise<void> {
+    // Only notify for a per-kid unlock: we need the kid's name and want to
+    // avoid double-notifying for a parent-level aggregate record.
+    if (!payload.kidId) {
+      return;
+    }
+    try {
+      const [kid, badge] = await Promise.all([
+        this.prisma.kid.findUnique({
+          where: { id: payload.kidId },
+          select: { name: true },
+        }),
+        this.prisma.badge.findUnique({
+          where: { id: payload.badgeId },
+          select: { title: true, badgeType: true },
+        }),
+      ]);
+
+      if (!badge) {
+        this.logger.warn(
+          `Badge ${payload.badgeId} not found; skipping engagement notification`,
+        );
+        return;
+      }
+
+      const kidName = kid?.name ?? 'Your child';
+
+      // `special` badges represent one-off achievements; everything else
+      // (count/streak/time progress badges) is surfaced as a badge earned.
+      if (badge.badgeType === 'special') {
+        await this.notificationService.sendNotification(
+          'AchievementUnlocked',
+          { kidName, achievementName: badge.title },
+          payload.userId,
+        );
+      } else {
+        await this.notificationService.sendNotification(
+          'BadgeEarned',
+          { kidName, badgeName: badge.title },
+          payload.userId,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Failed to emit badge-earned notification for user ${payload.userId}, kid ${payload.kidId}, badge ${payload.badgeId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+}

--- a/src/notification/listeners/subscription-event.listener.ts
+++ b/src/notification/listeners/subscription-event.listener.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { AppEvents, SubscriptionCancelledEvent } from '@/shared/events';
+import { PLANS } from '@/subscription/subscription.constants';
+import { NotificationService } from '../notification.service';
+
+/**
+ * Emits a SubscriptionAlert notification when a subscription is cancelled.
+ *
+ * Adapts green's direct SubscriptionAlert call (subscription.service cancel path)
+ * to blue's event architecture: SubscriptionService already emits
+ * AppEvents.SUBSCRIPTION_CANCELLED, so this listener reacts to it instead of
+ * coupling the subscription module to NotificationService. Best-effort: never
+ * throws (that would bubble back into the emitter).
+ *
+ * Note: the store-INITIATED webhook cancel path (subscription-webhook.service)
+ * does not emit this event, and the app-initiated store cancel
+ * (payment.service.cancelSubscription) notifies directly at that site.
+ */
+@Injectable()
+export class SubscriptionEventListener {
+  private readonly logger = new Logger(SubscriptionEventListener.name);
+
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @OnEvent(AppEvents.SUBSCRIPTION_CANCELLED)
+  async handleSubscriptionCancelled(
+    event: SubscriptionCancelledEvent,
+  ): Promise<void> {
+    try {
+      const planDisplay = PLANS[event.planId]?.display ?? event.planId;
+      await this.notificationService.sendNotification(
+        'SubscriptionAlert',
+        { message: `Your ${planDisplay} subscription was cancelled.` },
+        event.userId,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to emit SubscriptionAlert for user ${event.userId.substring(0, 8)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+}

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { BullModule } from '@nestjs/bullmq';
 import { NotificationService } from './notification.service';
@@ -31,6 +31,8 @@ import { PushProcessor } from './queue/push.processor';
 import { AuthEventListener } from './listeners/auth-event.listener';
 import { PasswordEventListener } from './listeners/password-event.listener';
 import { NotificationPreferenceEventListener } from './listeners/notification-preference-event.listener';
+import { EngagementEventListener } from './listeners/engagement-event.listener';
+import { SubscriptionEventListener } from './listeners/subscription-event.listener';
 import { HttpLatencyInterceptor } from '@/shared/interceptors/http-latency.interceptor';
 import {
   NOTIFICATION_PREFERENCE_REPOSITORY,
@@ -43,6 +45,7 @@ import {
   PrismaUserRepository,
 } from './repositories';
 
+@Global()
 @Module({
   imports: [
     HttpModule,
@@ -93,6 +96,9 @@ import {
     AuthEventListener,
     PasswordEventListener,
     NotificationPreferenceEventListener,
+    // Engagement + subscription notifications from real domain events
+    EngagementEventListener,
+    SubscriptionEventListener,
     // Repository Pattern (testability, decoupling)
     {
       provide: NOTIFICATION_PREFERENCE_REPOSITORY,

--- a/src/notification/notification.registry.ts
+++ b/src/notification/notification.registry.ts
@@ -16,11 +16,14 @@ export type Notifications =
   | 'PasswordChanged'
   | 'PinReset'
   | 'NewStory'
+  | 'StoryFinished'
   | 'AchievementUnlocked'
+  | 'BadgeEarned'
   | 'QuotaExhausted'
   | 'SubscriptionWelcome'
   | 'PaymentSuccess'
   | 'PaymentFailed'
+  | 'SubscriptionAlert'
   | 'SubscriptionReminder'
   | 'WeMissYou'
   | 'IncompleteStoryReminder'
@@ -155,6 +158,21 @@ export const NotificationRegistry: Record<
       );
     },
   },
+  StoryFinished: {
+    medium: 'in_app',
+    category: NotificationCategory.STORY_FINISHED,
+    subject: 'Story Finished!',
+    validate: (data) => {
+      if (!data.kidName) return 'Kid name is required';
+      if (!data.storyTitle) return 'Story title is required';
+      return null;
+    },
+    getTemplate: (data) => {
+      return Promise.resolve(
+        `${String(data.kidName)} finished "${String(data.storyTitle)}" 🎉`,
+      );
+    },
+  },
   AchievementUnlocked: {
     medium: 'in_app',
     category: NotificationCategory.ACHIEVEMENT_UNLOCKED,
@@ -166,6 +184,21 @@ export const NotificationRegistry: Record<
     getTemplate: (data) => {
       return Promise.resolve(
         `Congratulations! You've unlocked the "${String(data.achievementName)}" achievement.`,
+      );
+    },
+  },
+  BadgeEarned: {
+    medium: 'in_app',
+    category: NotificationCategory.BADGE_EARNED,
+    subject: 'Badge Earned!',
+    validate: (data) => {
+      if (!data.kidName) return 'Kid name is required';
+      if (!data.badgeName) return 'Badge name is required';
+      return null;
+    },
+    getTemplate: (data) => {
+      return Promise.resolve(
+        `${String(data.kidName)} earned the "${String(data.badgeName)}" badge!`,
       );
     },
   },
@@ -250,6 +283,18 @@ export const NotificationRegistry: Record<
         }),
       );
       return emailHtml;
+    },
+  },
+  SubscriptionAlert: {
+    medium: 'in_app',
+    category: NotificationCategory.SUBSCRIPTION_ALERT,
+    subject: 'Subscription Alert',
+    validate: (data) => {
+      if (!data.message) return 'Message is required';
+      return null;
+    },
+    getTemplate: (data) => {
+      return Promise.resolve(`${String(data.message)}`);
     },
   },
   SubscriptionReminder: {

--- a/src/notification/notification.registry.ts
+++ b/src/notification/notification.registry.ts
@@ -261,7 +261,7 @@ export const NotificationRegistry: Record<
     },
     getTemplate: (data) => {
       return Promise.resolve(
-        `Your payment of ${data.currency} ${data.amount} for the ${data.plan} plan was successful.`,
+        `Your payment of ${String(data.currency)} ${String(data.amount)} for the ${String(data.plan)} plan was successful.`,
       );
     },
   },
@@ -309,7 +309,7 @@ export const NotificationRegistry: Record<
     },
     getTemplate: (data) => {
       return Promise.resolve(
-        `Your ${data.plan} plan renews in ${data.daysLeft} day(s).`,
+        `Your ${String(data.plan)} plan renews in ${String(data.daysLeft)} day(s).`,
       );
     },
   },
@@ -323,7 +323,7 @@ export const NotificationRegistry: Record<
     },
     getTemplate: (data) => {
       return Promise.resolve(
-        `We miss you, ${data.name}! Come back for a new story.`,
+        `We miss you, ${String(data.name)}! Come back for a new story.`,
       );
     },
   },
@@ -337,7 +337,7 @@ export const NotificationRegistry: Record<
     },
     getTemplate: (data) => {
       return Promise.resolve(
-        `You still have "${data.storyTitle}" waiting to be finished!`,
+        `You still have "${String(data.storyTitle)}" waiting to be finished!`,
       );
     },
   },
@@ -350,7 +350,9 @@ export const NotificationRegistry: Record<
       return null;
     },
     getTemplate: (data) => {
-      return Promise.resolve(`Hi ${data.name}, ready for today's story time?`);
+      return Promise.resolve(
+        `Hi ${String(data.name)}, ready for today's story time?`,
+      );
     },
   },
 };

--- a/src/notification/notification.service.spec.ts
+++ b/src/notification/notification.service.spec.ts
@@ -14,7 +14,7 @@ import { NotificationDispatchService } from './services/notification-dispatch.se
 import { NotificationSettingsService } from './services/notification-settings.service';
 import { NotificationDeviceService } from './services/notification-device.service';
 import { InAppNotificationService } from './services/in-app-notification.service';
-import { NOTIFICATION_PREFERENCE_REPOSITORY } from './repositories';
+import { NOTIFICATION_PREFERENCE_REPOSITORY, USER_REPOSITORY } from './repositories';
 
 // Mock nodemailer
 jest.mock('nodemailer', () => ({
@@ -147,6 +147,13 @@ describe('NotificationService', () => {
           provide: NOTIFICATION_PREFERENCE_REPOSITORY,
           useValue: {
             findManyByUserCategoryAndTypes: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: USER_REPOSITORY,
+          useValue: {
+            findContactById: jest.fn(),
+            findActiveUsersBatch: jest.fn().mockResolvedValue([]),
           },
         },
         { provide: ConfigService, useValue: mockConfigService },

--- a/src/notification/notification.service.spec.ts
+++ b/src/notification/notification.service.spec.ts
@@ -14,7 +14,10 @@ import { NotificationDispatchService } from './services/notification-dispatch.se
 import { NotificationSettingsService } from './services/notification-settings.service';
 import { NotificationDeviceService } from './services/notification-device.service';
 import { InAppNotificationService } from './services/in-app-notification.service';
-import { NOTIFICATION_PREFERENCE_REPOSITORY, USER_REPOSITORY } from './repositories';
+import {
+  NOTIFICATION_PREFERENCE_REPOSITORY,
+  USER_REPOSITORY,
+} from './repositories';
 
 // Mock nodemailer
 jest.mock('nodemailer', () => ({

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -21,8 +21,13 @@ import {
 import { NotificationEmailService } from './services/notification-email.service';
 import { NotificationDispatchService } from './services/notification-dispatch.service';
 import { NotificationSettingsService } from './services/notification-settings.service';
-import { NotificationDeviceService } from './services/notification-device.service';
+import {
+  NotificationDeviceService,
+  BatchedBroadcastSummary,
+} from './services/notification-device.service';
 import { InAppNotificationService } from './services/in-app-notification.service';
+
+export type { BatchedBroadcastSummary } from './services/notification-device.service';
 
 /**
  * Thin facade over the notification module's focused services. Other modules
@@ -316,18 +321,82 @@ export class NotificationService {
   }
 
   /**
-   * Subscribe all existing active device tokens to the all_users topic.
+   * The environment-scoped FCM topic this backend broadcasts to and subscribes
+   * devices to (e.g. `all_users_production`). Single source of truth; other
+   * modules default to it instead of hardcoding a topic string.
+   */
+  getBroadcastTopic(): string {
+    return this.deviceService.getBroadcastTopic();
+  }
+
+  /**
+   * Subscribe all existing active device tokens to the broadcast topic.
+   * Defaults to the env-scoped topic (`all_users_<NODE_ENV>`); overridable.
    * Run once to seed existing devices. Processes in batches of 1000 (Firebase limit).
    */
   async subscribeAllExistingDevicesToTopic(
-    topic: string = 'all_users',
+    topic?: string,
   ): Promise<{ total: number; batches: number }> {
-    return this.deviceService.subscribeAllExistingDevicesToTopic(topic);
+    return this.deviceService.subscribeAllExistingDevicesToTopic(
+      topic as string,
+    );
+  }
+
+  /**
+   * Broadcast a push to ALL active device tokens in staggered batches (<= 500
+   * per FCM multicast call). Delegated to the device service.
+   */
+  async broadcastBatchedToAllDevices(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    return this.deviceService.broadcastBatchedToAllDevices(payload);
+  }
+
+  /**
+   * Write an in-app inbox record for every active user (batched). Used by admin
+   * broadcasts so an announcement lands in the in-app inbox, not just push.
+   */
+  async broadcastInAppToAllUsers(
+    title: string,
+    body: string,
+    data?: Record<string, unknown>,
+  ): Promise<{ delivered: number; failed: number }> {
+    return this.inAppNotificationService.broadcastInAppToAllUsers(
+      title,
+      body,
+      data,
+    );
+  }
+
+  /**
+   * Fan out a NewStory notification to every active user (batched, preference-
+   * aware). Meant to be fire-and-forget from the story-create path.
+   */
+  async broadcastNewStoryToUsers(
+    storyId: string,
+    storyTitle: string,
+  ): Promise<void> {
+    return this.dispatchService.broadcastNewStoryToUsers(storyId, storyTitle);
   }
 
   // ============================================
   // Event Listeners (cross-module communication)
   // ============================================
+
+  @OnEvent('notification.broadcast-batched')
+  async handleBatchedBroadcastNotification(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    return this.deviceService.handleBatchedBroadcastNotification(payload);
+  }
 
   @OnEvent('notification.broadcast')
   async handleBroadcastNotification(payload: {

--- a/src/notification/queue/push-queue.service.ts
+++ b/src/notification/queue/push-queue.service.ts
@@ -164,6 +164,14 @@ export class PushQueueService {
   ): Promise<QueuedPushResult> {
     const jobId = randomUUID();
 
+    // Enforce the documented per-batch cap up front so an oversized caller
+    // fails fast here rather than in the worker/provider path.
+    if (tokens.length === 0 || tokens.length > 500) {
+      const error = 'Token batch must contain between 1 and 500 tokens';
+      this.logger.warn(`Rejected token batch ${jobId}: ${error}`);
+      return { queued: false, jobId, error };
+    }
+
     try {
       const jobData: PushJobData = {
         jobId,

--- a/src/notification/queue/push-queue.service.ts
+++ b/src/notification/queue/push-queue.service.ts
@@ -144,6 +144,62 @@ export class PushQueueService {
   }
 
   /**
+   * Queue a single push job targeting a specific chunk of device tokens.
+   *
+   * Reuses the existing SEND_PUSH job path, which sends via
+   * `sendToTokens`/`sendEachForMulticast` when a `tokens[]` array is present
+   * (bypassing the per-user lookup). Used by the batched broadcast to stagger
+   * delivery over time via the BullMQ `delay` option.
+   *
+   * @param tokens Device tokens for this chunk (must be <= 500 for FCM multicast)
+   * @param delay Delay in milliseconds before this job becomes active
+   */
+  async queueTokenBatch(
+    tokens: string[],
+    title: string,
+    body: string,
+    data?: Record<string, string>,
+    delay?: number,
+    category: NotificationCategory = NotificationCategory.SYSTEM_ALERT,
+  ): Promise<QueuedPushResult> {
+    const jobId = randomUUID();
+
+    try {
+      const jobData: PushJobData = {
+        jobId,
+        // Sentinel user id: this job targets explicit tokens, not a user lookup.
+        userId: 'broadcast-batched',
+        category,
+        title,
+        body,
+        data,
+        tokens,
+      };
+
+      await this.pushQueue.add(PUSH_JOB_NAMES.SEND_PUSH, jobData, {
+        ...PUSH_QUEUE_DEFAULT_OPTIONS,
+        priority: PushPriority.NORMAL,
+        delay,
+        jobId,
+      });
+
+      this.logger.log(
+        `Token batch push queued: ${jobId} (${tokens.length} token(s), delay ${delay ?? 0}ms)`,
+      );
+
+      return { queued: true, jobId };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `Failed to queue token batch ${jobId}: ${errorMessage}`,
+      );
+
+      return { queued: false, jobId, error: errorMessage };
+    }
+  }
+
+  /**
    * Queue multiple push notifications (batch)
    */
   async queueBatch(

--- a/src/notification/repositories/prisma-user.repository.ts
+++ b/src/notification/repositories/prisma-user.repository.ts
@@ -12,4 +12,19 @@ export class PrismaUserRepository implements IUserRepository {
       select: { email: true, name: true },
     });
   }
+
+  async findActiveUsersBatch(params: {
+    take: number;
+    cursor?: string;
+  }): Promise<{ id: string }[]> {
+    return this.prisma.user.findMany({
+      where: { isDeleted: false, isSuspended: false },
+      select: { id: true },
+      orderBy: { id: 'asc' },
+      take: params.take,
+      ...(params.cursor
+        ? { skip: 1, cursor: { id: params.cursor } }
+        : {}),
+    });
+  }
 }

--- a/src/notification/repositories/prisma-user.repository.ts
+++ b/src/notification/repositories/prisma-user.repository.ts
@@ -22,9 +22,7 @@ export class PrismaUserRepository implements IUserRepository {
       select: { id: true },
       orderBy: { id: 'asc' },
       take: params.take,
-      ...(params.cursor
-        ? { skip: 1, cursor: { id: params.cursor } }
-        : {}),
+      ...(params.cursor ? { skip: 1, cursor: { id: params.cursor } } : {}),
     });
   }
 }

--- a/src/notification/repositories/user.repository.interface.ts
+++ b/src/notification/repositories/user.repository.interface.ts
@@ -9,6 +9,13 @@ export type UserContact = Prisma.UserGetPayload<{
 export interface IUserRepository {
   // Find a user's email + name by id (used to compose notification emails)
   findContactById(userId: string): Promise<UserContact | null>;
+
+  // Page active (non-deleted, non-suspended) user ids for broadcast fan-out.
+  // Cursor pagination ordered by id asc, selecting id only.
+  findActiveUsersBatch(params: {
+    take: number;
+    cursor?: string;
+  }): Promise<{ id: string }[]>;
 }
 
 export const USER_REPOSITORY = Symbol('USER_REPOSITORY');

--- a/src/notification/services/in-app-notification.service.ts
+++ b/src/notification/services/in-app-notification.service.ts
@@ -1,16 +1,81 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { NotificationCategory as PrismaCategory } from '@prisma/client';
 import {
   IInAppNotificationRepository,
   IN_APP_NOTIFICATION_REPOSITORY,
+  IUserRepository,
+  USER_REPOSITORY,
 } from '../repositories';
+import { InAppProvider } from '../providers/in-app.provider';
 import { buildCursorPaginatedResponse } from '@/shared/utils/cursor-pagination.helper';
 
 @Injectable()
 export class InAppNotificationService {
+  private readonly logger = new Logger(InAppNotificationService.name);
+
   constructor(
     @Inject(IN_APP_NOTIFICATION_REPOSITORY)
     private readonly inAppNotificationRepository: IInAppNotificationRepository,
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    private readonly inAppProvider: InAppProvider,
   ) {}
+
+  /**
+   * Write an in-app inbox record for every active user (batched). Used by admin
+   * broadcasts so an announcement lands in the in-app inbox, not just push.
+   * Best-effort per user; category defaults to SYSTEM_ALERT.
+   */
+  async broadcastInAppToAllUsers(
+    title: string,
+    body: string,
+    data?: Record<string, unknown>,
+  ): Promise<{ delivered: number; failed: number }> {
+    const BATCH = 500;
+    let cursor: string | undefined;
+    let delivered = 0;
+    let failed = 0;
+    for (;;) {
+      const users = await this.userRepository.findActiveUsersBatch({
+        take: BATCH,
+        cursor,
+      });
+      if (users.length === 0) {
+        break;
+      }
+      for (const user of users) {
+        try {
+          const result = await this.inAppProvider.send({
+            userId: user.id,
+            category: PrismaCategory.SYSTEM_ALERT,
+            title,
+            body,
+            data,
+          });
+          if (result.success) {
+            delivered++;
+          } else {
+            failed++;
+          }
+        } catch (error) {
+          failed++;
+          this.logger.warn(
+            `In-app broadcast failed for user ${user.id.substring(0, 8)}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      cursor = users[users.length - 1].id;
+      if (users.length < BATCH) {
+        break;
+      }
+    }
+    this.logger.log(
+      `In-app broadcast "${title}": ${delivered} delivered, ${failed} failed`,
+    );
+    return { delivered, failed };
+  }
 
   async getInAppNotifications(
     userId: string,

--- a/src/notification/services/notification-device.service.ts
+++ b/src/notification/services/notification-device.service.ts
@@ -5,7 +5,9 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NotificationCategory as PrismaCategory } from '@prisma/client';
+import { EnvConfig } from '@/shared/config/env.validation';
 import {
   DEVICE_TOKEN_REPOSITORY,
   IDeviceTokenRepository,
@@ -18,6 +20,27 @@ import {
   DeviceTokenListResponseDto,
   DevicePlatform,
 } from '../dto/device-token.dto';
+
+/** Summary returned by a batched (staggered) broadcast run. */
+export interface BatchedBroadcastSummary {
+  /** Total de-duplicated active device tokens targeted. */
+  totalDevices: number;
+  /** Number of push jobs enqueued (one per chunk of <= batchSize tokens). */
+  batches: number;
+  /** Batches successfully enqueued to BullMQ (these WILL deliver). */
+  succeededBatches: number;
+  /**
+   * Batches that failed to enqueue. When this is > 0 but succeededBatches is
+   * also > 0, the succeeded batches are already queued and will still fire —
+   * do NOT blindly re-run the full broadcast, or the already-queued cohort is
+   * double-delivered. Re-target only the failed cohort instead.
+   */
+  failedBatches: number;
+  /** Effective chunk size after clamping to [1, 500]. */
+  batchSize: number;
+  /** Delay (seconds) before the final batch fires: (batches - 1) * intervalSeconds. */
+  estimatedDurationSeconds: number;
+}
 
 /**
  * Owns push-device management for the notification module: device-token
@@ -32,12 +55,49 @@ import {
 export class NotificationDeviceService {
   private readonly logger = new Logger(NotificationDeviceService.name);
 
+  /**
+   * Single source of truth for the environment-scoped FCM broadcast topic.
+   *
+   * dev/staging/prod share ONE Firebase project, and FCM topics are global to
+   * the project. A hardcoded `all_users` topic therefore bleeds broadcasts
+   * across environments (a dev broadcast reaches prod-subscribed devices).
+   * Scoping the topic per environment (`all_users_<NODE_ENV>`) guarantees each
+   * backend only ever subscribes/broadcasts to its OWN environment's topic.
+   * `all_users_<env>` stays within the valid FCM topic charset
+   * (`[a-zA-Z0-9-_.~%]+`).
+   */
+  private readonly broadcastTopic: string;
+
+  /**
+   * The legacy, un-scoped topic every device was historically subscribed to.
+   * We no longer subscribe or broadcast to it; the re-seed migration also
+   * unsubscribes existing devices from it so a manual override broadcast to
+   * `all_users` can't reach cross-environment subscribers.
+   */
+  private readonly legacyBroadcastTopic = 'all_users';
+
   constructor(
     @Inject(DEVICE_TOKEN_REPOSITORY)
     private readonly deviceTokenRepository: IDeviceTokenRepository,
     private readonly pushProvider: PushProvider,
     private readonly pushQueueService: PushQueueService,
-  ) {}
+    private readonly configService: ConfigService<EnvConfig, true>,
+  ) {
+    // Compute the environment-scoped broadcast topic once. Fall back to
+    // 'development' when NODE_ENV is unset/empty, matching the env-validation
+    // default so the topic is never `all_users_` (an invalid, unscoped value).
+    const nodeEnv = this.configService.get('NODE_ENV') || 'development';
+    this.broadcastTopic = `all_users_${nodeEnv}`;
+  }
+
+  /**
+   * The environment-scoped FCM topic this backend broadcasts to and subscribes
+   * devices to (e.g. `all_users_production`). Exposed so other modules (e.g.
+   * AdminService) can default to it without duplicating the topic string.
+   */
+  getBroadcastTopic(): string {
+    return this.broadcastTopic;
+  }
 
   /**
    * Register a device token for push notifications.
@@ -72,12 +132,12 @@ export class NotificationDeviceService {
           deletedAt: null,
         });
         this.logger.log(`Updated device token for user ${userId}`);
-        // Re-subscribe to all_users topic (best-effort; don't fail token save on FCM side effects)
+        // Re-subscribe to the env-scoped broadcast topic (best-effort; don't fail token save on FCM side effects)
         this.pushProvider
-          .subscribeToTopic([token], 'all_users')
+          .subscribeToTopic([token], this.broadcastTopic)
           .catch((err) =>
             this.logger.warn(
-              `Failed to subscribe updated token to all_users: ${(err as Error).message}`,
+              `Failed to subscribe updated token to ${this.broadcastTopic}: ${(err as Error).message}`,
             ),
           );
         return this.toDeviceTokenResponse(updated);
@@ -95,12 +155,12 @@ export class NotificationDeviceService {
       this.logger.log(
         `Reassigned device token from user ${existingToken.userId} to ${userId}`,
       );
-      // Subscribe reassigned token to all_users topic (best-effort)
+      // Subscribe reassigned token to the env-scoped broadcast topic (best-effort)
       this.pushProvider
-        .subscribeToTopic([token], 'all_users')
+        .subscribeToTopic([token], this.broadcastTopic)
         .catch((err) =>
           this.logger.warn(
-            `Failed to subscribe reassigned token to all_users: ${(err as Error).message}`,
+            `Failed to subscribe reassigned token to ${this.broadcastTopic}: ${(err as Error).message}`,
           ),
         );
       return this.toDeviceTokenResponse(updated);
@@ -151,20 +211,20 @@ export class NotificationDeviceService {
     // Best-effort unsubscribe old tokens from broadcast topic
     if (oldTokenStrings.length > 0) {
       this.pushProvider
-        .unsubscribeFromTopic(oldTokenStrings, 'all_users')
+        .unsubscribeFromTopic(oldTokenStrings, this.broadcastTopic)
         .catch((err) =>
           this.logger.warn(
-            `Failed to unsubscribe old tokens from all_users: ${(err as Error).message}`,
+            `Failed to unsubscribe old tokens from ${this.broadcastTopic}: ${(err as Error).message}`,
           ),
         );
     }
 
-    // Subscribe the new token to the all_users topic (best-effort; don't fail registration on FCM side effects)
+    // Subscribe the new token to the env-scoped broadcast topic (best-effort; don't fail registration on FCM side effects)
     this.pushProvider
-      .subscribeToTopic([token], 'all_users')
+      .subscribeToTopic([token], this.broadcastTopic)
       .catch((err) =>
         this.logger.warn(
-          `Failed to subscribe new token to all_users: ${(err as Error).message}`,
+          `Failed to subscribe new token to ${this.broadcastTopic}: ${(err as Error).message}`,
         ),
       );
 
@@ -206,10 +266,10 @@ export class NotificationDeviceService {
 
     // Best-effort unsubscribe from broadcast topic
     this.pushProvider
-      .unsubscribeFromTopic([token], 'all_users')
+      .unsubscribeFromTopic([token], this.broadcastTopic)
       .catch((err) =>
         this.logger.warn(
-          `Failed to unsubscribe token from all_users: ${(err as Error).message}`,
+          `Failed to unsubscribe token from ${this.broadcastTopic}: ${(err as Error).message}`,
         ),
       );
 
@@ -277,11 +337,12 @@ export class NotificationDeviceService {
   }
 
   /**
-   * Subscribe all existing active device tokens to the all_users topic.
+   * Subscribe all existing active device tokens to the broadcast topic.
+   * Defaults to the env-scoped topic (`all_users_<NODE_ENV>`); overridable.
    * Run once to seed existing devices. Processes in batches of 1000 (Firebase limit).
    */
   async subscribeAllExistingDevicesToTopic(
-    topic: string = 'all_users',
+    topic: string = this.broadcastTopic,
   ): Promise<{ total: number; batches: number }> {
     const BATCH_SIZE = 1000;
     let cursor: string | undefined;
@@ -299,12 +360,35 @@ export class NotificationDeviceService {
 
       const tokens = devices.map((d) => d.token);
       await this.pushProvider.subscribeToTopic(tokens, topic);
+
+      // Migration cleanup: also unsubscribe this batch from the legacy global
+      // `all_users` topic, so a manual broadcast that overrides
+      // `topic: 'all_users'` can no longer reach stale cross-environment
+      // subscribers. Skip if we're deliberately (re)seeding `all_users` itself.
+      // Best-effort: a legacy-unsubscribe failure must not abort the re-seed.
+      if (topic !== this.legacyBroadcastTopic) {
+        try {
+          await this.pushProvider.unsubscribeFromTopic(
+            tokens,
+            this.legacyBroadcastTopic,
+          );
+        } catch (err) {
+          this.logger.warn(
+            `Failed to unsubscribe batch ${batches + 1} from legacy topic ` +
+              `${this.legacyBroadcastTopic}: ${(err as Error).message}`,
+          );
+        }
+      }
+
       batches++;
       total += tokens.length;
       cursor = devices[devices.length - 1].id;
 
       this.logger.log(
-        `Subscribed batch ${batches} (${tokens.length} tokens) to topic: ${topic}`,
+        `Subscribed batch ${batches} (${tokens.length} tokens) to topic: ${topic}` +
+          (topic !== this.legacyBroadcastTopic
+            ? ` and unsubscribed from ${this.legacyBroadcastTopic}`
+            : ''),
       );
 
       if (devices.length < BATCH_SIZE) break;
@@ -319,6 +403,161 @@ export class NotificationDeviceService {
     }
 
     return { total, batches };
+  }
+
+  /**
+   * Broadcast a push to ALL active device tokens in staggered batches of
+   * <= 500 tokens (the FCM multicast hard limit), instead of a single topic
+   * fan-out. Batch i is delayed by `i * intervalSeconds` so users don't all
+   * receive the push (and open the app) simultaneously — this protects the
+   * connection-capped production RDS instance.
+   *
+   * Token reads reuse the exact same cursor pagination and active-token filter
+   * as `subscribeAllExistingDevicesToTopic`. Tokens are de-duplicated before
+   * chunking so a token never gets two pushes.
+   */
+  async broadcastBatchedToAllDevices(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    // Clamp to safe bounds; fall back to defaults for non-finite inputs (NaN /
+    // Infinity) so a direct programmatic call can't produce NaN chunk sizes.
+    const batchSize = Number.isFinite(payload.batchSize)
+      ? Math.min(Math.max(payload.batchSize as number, 1), 500)
+      : 500;
+    const intervalSeconds = Number.isFinite(payload.intervalSeconds)
+      ? Math.max(payload.intervalSeconds as number, 0)
+      : 120;
+
+    // Page ALL active device tokens using the same batching approach as
+    // subscribeAllExistingDevicesToTopic (DB page size of 1000).
+    const DB_PAGE_SIZE = 1000;
+    let cursor: string | undefined;
+    const uniqueTokens = new Set<string>();
+
+    while (true) {
+      const devices =
+        await this.deviceTokenRepository.findActiveNotDeletedBatch({
+          take: DB_PAGE_SIZE,
+          cursor,
+        });
+
+      if (devices.length === 0) break;
+
+      // De-duplicate tokens across pages so a token appearing twice is only
+      // pushed once.
+      for (const device of devices) {
+        uniqueTokens.add(device.token);
+      }
+      cursor = devices[devices.length - 1].id;
+
+      if (devices.length < DB_PAGE_SIZE) break;
+    }
+
+    const tokens = Array.from(uniqueTokens);
+    const totalDevices = tokens.length;
+
+    if (totalDevices === 0) {
+      this.logger.warn(
+        'Batched broadcast requested but no active device tokens were found; nothing queued',
+      );
+      return {
+        totalDevices: 0,
+        batches: 0,
+        succeededBatches: 0,
+        failedBatches: 0,
+        batchSize,
+        estimatedDurationSeconds: 0,
+      };
+    }
+
+    // Split tokens into chunks of <= batchSize.
+    const chunks: string[][] = [];
+    for (let i = 0; i < tokens.length; i += batchSize) {
+      chunks.push(tokens.slice(i, i + batchSize));
+    }
+
+    // The last batch fires after (batches - 1) intervals.
+    const estimatedDurationSeconds = (chunks.length - 1) * intervalSeconds;
+
+    this.logger.log(
+      `Batched broadcast: ${totalDevices} device(s) -> ${chunks.length} batch(es) of <= ${batchSize} ` +
+        `at ${intervalSeconds}s intervals (estimated duration ${estimatedDurationSeconds}s)`,
+    );
+
+    // One job per chunk, staggered: batch i is delayed by i * intervalSeconds.
+    const enqueueResults = await Promise.all(
+      chunks.map((chunk, index) =>
+        this.pushQueueService.queueTokenBatch(
+          chunk,
+          payload.title,
+          payload.body,
+          payload.data,
+          index * intervalSeconds * 1000,
+        ),
+      ),
+    );
+
+    // Partial-failure handling. queueTokenBatch never rejects — it returns
+    // { queued: false } on error — so by the time we're here every SUCCEEDED
+    // chunk is already enqueued in BullMQ and WILL fire.
+    //   - all batches failed  -> nothing queued, a full retry is safe -> throw.
+    //   - some batches failed  -> surface counts + warn; do NOT throw.
+    const failed = enqueueResults.filter((r) => !r.queued);
+    const failedBatches = failed.length;
+    const succeededBatches = enqueueResults.length - failedBatches;
+
+    if (failedBatches > 0) {
+      const errs = failed.map((f) => f.error ?? 'unknown error').join('; ');
+      if (succeededBatches === 0) {
+        // Nothing was enqueued — safe to fail loudly so the caller can retry.
+        throw new Error(
+          `Batched broadcast failed to enqueue all ${failedBatches} batch(es): ${errs}`,
+        );
+      }
+      // Partial success: some batches are already queued and will deliver.
+      this.logger.warn(
+        `Batched broadcast PARTIAL failure: ${succeededBatches}/${enqueueResults.length} batch(es) ` +
+          `enqueued and WILL deliver; ${failedBatches} failed (${errs}). Do NOT re-run the full ` +
+          `broadcast — that double-delivers to the already-queued cohort. Re-target only the failed batches.`,
+      );
+    }
+
+    return {
+      totalDevices,
+      batches: chunks.length,
+      succeededBatches,
+      failedBatches,
+      batchSize,
+      estimatedDurationSeconds,
+    };
+  }
+
+  /**
+   * Handle a batched broadcast event by fanning out staggered per-token pushes.
+   * Invoked by NotificationService's @OnEvent('notification.broadcast-batched').
+   */
+  async handleBatchedBroadcastNotification(payload: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+    batchSize?: number;
+    intervalSeconds?: number;
+  }): Promise<BatchedBroadcastSummary> {
+    this.logger.log(`Handling batched broadcast event: "${payload.title}"`);
+    try {
+      return await this.broadcastBatchedToAllDevices(payload);
+    } catch (err) {
+      this.logger.error(
+        `Failed to run batched broadcast for "${payload.title}": ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+      // Re-throw so emitAsync in the admin service can detect failure.
+      throw err;
+    }
   }
 
   /**

--- a/src/notification/services/notification-device.topic.spec.ts
+++ b/src/notification/services/notification-device.topic.spec.ts
@@ -1,0 +1,140 @@
+import { NotificationDeviceService } from './notification-device.service';
+
+/**
+ * Focused unit tests for the env-scoped broadcast topic and the batched
+ * broadcast, constructed directly with mocked collaborators (no Nest DI).
+ */
+function build(nodeEnv: string | undefined) {
+  const deviceTokenRepository = {
+    findActiveNotDeletedBatch: jest.fn(),
+  } as any;
+  const pushProvider = {
+    subscribeToTopic: jest.fn().mockResolvedValue(undefined),
+    unsubscribeFromTopic: jest.fn().mockResolvedValue(undefined),
+    isReady: jest.fn().mockReturnValue(true),
+  } as any;
+  const pushQueueService = {
+    queueTokenBatch: jest.fn().mockResolvedValue({ queued: true, jobId: 'x' }),
+  } as any;
+  const configService = {
+    get: jest.fn((key: string) => (key === 'NODE_ENV' ? nodeEnv : undefined)),
+  } as any;
+
+  const service = new NotificationDeviceService(
+    deviceTokenRepository,
+    pushProvider,
+    pushQueueService,
+    configService,
+  );
+  return { service, deviceTokenRepository, pushProvider, pushQueueService };
+}
+
+describe('NotificationDeviceService - env-scoped broadcast topic', () => {
+  it('resolves all_users_<NODE_ENV> for production/staging/development', () => {
+    expect(build('production').service.getBroadcastTopic()).toBe(
+      'all_users_production',
+    );
+    expect(build('staging').service.getBroadcastTopic()).toBe(
+      'all_users_staging',
+    );
+    expect(build('development').service.getBroadcastTopic()).toBe(
+      'all_users_development',
+    );
+  });
+
+  it('falls back to all_users_development when NODE_ENV is unset', () => {
+    expect(build(undefined).service.getBroadcastTopic()).toBe(
+      'all_users_development',
+    );
+  });
+
+  it('never produces the unscoped global "all_users" topic', () => {
+    for (const env of ['production', 'staging', 'development', undefined]) {
+      expect(build(env).service.getBroadcastTopic()).not.toBe('all_users');
+    }
+  });
+
+  describe('subscribeAllExistingDevicesToTopic', () => {
+    it('defaults to the env-scoped topic and unsubscribes the batch from legacy all_users', async () => {
+      const { service, deviceTokenRepository, pushProvider } = build('staging');
+      deviceTokenRepository.findActiveNotDeletedBatch
+        .mockResolvedValueOnce([{ id: 'dt-1', token: 'token-1' }])
+        .mockResolvedValueOnce([]);
+
+      await service.subscribeAllExistingDevicesToTopic();
+
+      expect(pushProvider.subscribeToTopic).toHaveBeenCalledWith(
+        ['token-1'],
+        'all_users_staging',
+      );
+      expect(pushProvider.unsubscribeFromTopic).toHaveBeenCalledWith(
+        ['token-1'],
+        'all_users',
+      );
+    });
+
+    it('does NOT unsubscribe when deliberately re-seeding all_users itself', async () => {
+      const { service, deviceTokenRepository, pushProvider } = build('staging');
+      deviceTokenRepository.findActiveNotDeletedBatch
+        .mockResolvedValueOnce([{ id: 'dt-1', token: 'token-1' }])
+        .mockResolvedValueOnce([]);
+
+      await service.subscribeAllExistingDevicesToTopic('all_users');
+
+      expect(pushProvider.unsubscribeFromTopic).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('broadcastBatchedToAllDevices', () => {
+    it('de-duplicates tokens, chunks by <= batchSize and staggers delays', async () => {
+      const { service, deviceTokenRepository, pushQueueService } =
+        build('production');
+      const unique = Array.from({ length: 600 }, (_, i) => `dup-${i}`);
+      deviceTokenRepository.findActiveNotDeletedBatch.mockImplementation(
+        (args: { cursor?: string; take: number }) => {
+          // 1200 rows (each token duplicated) delivered in one page.
+          if (args.cursor) return Promise.resolve([]);
+          const rows = [...unique, ...unique].map((token, i) => ({
+            id: `id-${i}`,
+            token,
+          }));
+          return Promise.resolve(rows);
+        },
+      );
+
+      const summary = await service.broadcastBatchedToAllDevices({
+        title: 'Hi',
+        body: 'There',
+        batchSize: 500,
+        intervalSeconds: 60,
+      });
+
+      expect(summary.totalDevices).toBe(600);
+      expect(summary.batches).toBe(2);
+      expect(summary.succeededBatches).toBe(2);
+      const delivered = pushQueueService.queueTokenBatch.mock.calls.flatMap(
+        (c: unknown[]) => c[0] as string[],
+      );
+      expect(new Set(delivered).size).toBe(600);
+      const delays = pushQueueService.queueTokenBatch.mock.calls.map(
+        (c: unknown[]) => c[4] as number,
+      );
+      expect(delays.sort((a: number, b: number) => a - b)).toEqual([0, 60_000]);
+    });
+
+    it('returns zero and queues nothing when there are no devices', async () => {
+      const { service, deviceTokenRepository, pushQueueService } =
+        build('production');
+      deviceTokenRepository.findActiveNotDeletedBatch.mockResolvedValue([]);
+
+      const summary = await service.broadcastBatchedToAllDevices({
+        title: 'Hi',
+        body: 'There',
+      });
+
+      expect(summary.totalDevices).toBe(0);
+      expect(summary.batches).toBe(0);
+      expect(pushQueueService.queueTokenBatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/notification/services/notification-dispatch.service.ts
+++ b/src/notification/services/notification-dispatch.service.ts
@@ -6,6 +6,8 @@ import {
 import {
   NOTIFICATION_PREFERENCE_REPOSITORY,
   INotificationPreferenceRepository,
+  USER_REPOSITORY,
+  IUserRepository,
 } from '../repositories';
 import { NotificationRegistry, Notifications } from '../notification.registry';
 import { InAppProvider } from '../providers/in-app.provider';
@@ -33,6 +35,8 @@ export class NotificationDispatchService {
   constructor(
     @Inject(NOTIFICATION_PREFERENCE_REPOSITORY)
     private readonly notificationPreferenceRepository: INotificationPreferenceRepository,
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
     private readonly inAppProvider: InAppProvider,
     private readonly emailProvider: EmailProvider,
     private readonly pushProvider: PushProvider,
@@ -42,6 +46,56 @@ export class NotificationDispatchService {
     this.providers.set('email', this.emailProvider);
     this.providers.set('in_app', this.inAppProvider);
     this.providers.set('push', this.pushProvider);
+  }
+
+  /**
+   * Fan out a NewStory notification to every active user, batched by id cursor.
+   * Each send goes through sendNotification so it respects the user's NEW_STORY
+   * preference (opt-out) and writes both the in-app record and push. Best-effort:
+   * one failure never aborts the batch. Meant to be fire-and-forget from the
+   * story-create path.
+   */
+  async broadcastNewStoryToUsers(
+    storyId: string,
+    storyTitle: string,
+  ): Promise<void> {
+    const BATCH = 500;
+    let cursor: string | undefined;
+    let sent = 0;
+    let failed = 0;
+    for (;;) {
+      const users = await this.userRepository.findActiveUsersBatch({
+        take: BATCH,
+        cursor,
+      });
+      if (users.length === 0) {
+        break;
+      }
+      for (const user of users) {
+        try {
+          await this.sendNotification(
+            'NewStory',
+            { storyTitle, storyId },
+            user.id,
+          );
+          sent++;
+        } catch (error) {
+          failed++;
+          this.logger.warn(
+            `NewStory send failed for user ${user.id.substring(0, 8)}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      cursor = users[users.length - 1].id;
+      if (users.length < BATCH) {
+        break;
+      }
+    }
+    this.logger.log(
+      `NewStory broadcast for story ${storyId}: ${sent} sent, ${failed} failed`,
+    );
   }
 
   async sendNotification(

--- a/src/notification/services/notification-dispatch.service.ts
+++ b/src/notification/services/notification-dispatch.service.ts
@@ -73,12 +73,19 @@ export class NotificationDispatchService {
       }
       for (const user of users) {
         try {
-          await this.sendNotification(
+          // sendNotification returns { success:false } on a caught
+          // provider/validation failure (it does not throw), so count by the
+          // result rather than assuming success after the await.
+          const result = await this.sendNotification(
             'NewStory',
             { storyTitle, storyId },
             user.id,
           );
-          sent++;
+          if (result.success) {
+            sent++;
+          } else {
+            failed++;
+          }
         } catch (error) {
           failed++;
           this.logger.warn(

--- a/src/payment/apple-notification.spec.ts
+++ b/src/payment/apple-notification.spec.ts
@@ -252,9 +252,16 @@ describeIf('AppleVerificationService.parseSignedNotification', () => {
       data: { ...notificationPayload.data, bundleId: 'com.evil.other' },
     });
 
-    expect(() => scoped.parseSignedNotification(signedPayload)).toThrow(
-      /bundleId/i,
-    );
+    // Assert both the message AND the HTTP status (400) so this cannot silently
+    // regress to a 500 Internal Server Error.
+    try {
+      scoped.parseSignedNotification(signedPayload);
+      throw new Error('expected parseSignedNotification to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(400);
+      expect((err as HttpException).message).toMatch(/bundleId/i);
+    }
   });
 });
 
@@ -286,8 +293,15 @@ describe('AppleVerificationService.parseSignedNotification malformed header', ()
     }
   });
 
-  it('rejects a JWS whose header decodes to an array', () => {
+  it('rejects a JWS whose header decodes to an array (400)', () => {
     const jws = `${b64('[]')}.${b64('{}')}.${b64('sig')}`;
-    expect(() => service.parseSignedNotification(jws)).toThrow(HttpException);
+    try {
+      service.parseSignedNotification(jws);
+      throw new Error('expected parseSignedNotification to throw');
+    } catch (err) {
+      // Assert the HTTP status (400) so a regression to 500 is caught.
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(400);
+    }
   });
 });

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -9,6 +9,7 @@ import { ConfigService } from '@nestjs/config';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotificationService } from '../notification/notification.service';
 import { Prisma } from '@prisma/client';
 import {
   SUBSCRIPTION_REPOSITORY,
@@ -97,6 +98,12 @@ describe('PaymentService', () => {
         },
         { provide: AppleVerificationService, useValue: mockAppleVerification },
         { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: NotificationService,
+          useValue: {
+            sendNotification: jest.fn().mockResolvedValue({ success: true }),
+          },
+        },
       ],
     }).compile();
 

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PaymentService } from './payment.service';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GoogleVerificationService } from './google-verification.service';
 import { AppleVerificationService } from './apple-verification.service';
@@ -25,7 +29,11 @@ type MockPaymentTransactionRepository = Record<
 
 const createMockSubscriptionRepository = (): MockSubscriptionRepository => ({
   findFirstByUser: jest.fn(),
+  findById: jest.fn(),
   updateById: jest.fn(),
+  // CAS write defaults to a matched row (applied). Conflict/lost-race tests
+  // override this to resolve 0.
+  updateByIdIfToken: jest.fn().mockResolvedValue(1),
   create: jest.fn(),
 });
 
@@ -343,6 +351,130 @@ describe('PaymentService', () => {
       );
     });
 
+    it('does NOT clobber a concurrently-installed DIFFERENT token (CAS conflict)', async () => {
+      const userId = 'user-1';
+      const dto = {
+        platform: 'google' as const,
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'new-google-token',
+      };
+      const now = new Date();
+
+      mockGoogleVerification.verify.mockResolvedValue({
+        success: true,
+        isSubscription: true,
+        platformTxId: 'GPA.5678',
+        amount: 4.99,
+        currency: 'USD',
+        expirationTime: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        linkedPurchaseToken: 'old-google-token',
+        metadata: { acknowledgementState: 1 },
+      });
+
+      // The migration reads the row (still the linked/old token). The CAS
+      // affects zero rows because a concurrent delivery already swapped the row
+      // to a DIFFERENT token; the re-read reveals that winning token.
+      mockSubscriptionRepo.findFirstByUser.mockResolvedValue({
+        id: 'sub-1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        purchaseToken: 'old-google-token',
+      });
+      mockSubscriptionRepo.updateByIdIfToken.mockResolvedValue(0);
+      mockSubscriptionRepo.findById.mockResolvedValue({
+        id: 'sub-1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        purchaseToken: 'concurrent-winner-token',
+      });
+
+      // The delivery must abort so the concurrent winner is preserved.
+      await expect(service.verifyPurchase(userId, dto)).rejects.toThrow(
+        ConflictException,
+      );
+
+      // Only the migration CAS was attempted (0). The flow never reached the
+      // subscription upsert, so the winning token is never overwritten.
+      expect(mockSubscriptionRepo.updateByIdIfToken).toHaveBeenCalledTimes(1);
+      expect(mockSubscriptionRepo.updateByIdIfToken).toHaveBeenCalledWith(
+        'sub-1',
+        'old-google-token',
+        { purchaseToken: 'new-google-token' },
+      );
+      expect(mockSubscriptionRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('treats a zero-row CAS as success when the row already holds OUR token (idempotent repeat)', async () => {
+      const userId = 'user-1';
+      const dto = {
+        platform: 'google' as const,
+        productId: 'com.storytime.monthly',
+        purchaseToken: 'new-google-token',
+      };
+      const now = new Date();
+
+      mockGoogleVerification.verify.mockResolvedValue({
+        success: true,
+        isSubscription: true,
+        platformTxId: 'GPA.5678',
+        amount: 4.99,
+        currency: 'USD',
+        expirationTime: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        linkedPurchaseToken: 'old-google-token',
+        metadata: { acknowledgementState: 1 },
+      });
+
+      // Migration read sees the old token; the CAS misses because an identical
+      // concurrent delivery already migrated the row to OUR new token. The
+      // re-read confirms it holds newToken, so this is an idempotent repeat and
+      // the flow proceeds to a successful result.
+      mockSubscriptionRepo.findFirstByUser
+        .mockResolvedValueOnce({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          purchaseToken: 'old-google-token',
+        })
+        .mockResolvedValue({
+          id: 'sub-1',
+          userId,
+          plan: 'monthly',
+          status: 'active',
+          startedAt: now,
+          endsAt: now,
+          purchaseToken: 'new-google-token',
+        });
+      // Migration CAS misses (0); the subsequent upsert guard matches (1).
+      mockSubscriptionRepo.updateByIdIfToken
+        .mockResolvedValueOnce(0)
+        .mockResolvedValue(1);
+      mockSubscriptionRepo.findById.mockResolvedValue({
+        id: 'sub-1',
+        userId,
+        plan: 'monthly',
+        status: 'active',
+        startedAt: now,
+        endsAt: now,
+        purchaseToken: 'new-google-token',
+      });
+      mockPaymentTxRepo.create.mockResolvedValue({
+        id: 'tx-idem',
+        userId,
+        amount: 4.99,
+        currency: 'USD',
+        status: 'success',
+        reference: 'hash-idem',
+      });
+
+      const result = await service.verifyPurchase(userId, dto);
+
+      expect(result.success).toBe(true);
+      expect(mockSubscriptionRepo.create).not.toHaveBeenCalled();
+    });
+
     it('should update existing subscription for returning user', async () => {
       const userId = 'user-1';
       const dto = {
@@ -370,25 +502,39 @@ describe('PaymentService', () => {
         reference: 'hash-789',
       });
 
+      // Initial read sees the old row; the guarded re-read after the write
+      // returns the upgraded row.
       mockSubscriptionRepo.findFirstByUser.mockResolvedValue({
         id: 'existing-sub',
         userId,
         plan: 'monthly',
         status: 'active',
+        purchaseToken: null,
       });
-
-      mockSubscriptionRepo.updateById.mockResolvedValue({
+      mockSubscriptionRepo.findById.mockResolvedValue({
         id: 'existing-sub',
         userId,
         plan: 'yearly',
         status: 'active',
         startedAt: now,
         endsAt: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
+        purchaseToken: 'new-token',
       });
 
       const result = await service.verifyPurchase(userId, dto);
 
-      expect(mockSubscriptionRepo.updateById).toHaveBeenCalled();
+      // Existing-row writes go through the token-guarded CAS (updateByIdIfToken),
+      // not an unconditional update-by-id, so a concurrent token cannot be
+      // clobbered.
+      expect(mockSubscriptionRepo.updateByIdIfToken).toHaveBeenCalledWith(
+        'existing-sub',
+        null,
+        expect.objectContaining({
+          plan: 'yearly',
+          purchaseToken: 'new-token',
+        }),
+      );
+      expect(mockSubscriptionRepo.updateById).not.toHaveBeenCalled();
       expect(mockSubscriptionRepo.create).not.toHaveBeenCalled();
       expect(result.subscription?.plan).toBe('yearly');
     });

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -17,6 +17,7 @@ import {
   PRODUCT_ID_TO_PLAN,
 } from '@/subscription/subscription.constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotificationService } from '../notification/notification.service';
 import {
   SUBSCRIPTION_REPOSITORY,
   ISubscriptionRepository,
@@ -47,7 +48,33 @@ export class PaymentService {
     private readonly googleVerificationService: GoogleVerificationService,
     private readonly appleVerificationService: AppleVerificationService,
     private readonly eventEmitter: EventEmitter2,
+    // NotificationModule is @Global, so no payment.module import change is needed.
+    private readonly notificationService: NotificationService,
   ) {}
+
+  /**
+   * Emit a notification, swallowing any error so notification failures never
+   * break the payment/subscription flow.
+   */
+  private async emitNotification(
+    type: 'PaymentSuccess' | 'SubscriptionAlert',
+    data: Record<string, unknown>,
+    userId: string,
+  ): Promise<void> {
+    try {
+      await this.notificationService.sendNotification(type, data, userId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to emit ${type} notification for user ${userId.substring(0, 8)}: ${this.getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /** Resolve a human-friendly plan name from a product ID, without throwing. */
+  private resolvePlanDisplay(productId: string): string {
+    const planKey = PRODUCT_ID_TO_PLAN[productId];
+    return (planKey && PLANS[planKey]?.display) || productId;
+  }
 
   /**
    * Verify an In-App Purchase from Google Play or App Store
@@ -412,6 +439,18 @@ export class PaymentService {
       trigger: existingSub ? 'subscription_renewed' : 'subscription_created',
     });
 
+    // Payment has succeeded and the subscription is now active/renewed.
+    // Best-effort in-app + push PaymentSuccess (opt-out respected downstream).
+    await this.emitNotification(
+      'PaymentSuccess',
+      {
+        amount: transaction.amount,
+        currency: transaction.currency ?? 'USD',
+        plan: PLANS[plan]?.display ?? plan,
+      },
+      userId,
+    );
+
     return {
       success: true,
       alreadyProcessed: false,
@@ -526,6 +565,16 @@ export class PaymentService {
     const subscription = await this.subscriptionRepository.updateById(
       existing.id,
       { status: 'cancelled', endsAt },
+    );
+
+    // Best-effort SubscriptionAlert on the store-side (app-initiated) cancel.
+    const cancelledPlan = existing.productId
+      ? this.resolvePlanDisplay(existing.productId)
+      : existing.plan;
+    await this.emitNotification(
+      'SubscriptionAlert',
+      { message: `Your ${cancelledPlan} subscription was cancelled.` },
+      userId,
     );
 
     if (appleAutoRenewWarning) {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -69,7 +70,8 @@ export class PaymentService {
     } catch (error) {
       if (
         error instanceof BadRequestException ||
-        error instanceof NotFoundException
+        error instanceof NotFoundException ||
+        error instanceof ConflictException
       ) {
         throw error;
       }
@@ -188,6 +190,12 @@ export class PaymentService {
    * subscription upsert also writes the new token, so this is idempotent — it
    * exists so the migration is explicit and happens even if the stored token is
    * the linked one on a distinct Subscription row.
+   *
+   * Concurrency: the swap is a DB-level compare-and-swap. When it affects zero
+   * rows we re-read to distinguish an idempotent repeat (row already holds
+   * `newToken` — safe to continue) from a lost race where a concurrent delivery
+   * installed a DIFFERENT token. In the latter case we throw so the caller's
+   * subsequent upsert never overwrites (clobbers) the concurrent winner.
    */
   private async migrateGoogleLinkedToken(
     userId: string,
@@ -205,9 +213,38 @@ export class PaymentService {
       return;
     }
 
-    await this.subscriptionRepository.updateById(existing.id, {
-      purchaseToken: newToken,
-    });
+    // Compare-and-swap: fold the token match into the write so a concurrent
+    // replacement cannot also pass the in-memory check above and leave the row
+    // mapped to the wrong token. Guarding on the still-stored `linkedToken` means
+    // only the delivery that still sees the old token wins.
+    const affected = await this.subscriptionRepository.updateByIdIfToken(
+      existing.id,
+      linkedToken,
+      { purchaseToken: newToken },
+    );
+    if (affected === 0) {
+      // `count === 0` is NOT unconditionally benign: the guard missed either
+      // because we (or an idempotent retry) already installed `newToken`, OR
+      // because a concurrent delivery installed a DIFFERENT token. Re-read to
+      // tell these apart. Only continue when the row already holds `newToken`
+      // (our write / an idempotent repeat). If some other token won the race we
+      // must NOT let the caller's subsequent upsert clobber it — abort this
+      // delivery so the concurrent winner is preserved.
+      const current = await this.subscriptionRepository.findById(existing.id);
+      if (current?.purchaseToken === newToken) {
+        this.logger.log(
+          `Skipped Google purchaseToken migration for user ${userId.substring(0, 8)} (already migrated to this token)`,
+        );
+        return;
+      }
+      this.logger.warn(
+        `Aborting Google purchaseToken migration for user ${userId.substring(0, 8)}: ` +
+          `a concurrent delivery installed a different token; preserving the winner`,
+      );
+      throw new ConflictException(
+        'Purchase token changed concurrently; please retry',
+      );
+    }
     this.logger.log(
       `Migrated Google purchaseToken (linked) for user ${userId.substring(0, 8)}`,
     );
@@ -336,12 +373,35 @@ export class PaymentService {
       purchaseToken: platformDetails?.purchaseToken ?? null,
     };
 
-    const subscription = existingSub
-      ? await this.subscriptionRepository.updateById(existingSub.id, data)
-      : await this.subscriptionRepository.create({
-          userId,
-          ...data,
-        });
+    let subscription;
+    if (existingSub) {
+      // Token-guarded write (defense-in-depth CAS): only mutate the row while its
+      // purchaseToken is still the value we just read. If a concurrent
+      // verification installed a different token between the read above and this
+      // write, the guard misses (count === 0) and we must NOT overwrite the
+      // concurrent winner — re-read and return the current row unchanged so a
+      // later unconditional update-by-id can never clobber the winning token.
+      const guardToken = existingSub.purchaseToken ?? null;
+      const affected = await this.subscriptionRepository.updateByIdIfToken(
+        existingSub.id,
+        guardToken,
+        data,
+      );
+      if (affected === 0) {
+        this.logger.warn(
+          `Skipped subscription token write for user ${userId.substring(0, 8)}: ` +
+            `a concurrent verification changed the purchase token; preserving the winner`,
+        );
+      }
+      subscription = (await this.subscriptionRepository.findById(
+        existingSub.id,
+      )) ?? { userId, ...data };
+    } else {
+      subscription = await this.subscriptionRepository.create({
+        userId,
+        ...data,
+      });
+    }
 
     this.eventEmitter.emit('admin.sse.activity', {
       type: 'SUBSCRIPTION',

--- a/src/payment/repositories/prisma-subscription.repository.ts
+++ b/src/payment/repositories/prisma-subscription.repository.ts
@@ -13,6 +13,12 @@ export class PrismaSubscriptionRepository implements ISubscriptionRepository {
     });
   }
 
+  async findById(id: string): Promise<Subscription | null> {
+    return this.prisma.subscription.findFirst({
+      where: { id },
+    });
+  }
+
   async updateById(
     id: string,
     data: Prisma.SubscriptionUncheckedUpdateInput,
@@ -21,6 +27,22 @@ export class PrismaSubscriptionRepository implements ISubscriptionRepository {
       where: { id },
       data,
     });
+  }
+
+  async updateByIdIfToken(
+    id: string,
+    expectedToken: string | null,
+    data: Prisma.SubscriptionUncheckedUpdateInput,
+  ): Promise<number> {
+    // Compare-and-swap: the `purchaseToken` guard is folded into the WHERE so the
+    // token match and the write happen atomically. If a concurrent verification
+    // changed the token between the caller's read and this write, the WHERE
+    // matches no row and `count === 0` — the caller must NOT overwrite the winner.
+    const res = await this.prisma.subscription.updateMany({
+      where: { id, purchaseToken: expectedToken },
+      data: data as Prisma.SubscriptionUpdateManyMutationInput,
+    });
+    return res.count;
   }
 
   async create(

--- a/src/payment/repositories/subscription.repository.interface.ts
+++ b/src/payment/repositories/subscription.repository.interface.ts
@@ -5,11 +5,27 @@ export interface ISubscriptionRepository {
   // Find the first subscription owned by a user
   findFirstByUser(userId: string): Promise<Subscription | null>;
 
+  // Find a subscription by id (used to re-read a row after a compare-and-swap
+  // write misses, to distinguish an idempotent repeat from a concurrent clobber)
+  findById(id: string): Promise<Subscription | null>;
+
   // Update a subscription by id
   updateById(
     id: string,
     data: Prisma.SubscriptionUncheckedUpdateInput,
   ): Promise<Subscription>;
+
+  // Compare-and-swap update: mutate the row ONLY while its stored purchaseToken
+  // still equals `expectedToken` (pass `null` to match a currently-null token).
+  // The token match is folded into the write so a concurrent replacement between
+  // an in-memory read and this write cannot be clobbered. Returns the number of
+  // rows affected (1 = the guard matched and the write applied; 0 = a concurrent
+  // writer already changed the token, so nothing was written).
+  updateByIdIfToken(
+    id: string,
+    expectedToken: string | null,
+    data: Prisma.SubscriptionUncheckedUpdateInput,
+  ): Promise<number>;
 
   // Create a subscription
   create(data: Prisma.SubscriptionUncheckedCreateInput): Promise<Subscription>;

--- a/src/payment/subscription-webhook.service.spec.ts
+++ b/src/payment/subscription-webhook.service.spec.ts
@@ -17,7 +17,11 @@ type MockPrisma = {
     update: jest.Mock;
     updateMany: jest.Mock;
   };
-  subscription: { findFirst: jest.Mock; update: jest.Mock };
+  subscription: {
+    findFirst: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
 };
 
 const SUB = {
@@ -84,6 +88,9 @@ describe('SubscriptionWebhookService', () => {
       subscription: {
         findFirst: jest.fn().mockResolvedValue({ ...SUB }),
         update: jest.fn().mockResolvedValue({ ...SUB }),
+        // CAS writes: default to a matched row (applied). Stale/lost-race tests
+        // override this to `{ count: 0 }`.
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
     };
     apple = { parseSignedNotification: jest.fn() };
@@ -537,9 +544,10 @@ describe('SubscriptionWebhookService', () => {
 
         expect(res.status).toBe('processed');
         expect(res.action).toBe('google:SUBSCRIPTION_4 -> activate');
-        // Row's purchaseToken migrated from the old token to the new one.
-        expect(prisma.subscription.update).toHaveBeenCalledWith({
-          where: { id: 'sub-1' },
+        // Row's purchaseToken migrated from the old token to the new one via a
+        // compare-and-swap guarded on the still-stored linked token.
+        expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+          where: { id: 'sub-1', purchaseToken: 'g-token-1' },
           data: { purchaseToken: 'new-token' },
         });
       });
@@ -592,8 +600,8 @@ describe('SubscriptionWebhookService', () => {
         const res = await service.handleGoogle(body);
 
         expect(res.status).toBe('processed');
-        expect(prisma.subscription.update).toHaveBeenCalledWith({
-          where: { id: 'sub-1' },
+        expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+          where: { id: 'sub-1', purchaseToken: 'token-A' },
           data: { purchaseToken: 'token-C' },
         });
       });
@@ -683,12 +691,17 @@ describe('SubscriptionWebhookService', () => {
   });
 
   // --------------------------------------- out-of-order delivery watermark ----
-  describe('out-of-order delivery protection (event watermark)', () => {
+  describe('out-of-order delivery protection (event watermark, CAS)', () => {
     const OLD = new Date('2026-05-01T00:00:00Z');
     const NEW = new Date('2026-06-01T00:00:00Z');
 
+    // The watermark guard is a compare-and-swap: the timestamp comparison lives
+    // in the `updateMany` WHERE, and the affected-row count decides applied vs
+    // skipped. When `eventAt` is known the service uses `updateMany`, never a
+    // bare `update`.
+
     // ------------------------------------------------------------- Apple ----
-    it('applies a newer Apple event and advances lastEventAt atomically', async () => {
+    it('applies a newer Apple event via a guarded updateMany and advances lastEventAt', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: OLD,
@@ -704,22 +717,30 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleApple({ signedPayload: 'jws' });
 
       expect(res.status).toBe('processed');
-      expect(prisma.subscription.update).toHaveBeenCalledWith({
-        where: { id: 'sub-1' },
+      // State change + watermark advance are a single conditional write.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
         data: {
           status: 'active',
           endsAt: new Date('2026-03-01'),
           lastEventAt: NEW,
         },
       });
+      // No unguarded update when a timestamp is present.
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a stale Apple event (older than lastEventAt) without regressing state', async () => {
+    it('skips a stale Apple event when the CAS matches no row (older delivery loses the race)', async () => {
       // Already applied a DID_RENEW at NEW; a delayed EXPIRED at OLD arrives.
+      // The conditional write matches zero rows (stored watermark is newer).
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: NEW,
       });
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
       apple.parseSignedNotification.mockReturnValue(
         appleInfo({
           notificationType: 'EXPIRED',
@@ -732,10 +753,20 @@ describe('SubscriptionWebhookService', () => {
 
       expect(res.status).toBe('skipped');
       expect(res.action).toContain('stale/out-of-order');
+      // The CAS was attempted (guarded), but nothing was regressed.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'sub-1' }),
+        }),
+      );
       expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a duplicate Apple event arriving at the exact same timestamp', async () => {
+    it('applies a DISTINCT Apple event arriving at the exact same timestamp (equality is not stale)', async () => {
+      // Same-millisecond, different notificationUUID -> a distinct event. True
+      // duplicates are filtered by the WebhookEvent idempotency layer, so this
+      // must be processed, not dropped. The CAS WHERE uses `lte`, so an equal
+      // stored watermark still matches.
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         lastEventAt: NEW,
@@ -743,15 +774,25 @@ describe('SubscriptionWebhookService', () => {
       apple.parseSignedNotification.mockReturnValue(
         appleInfo({
           notificationType: 'DID_RENEW',
-          notificationUUID: 'wm-a-dup',
+          notificationUUID: 'wm-a-same-instant',
           signedDate: NEW.getTime(),
         }),
       );
 
       const res = await service.handleApple({ signedPayload: 'jws' });
 
-      expect(res.status).toBe('skipped');
-      expect(prisma.subscription.update).not.toHaveBeenCalled();
+      expect(res.status).toBe('processed');
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
+        data: {
+          status: 'active',
+          endsAt: new Date('2026-03-01'),
+          lastEventAt: NEW,
+        },
+      });
     });
 
     it('applies an Apple event and sets lastEventAt when no prior watermark exists', async () => {
@@ -770,12 +811,52 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleApple({ signedPayload: 'jws' });
 
       expect(res.status).toBe('processed');
-      const call = prisma.subscription.update.mock.calls[0][0];
+      const call = prisma.subscription.updateMany.mock.calls[0][0];
       expect(call.data.lastEventAt).toEqual(NEW);
+      // Guard admits a null stored watermark.
+      expect(call.where.OR).toContainEqual({ lastEventAt: null });
+    });
+
+    it('simulated concurrent old/new delivery: the newer applies, the older is skipped', async () => {
+      // Newer event (NEW): stored watermark is OLD -> CAS matches (count 1).
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: OLD,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 1 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'wm-a-conc-new',
+          signedDate: NEW.getTime(),
+        }),
+      );
+
+      const newer = await service.handleApple({ signedPayload: 'jws' });
+      expect(newer.status).toBe('processed');
+
+      // Older event (OLD) races in after the watermark advanced to NEW. Both the
+      // read and the CAS now see the newer watermark -> count 0 -> skipped.
+      prisma.subscription.findFirst.mockResolvedValueOnce({
+        ...SUB,
+        lastEventAt: NEW,
+      });
+      prisma.subscription.updateMany.mockResolvedValueOnce({ count: 0 });
+      apple.parseSignedNotification.mockReturnValueOnce(
+        appleInfo({
+          notificationType: 'EXPIRED',
+          notificationUUID: 'wm-a-conc-old',
+          signedDate: OLD.getTime(),
+        }),
+      );
+
+      const older = await service.handleApple({ signedPayload: 'jws' });
+      expect(older.status).toBe('skipped');
+      expect(older.action).toContain('stale/out-of-order');
     });
 
     // ------------------------------------------------------------ Google ----
-    it('applies a newer Google event and advances lastEventAt', async () => {
+    it('applies a newer Google event via a guarded updateMany and advances lastEventAt', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         platform: 'google',
@@ -801,23 +882,28 @@ describe('SubscriptionWebhookService', () => {
       const res = await service.handleGoogle(body);
 
       expect(res.status).toBe('processed');
-      expect(prisma.subscription.update).toHaveBeenCalledWith({
-        where: { id: 'sub-1' },
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'sub-1',
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: NEW } }],
+        },
         data: {
           status: 'active',
           endsAt: new Date('2026-07-01'),
           lastEventAt: NEW,
         },
       });
+      expect(prisma.subscription.update).not.toHaveBeenCalled();
     });
 
-    it('skips a stale Google EXPIRED that would clobber a newer RENEWED', async () => {
+    it('skips a stale Google EXPIRED that would clobber a newer RENEWED (CAS matches no row)', async () => {
       prisma.subscription.findFirst.mockResolvedValue({
         ...SUB,
         platform: 'google',
         purchaseToken: 'g-token-1',
         lastEventAt: NEW,
       });
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
       const body = googleBody(
         {
           eventTimeMillis: String(OLD.getTime()),
@@ -835,6 +921,75 @@ describe('SubscriptionWebhookService', () => {
       expect(res.status).toBe('skipped');
       expect(res.action).toContain('stale/out-of-order');
       expect(prisma.subscription.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ----------------------------- linked-token migration is compare-and-swap ----
+  describe('linked-token migration (CAS)', () => {
+    it('re-resolves by the event token when the migration CAS loses the race', async () => {
+      // Event token 'new-token' is not stored; its linkedPurchaseToken is
+      // 'g-token-1', which we DO store. A concurrent delivery migrates the row
+      // first, so our guarded updateMany matches 0 rows and we must re-resolve by
+      // the (now stored) event token instead of mis-mapping.
+      let newTokenLookups = 0;
+      prisma.subscription.findFirst.mockImplementation(
+        ({ where }: { where: { purchaseToken?: string } }) => {
+          if (where.purchaseToken === 'g-token-1') {
+            return Promise.resolve({
+              ...SUB,
+              platform: 'google',
+              purchaseToken: 'g-token-1',
+            });
+          }
+          if (where.purchaseToken === 'new-token') {
+            // First lookup is the fast-path (token not stored yet) -> null. The
+            // second lookup is the post-lost-race re-resolution: a concurrent
+            // delivery already migrated the row, so it now holds 'new-token'.
+            newTokenLookups += 1;
+            if (newTokenLookups === 1) return Promise.resolve(null);
+            return Promise.resolve({
+              ...SUB,
+              platform: 'google',
+              purchaseToken: 'new-token',
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+      // Lost the migration race.
+      prisma.subscription.updateMany.mockResolvedValue({ count: 0 });
+      google.verify
+        .mockResolvedValueOnce({
+          success: true,
+          linkedPurchaseToken: 'g-token-1',
+        })
+        .mockResolvedValue({
+          success: true,
+          expirationTime: new Date('2026-04-01'),
+        });
+
+      const body = googleBody(
+        {
+          packageName: 'com.storytime.app',
+          subscriptionNotification: {
+            notificationType: 4, // PURCHASED
+            purchaseToken: 'new-token',
+            subscriptionId: 'com.storytime.monthly',
+          },
+        },
+        'msg-link-cas-race',
+      );
+
+      const res = await service.handleGoogle(body);
+
+      // The migration CAS was guarded on the still-stored linked token.
+      expect(prisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { id: 'sub-1', purchaseToken: 'g-token-1' },
+        data: { purchaseToken: 'new-token' },
+      });
+      // Despite losing the race, the event still resolves and applies.
+      expect(res.status).toBe('processed');
+      expect(res.action).toBe('google:SUBSCRIPTION_4 -> activate');
     });
   });
 });

--- a/src/payment/subscription-webhook.service.ts
+++ b/src/payment/subscription-webhook.service.ts
@@ -168,7 +168,7 @@ export class SubscriptionWebhookService {
     if (!applied) {
       return {
         status: 'skipped',
-        action: `apple:${info.notificationType} stale/out-of-order (event <= lastEventAt)`,
+        action: `apple:${info.notificationType} stale/out-of-order (event older than watermark)`,
       };
     }
     return {
@@ -315,7 +315,8 @@ export class SubscriptionWebhookService {
       if (!applied) {
         return {
           status: 'skipped',
-          action: 'google:voided stale/out-of-order (event <= lastEventAt)',
+          action:
+            'google:voided stale/out-of-order (event older than watermark)',
         };
       }
       return { status: 'processed', action: 'google:voided -> revoke' };
@@ -376,7 +377,7 @@ export class SubscriptionWebhookService {
     if (!applied) {
       return {
         status: 'skipped',
-        action: `google:SUBSCRIPTION_${sub.notificationType} stale/out-of-order (event <= lastEventAt)`,
+        action: `google:SUBSCRIPTION_${sub.notificationType} stale/out-of-order (event older than watermark)`,
       };
     }
     return {
@@ -673,15 +674,28 @@ export class SubscriptionWebhookService {
 
       const sub = await this.findSubscription('google', linkedToken);
       if (sub) {
-        // Migrate the known row forward to the newest (event) token in place.
-        const migrated = await this.prisma.subscription.update({
-          where: { id: sub.id },
+        // Migrate the known row forward to the newest (event) token in place,
+        // via a compare-and-swap guarded on the still-stored `linkedToken`. The
+        // in-memory read above then an id-only update would be a TOCTOU race:
+        // two concurrent replacements could both pass and the last writer could
+        // leave the row mapped to the wrong token. `updateMany` performs the
+        // token match and the write atomically.
+        const res = await this.prisma.subscription.updateMany({
+          where: { id: sub.id, purchaseToken: linkedToken },
           data: { purchaseToken: eventToken },
         });
+        if (res.count === 0) {
+          // A concurrent delivery already migrated this row. Re-resolve by the
+          // event token (now the stored token) so this event still applies.
+          this.logger.log(
+            `Lost linked-token migration race for subscription ${sub.id}; re-resolving by event token`,
+          );
+          return this.findSubscription('google', eventToken);
+        }
         this.logger.log(
           `Migrated Google purchaseToken ${this.mask(linkedToken)} -> ${this.mask(eventToken)} for subscription ${sub.id} (${hop + 1} hop(s))`,
         );
-        return migrated;
+        return { ...sub, purchaseToken: eventToken };
       }
 
       currentToken = linkedToken;
@@ -722,11 +736,36 @@ export class SubscriptionWebhookService {
    * - deactivate:     status cancelled, endsAt = now (access ends immediately)
    * - revoke:         status cancelled, endsAt = now (refund/chargeback)
    *
-   * Out-of-order protection: when `eventAt` is known and the subscription's
-   * stored `lastEventAt` is >= `eventAt`, the event is stale (a late/duplicate
-   * delivery) and the mutation is SKIPPED (returns `false`) so it cannot clobber
-   * newer state. Otherwise the state change AND the advanced `lastEventAt`
-   * watermark are written in a single update (atomic), and `true` is returned.
+   * Out-of-order protection (compare-and-swap): the `lastEventAt` watermark guard
+   * runs INSIDE the write, never as a separate read-then-write. A prior in-memory
+   * compare-then-`update` was a TOCTOU race — two concurrent deliveries could both
+   * read the old watermark, both pass, and both write, letting the older event
+   * commit last and regress the subscription. Here a conditional `updateMany`
+   * performs the comparison and the state mutation as a single atomic statement,
+   * and we branch on the affected-row count:
+   *  - count === 1 -> the guard matched; state change + advanced watermark applied.
+   *  - count === 0 -> a newer watermark is already stored (this event lost the race
+   *    / is stale); nothing is written and we return `false`.
+   *
+   * Ordering semantics (see also `prisma/schema.prisma` `Subscription.lastEventAt`):
+   * apply when there is no stored watermark yet OR the stored watermark is <= this
+   * event (`lte`). A STRICTLY greater stored watermark skips (a newer event already
+   * won). Equality APPLIES rather than skips so that two DISTINCT notifications that
+   * happen to share a millisecond are both processed (true duplicates are already
+   * filtered upstream by the `WebhookEvent (platform, externalEventId)` idempotency
+   * layer, so a same-instant event reaching here is always a distinct one).
+   *
+   * Honest limitation: for two CONFLICTING events sharing the exact same millisecond
+   * this is NOT serialized by arrival order — both pass the `<=` guard and whichever
+   * DB write commits last wins (last-write-wins in DB-commit order, which need not
+   * match arrival order). We deliberately do NOT add per-subscription serialization
+   * or a monotonic tie-breaker: Apple and Google emit one notification per state
+   * transition, each with a distinct timestamp, so conflicting same-millisecond
+   * lifecycle events for one subscription do not occur in practice, and the heavy
+   * locking/sequence infrastructure required to serialize them is not warranted.
+   *
+   * When `eventAt` is null the event has no derivable timestamp; ordering cannot
+   * be established, so it is applied unconditionally (never blocked).
    */
   private async applyAction(
     subscription: Subscription,
@@ -756,29 +795,33 @@ export class SubscriptionWebhookService {
         return false;
     }
 
-    // Skip stale / out-of-order deliveries. `>=` also drops a distinct event
-    // arriving at the exact same timestamp as the last applied one.
-    if (
-      eventAt &&
-      subscription.lastEventAt &&
-      subscription.lastEventAt.getTime() >= eventAt.getTime()
-    ) {
-      this.logger.log(
-        `Skipping stale/out-of-order ${action} for subscription ${subscription.id} ` +
-          `(event ${eventAt.toISOString()} <= lastEventAt ${subscription.lastEventAt.toISOString()})`,
-      );
-      return false;
-    }
-
-    // Advance the watermark atomically with the state change (same UPDATE).
     if (eventAt) {
+      // Advance the watermark atomically with the state change (same write).
       data.lastEventAt = eventAt;
+      // CAS guard: apply only when no watermark is stored yet, or the stored one
+      // is <= this event. A strictly-greater stored watermark means a newer event
+      // already won -> the WHERE does not match and count === 0 (stale/skip).
+      const res = await this.prisma.subscription.updateMany({
+        where: {
+          id: subscription.id,
+          OR: [{ lastEventAt: null }, { lastEventAt: { lte: eventAt } }],
+        },
+        data: data as Prisma.SubscriptionUpdateManyMutationInput,
+      });
+      if (res.count === 0) {
+        this.logger.log(
+          `Skipping stale/out-of-order ${action} for subscription ${subscription.id} ` +
+            `(event ${eventAt.toISOString()} older than stored watermark)`,
+        );
+        return false;
+      }
+    } else {
+      // No derivable event timestamp -> apply without ordering gating.
+      await this.prisma.subscription.update({
+        where: { id: subscription.id },
+        data,
+      });
     }
-
-    await this.prisma.subscription.update({
-      where: { id: subscription.id },
-      data,
-    });
 
     this.eventEmitter.emit('admin.sse.activity', {
       type: 'SUBSCRIPTION',

--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,82 @@
+import {
+  parseConnectionLimit,
+  resolvePrismaDatasourceUrl,
+} from './prisma.service';
+
+describe('resolvePrismaDatasourceUrl', () => {
+  it('returns undefined when resolvePrismaDatasourceUrl receives undefined', () => {
+    expect(resolvePrismaDatasourceUrl(undefined, 3)).toBeUndefined();
+  });
+
+  it('returns an empty string when resolvePrismaDatasourceUrl receives an empty string', () => {
+    expect(resolvePrismaDatasourceUrl('', 3)).toBe('');
+  });
+
+  it('adds a default connection limit to direct postgres URLs', () => {
+    expect(
+      resolvePrismaDatasourceUrl(
+        'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime',
+        3,
+      ),
+    ).toBe(
+      'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=3',
+    );
+  });
+
+  it('preserves an existing connection limit', () => {
+    expect(
+      resolvePrismaDatasourceUrl(
+        'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=7',
+        3,
+      ),
+    ).toBe(
+      'postgresql://user:pass@localhost:5432/storytime_dev?schema=storytime&connection_limit=7',
+    );
+  });
+
+  it('leaves prisma accelerate URLs unchanged', () => {
+    expect(
+      resolvePrismaDatasourceUrl('prisma://accelerate.example.com', 3),
+    ).toBe('prisma://accelerate.example.com');
+  });
+
+  it('returns the original URL when parsing fails', () => {
+    expect(resolvePrismaDatasourceUrl('not-a-url', 3)).toBe('not-a-url');
+  });
+
+  it('does not add a connection limit to non-postgres URLs', () => {
+    expect(resolvePrismaDatasourceUrl('mysql://localhost/storytime', 3)).toBe(
+      'mysql://localhost/storytime',
+    );
+  });
+});
+
+describe('parseConnectionLimit', () => {
+  it('returns the fallback when parseConnectionLimit receives undefined', () => {
+    expect(parseConnectionLimit(undefined)).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives an empty string', () => {
+    expect(parseConnectionLimit('')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives whitespace only', () => {
+    expect(parseConnectionLimit('   ')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives a non-numeric string', () => {
+    expect(parseConnectionLimit('not-a-number')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives a negative number', () => {
+    expect(parseConnectionLimit('-1')).toBe(3);
+  });
+
+  it('returns the fallback when parseConnectionLimit receives zero', () => {
+    expect(parseConnectionLimit('0')).toBe(3);
+  });
+
+  it('returns the parsed value when parseConnectionLimit receives a valid integer', () => {
+    expect(parseConnectionLimit('7')).toBe(7);
+  });
+});

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -10,6 +10,45 @@ import IHealth, { HealthResponse } from '@/health/Ihealth.interfaces';
 // Threshold for slow query warnings (milliseconds)
 const SLOW_QUERY_THRESHOLD_MS = 100;
 
+const FALLBACK_DATABASE_CONNECTION_LIMIT = 3;
+
+export const parseConnectionLimit = (value: string | undefined): number => {
+  if (value === undefined || value.trim() === '') {
+    return FALLBACK_DATABASE_CONNECTION_LIMIT;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : FALLBACK_DATABASE_CONNECTION_LIMIT;
+};
+
+const DEFAULT_DATABASE_CONNECTION_LIMIT = parseConnectionLimit(
+  process.env.DATABASE_CONNECTION_LIMIT,
+);
+
+export const resolvePrismaDatasourceUrl = (
+  databaseUrl: string | undefined,
+  connectionLimit = DEFAULT_DATABASE_CONNECTION_LIMIT,
+): string | undefined => {
+  if (!databaseUrl || databaseUrl.startsWith('prisma://')) {
+    return databaseUrl;
+  }
+
+  try {
+    const url = new URL(databaseUrl);
+    const isPostgresUrl =
+      url.protocol === 'postgres:' || url.protocol === 'postgresql:';
+
+    if (isPostgresUrl && !url.searchParams.has('connection_limit')) {
+      url.searchParams.set('connection_limit', String(connectionLimit));
+    }
+    return url.toString();
+  } catch {
+    return databaseUrl;
+  }
+};
+
 @Injectable()
 export class PrismaService
   extends PrismaClient
@@ -18,12 +57,15 @@ export class PrismaService
   private readonly logger = new Logger(PrismaService.name);
 
   constructor() {
-    // Configure connection pool via datasource URL parameters
-    // These can be overridden in DATABASE_URL: ?connection_limit=10&pool_timeout=10
+    // Configure connection pool via datasource URL parameters. A bounded
+    // connection_limit is auto-appended to direct (postgresql://) URLs so a
+    // single instance can't exhaust the shared database pool; Prisma Accelerate
+    // (prisma://) URLs are passed through untouched. Any of these can be
+    // overridden in DATABASE_URL: ?connection_limit=10&pool_timeout=10
     super({
       datasources: {
         db: {
-          url: process.env.DATABASE_URL,
+          url: resolvePrismaDatasourceUrl(process.env.DATABASE_URL),
         },
       },
       log:

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -230,7 +230,7 @@ export const RedisClientProvider: Provider = {
       if (
         error.name === 'SocketClosedUnexpectedlyError' ||
         error.message.includes('ECONNREFUSED') ||
-        error.message.includes('ETIMEOUT') ||
+        error.message.includes('ETIMEDOUT') ||
         error.message.includes('ENOTFOUND') ||
         error.message.includes('EAI_AGAIN')
       ) {

--- a/src/story/repositories/prisma-story-progress.repository.ts
+++ b/src/story/repositories/prisma-story-progress.repository.ts
@@ -62,7 +62,9 @@ export class PrismaStoryProgressRepository implements IStoryProgressRepository {
       where: { kidId_storyId: { kidId, storyId } },
       update: {
         progress: data.progress,
-        completed: data.completed,
+        // Monotonic completion: only ever flip to true, never downgrade an
+        // already-completed record (mirrors the guest progress repository).
+        ...(data.completed ? { completed: true } : {}),
         lastAccessed: new Date(),
         totalTimeSpent: { increment: data.sessionTime },
       },
@@ -145,7 +147,9 @@ export class PrismaStoryProgressRepository implements IStoryProgressRepository {
       where: { userId_storyId: { userId, storyId } },
       update: {
         progress: data.progress,
-        completed: data.completed,
+        // Monotonic completion: only ever flip to true, never downgrade an
+        // already-completed record (mirrors the guest progress repository).
+        ...(data.completed ? { completed: true } : {}),
         lastAccessed: new Date(),
         totalTimeSpent: data.updateTotalTimeSpent,
         isDeleted: false,

--- a/src/story/story-progress.service.ts
+++ b/src/story/story-progress.service.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_CURSOR_LIMIT,
   PaginationUtil,
 } from '@/shared/utils/pagination.util';
+import { NotificationService } from '../notification/notification.service';
 
 /** Max session time in seconds (24 h), matching the DTO contract. */
 const MAX_SESSION_TIME = 86_400;
@@ -40,6 +41,8 @@ export class StoryProgressService {
   constructor(
     @Inject(STORY_PROGRESS_REPOSITORY)
     private readonly progressRepository: IStoryProgressRepository,
+    // NotificationModule is @Global; StoryModule already imports it too.
+    private readonly notificationService: NotificationService,
   ) {}
 
   /** Wraps a query to handle invalid cursor IDs gracefully */
@@ -116,6 +119,20 @@ export class StoryProgressService {
         const msg = e instanceof Error ? e.message : String(e);
         this.logger.error(`Failed to adjust reading level: ${msg}`);
       });
+
+      // Best-effort StoryFinished notification to the kid's parent. Emitted only
+      // on the false->true completion transition. Must never break the progress
+      // flow, so failures are logged and swallowed.
+      try {
+        await this.notificationService.sendNotification(
+          'StoryFinished',
+          { kidName: kid.name ?? 'Your child', storyTitle: story.title },
+          kid.parentId,
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`Failed to send StoryFinished notification: ${msg}`);
+      }
     }
     return result;
   }
@@ -244,6 +261,25 @@ export class StoryProgressService {
         updateTotalTimeSpent: totalTimeSpentUpdate,
       },
     );
+
+    // Best-effort StoryFinished notification on the user (web) completion path —
+    // mirrors the kid setProgress path. Only on the true false->true transition;
+    // never breaks progress recording.
+    if (dto.completed && (!existing || !existing.completed)) {
+      try {
+        await this.notificationService.sendNotification(
+          'StoryFinished',
+          { kidName: user.name ?? 'You', storyTitle: story.title },
+          userId,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to send StoryFinished (user path): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
 
     return {
       id: result.id,

--- a/src/story/story-progress.service.ts
+++ b/src/story/story-progress.service.ts
@@ -78,23 +78,36 @@ export class StoryProgressService {
     if (!story) throw new NotFoundException('Story not found');
 
     const sessionTime = normalizeSessionTime(dto.sessionTime);
+    // Clamp incoming progress to a valid [0, 100] percentage.
+    const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     const existing = await this.progressRepository.findStoryProgress(
       dto.kidId,
       dto.storyId,
     );
 
+    // Completion is monotonic and auto-derived (mirrors the guest path): once a
+    // story is completed it stays completed, and reaching 100% marks it done
+    // even without an explicit flag — so a later partial-progress ping can no
+    // longer silently un-complete the story.
+    const shouldComplete =
+      existing?.completed === true ||
+      dto.completed === true ||
+      clampedProgress >= 100;
+
     const result = await this.progressRepository.upsertKidProgress(
       dto.kidId,
       dto.storyId,
       {
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
+        completed: shouldComplete,
         sessionTime,
       },
     );
 
-    if (dto.completed && (!existing || !existing.completed)) {
+    // Fire the (non-idempotent) reading-level adjustment only on the transition
+    // from not-completed to completed, now including the auto-derived 100% case.
+    if (shouldComplete && !existing?.completed) {
       this.adjustReadingLevel(
         dto.kidId,
         dto.storyId,
@@ -204,6 +217,8 @@ export class StoryProgressService {
     );
 
     const sessionTime = normalizeSessionTime(dto.sessionTime);
+    // Clamp incoming progress to a valid [0, 100] percentage.
+    const clampedProgress = Math.max(0, Math.min(100, dto.progress));
 
     // If restoring a soft-deleted record, reset totalTimeSpent instead of
     // accumulating stale time from before the removal.
@@ -211,12 +226,20 @@ export class StoryProgressService {
       ? sessionTime
       : { increment: sessionTime };
 
+    // Completion is monotonic and auto-derived at 100% (mirrors the guest path):
+    // once completed the story stays completed until removeFromUserLibrary
+    // resets it, so a later partial-progress ping can no longer un-complete it.
+    const shouldComplete =
+      existing?.completed === true ||
+      dto.completed === true ||
+      clampedProgress >= 100;
+
     const result = await this.progressRepository.upsertUserProgress(
       userId,
       dto.storyId,
       {
-        progress: dto.progress,
-        completed: dto.completed ?? false,
+        progress: clampedProgress,
+        completed: shouldComplete,
         createTotalTimeSpent: sessionTime,
         updateTotalTimeSpent: totalTimeSpentUpdate,
       },

--- a/src/story/story-progress.service.ts
+++ b/src/story/story-progress.service.ts
@@ -264,8 +264,9 @@ export class StoryProgressService {
 
     // Best-effort StoryFinished notification on the user (web) completion path —
     // mirrors the kid setProgress path. Only on the true false->true transition;
-    // never breaks progress recording.
-    if (dto.completed && (!existing || !existing.completed)) {
+    // uses shouldComplete (not dto.completed) so an auto-derived 100% completion
+    // also notifies. Never breaks progress recording.
+    if (shouldComplete && (!existing || !existing.completed)) {
       try {
         await this.notificationService.sendNotification(
           'StoryFinished',

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { StoryService } from './story.service';
 import { StoryFeedService } from './story-feed.service';
+import { NotificationService } from '../notification/notification.service';
 import { STORY_REPOSITORY } from './repositories/story.repository.interface';
 import { GeminiService } from './gemini.service';
 import { ElevenLabsService } from './elevenlabs.service';
@@ -99,6 +100,12 @@ describe('StoryService - Library & Generation', () => {
         {
           provide: StoryGenerationService,
           useValue: mockStoryGenerationService,
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            broadcastNewStoryToUsers: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -55,6 +55,7 @@ import { StoryRecommendationService } from './story-recommendation.service';
 import { DailyChallengeService } from './daily-challenge.service';
 import { StoryFeedService } from './story-feed.service';
 import { StoryGenerationService } from './story-generation.service';
+import { NotificationService } from '../notification/notification.service';
 
 @Injectable()
 export class StoryService {
@@ -103,6 +104,8 @@ export class StoryService {
     private readonly storyRecommendationService: StoryRecommendationService,
     private readonly dailyChallengeService: DailyChallengeService,
     private readonly storyFeedService: StoryFeedService,
+    // NotificationModule is @Global; StoryModule already imports it too.
+    private readonly notificationService: NotificationService,
   ) {}
 
   /**
@@ -206,6 +209,18 @@ export class StoryService {
       },
       include: { images: true, branches: true },
     });
+
+    // Announce the new catalog story to all users — batched, preference-aware,
+    // and best-effort. Fire-and-forget so story creation isn't blocked.
+    void this.notificationService
+      .broadcastNewStoryToUsers(story.id, story.title)
+      .catch((error) =>
+        this.logger.warn(
+          `NewStory broadcast failed for story ${story.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      );
 
     await this.invalidateStoryCaches();
     return story;

--- a/src/story/text-to-speech.service.spec.ts
+++ b/src/story/text-to-speech.service.spec.ts
@@ -16,6 +16,7 @@ import { MAX_TTS_TEXT_LENGTH } from '../voice/voice.config';
 import { CircuitBreakerService } from '@/shared/services/circuit-breaker.service';
 import { TTS_CIRCUIT_BREAKER_CONFIG } from '@/shared/constants/circuit-breaker.constants';
 import { VOICE_CONFIG } from '../voice/voice.constants';
+import { QuotaExhaustedError } from '../voice/errors/quota-exhausted.error';
 
 describe('TextToSpeechService', () => {
   let service: TextToSpeechService;
@@ -1062,6 +1063,26 @@ describe('TextToSpeechService', () => {
         );
 
         expect(result.providerStatus).toBeUndefined();
+      });
+
+      it('should throw QuotaExhaustedError for overridden ElevenLabs when quota is denied', async () => {
+        mockPrisma.paragraphAudioCache.findFirst.mockResolvedValue(null);
+        mockIsPremiumUser.mockResolvedValue(false);
+        mockCanFreeUserUseElevenLabs.mockResolvedValue(false);
+
+        await expect(
+          service.generateSingleParagraphTTS(
+            storyId,
+            'A single paragraph for retry fallback.',
+            VoiceType.MILO,
+            userId,
+            { isPremium: false, providerOverride: 'elevenlabs' },
+          ),
+        ).rejects.toBeInstanceOf(QuotaExhaustedError);
+
+        expect(mockElevenLabsGenerate).not.toHaveBeenCalled();
+        expect(mockDeepgramGenerate).not.toHaveBeenCalled();
+        expect(mockEdgeTtsGenerate).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/story/tts/tts-synthesis.service.ts
+++ b/src/story/tts/tts-synthesis.service.ts
@@ -17,6 +17,7 @@ import { EdgeTTSProvider } from '../../voice/providers/edge-tts.provider';
 import type { IStoryTtsRepository } from '../repositories/story-tts.repository.interface';
 import { VoiceQuotaService } from '../../voice/voice-quota.service';
 import { SubscriptionService } from '../../subscription/subscription.service';
+import { QuotaExhaustedError } from '../../voice/errors/quota-exhausted.error';
 import {
   CircuitBreakerService,
   CircuitBreaker,
@@ -270,9 +271,10 @@ export class TtsSynthesisService {
     // Honour the quota decision: if ElevenLabs was denied, don't bypass via override.
     if (override) {
       if (override === 'elevenlabs' && !useElevenLabs) {
-        throw new InternalServerErrorException(
-          'ElevenLabs quota exhausted for this request',
-        );
+        // Throw the typed quota error (not a generic 500) so the batch
+        // processor's isQuotaError() recognises it and cascades to the
+        // Deepgram/Edge fallback instead of failing the paragraph outright.
+        throw new QuotaExhaustedError('ElevenLabs');
       }
       return this.attemptSingleProvider(
         override,

--- a/src/voice/queue/tts-batch-job.interface.ts
+++ b/src/voice/queue/tts-batch-job.interface.ts
@@ -18,6 +18,12 @@ export interface TtsBatchJobData {
     duplicateIndices?: number[];
   }>;
   totalParagraphs: number;
+  /**
+   * Self-heal round for this job. Absent/0 on the initial run; incremented on
+   * each delayed follow-up that re-attempts paragraphs which exhausted the
+   * whole provider chain. Bounded by MAX_RETRY_GENERATIONS.
+   */
+  retryGeneration?: number;
 }
 
 export interface TtsBatchJobResult {

--- a/src/voice/queue/tts-batch-queue.constants.ts
+++ b/src/voice/queue/tts-batch-queue.constants.ts
@@ -17,6 +17,19 @@ export const TTS_BATCH_REDIS_PREFIX = 'tts-batch';
 /** TTL for batch tracking Redis keys (30 minutes) */
 export const TTS_BATCH_REDIS_TTL = 1800;
 
+/**
+ * Maximum number of delayed self-heal rounds after the initial run. Each round
+ * re-attempts only the paragraphs that exhausted the whole provider chain, so
+ * this bounds the total work and guarantees the chain can't loop forever.
+ */
+export const MAX_RETRY_GENERATIONS = 2;
+
+/**
+ * Delay before a self-heal retry job runs. Gives a transient provider outage
+ * time to recover before we re-attempt the failed paragraphs.
+ */
+export const TTS_BATCH_RETRY_DELAY_MS = 45_000;
+
 export const TTS_BATCH_QUEUE_OPTIONS = {
   attempts: 3,
   backoff: { type: 'exponential' as const, delay: 5_000 },

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -9,6 +9,7 @@ import {
   TTS_BATCH_QUEUE_OPTIONS,
   TTS_BATCH_REDIS_PREFIX,
   TTS_BATCH_REDIS_TTL,
+  TTS_BATCH_RETRY_DELAY_MS,
 } from './tts-batch-queue.constants';
 import {
   TtsBatchJobData,
@@ -78,6 +79,48 @@ export class TtsBatchQueueService implements OnModuleDestroy {
     return batchJobId;
   }
 
+  /**
+   * Queue a delayed self-heal round for paragraphs that exhausted the whole
+   * provider chain. Re-uses the ORIGINAL batchJobId (so recovered paragraphs
+   * land in the same completed/failed tracking sets and the client polling the
+   * batch sees them heal), but with a distinct BullMQ jobId per generation and
+   * a delay so a transient outage has time to recover. The tracking keys are
+   * left intact — only their TTL is refreshed so they survive until the retry
+   * runs.
+   */
+  async queueRetryBatch(
+    original: TtsBatchJobData,
+    failedParagraphs: TtsBatchJobData['paragraphs'],
+    generation: number,
+  ): Promise<void> {
+    const { batchJobId } = original;
+
+    const jobData: TtsBatchJobData = {
+      ...original,
+      paragraphs: failedParagraphs,
+      retryGeneration: generation,
+    };
+
+    await this.batchQueue.add(TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS, jobData, {
+      ...TTS_BATCH_QUEUE_OPTIONS,
+      jobId: `${batchJobId}:retry:${generation}`,
+      delay: TTS_BATCH_RETRY_DELAY_MS,
+    });
+
+    const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
+    const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;
+    const failedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:failed`;
+    const pipeline = this.redis.pipeline();
+    pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
+    await pipeline.exec();
+
+    this.logger.log(
+      `TTS batch retry queued: ${batchJobId} (generation ${generation}) — ${failedParagraphs.length} paragraph(s), delay ${TTS_BATCH_RETRY_DELAY_MS}ms`,
+    );
+  }
+
   async getBatchStatus(
     batchJobId: string,
     userId?: string,
@@ -123,10 +166,15 @@ export class TtsBatchQueueService implements OnModuleDestroy {
     audioUrl: string,
   ): Promise<void> {
     const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;
+    const failedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:failed`;
     const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
     const pipeline = this.redis.pipeline();
     pipeline.hset(completedKey, String(index), audioUrl);
+    // A self-heal retry can complete a paragraph that a previous run marked
+    // failed — clear it from the failed set so it isn't reported in both.
+    pipeline.srem(failedKey, String(index));
     pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
+    pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
     pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
     await pipeline.exec();
   }

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -101,11 +101,15 @@ export class TtsBatchQueueService implements OnModuleDestroy {
       retryGeneration: generation,
     };
 
-    await this.batchQueue.add(TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS, jobData, {
-      ...TTS_BATCH_QUEUE_OPTIONS,
-      jobId: `${batchJobId}:retry:${generation}`,
-      delay: TTS_BATCH_RETRY_DELAY_MS,
-    });
+    await this.batchQueue.add(
+      TTS_BATCH_JOB_NAMES.GENERATE_PARAGRAPHS,
+      jobData,
+      {
+        ...TTS_BATCH_QUEUE_OPTIONS,
+        jobId: `${batchJobId}:retry:${generation}`,
+        delay: TTS_BATCH_RETRY_DELAY_MS,
+      },
+    );
 
     const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
     const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;

--- a/src/voice/queue/tts-batch.processor.spec.ts
+++ b/src/voice/queue/tts-batch.processor.spec.ts
@@ -25,6 +25,8 @@ describe('TtsBatchProcessor', () => {
     markParagraphCompleted: jest.Mock;
     markParagraphFailed: jest.Mock;
     updateBatchMeta: jest.Mock;
+    getBatchStatus: jest.Mock;
+    queueRetryBatch: jest.Mock;
   };
   let ttsService: { generateSingleParagraphTTS: jest.Mock };
 
@@ -33,6 +35,9 @@ describe('TtsBatchProcessor', () => {
       markParagraphCompleted: jest.fn().mockResolvedValue(undefined),
       markParagraphFailed: jest.fn().mockResolvedValue(undefined),
       updateBatchMeta: jest.fn().mockResolvedValue(undefined),
+      // Null snapshot → final status falls back to this run's local counts.
+      getBatchStatus: jest.fn().mockResolvedValue(null),
+      queueRetryBatch: jest.fn().mockResolvedValue(undefined),
     };
     ttsService = { generateSingleParagraphTTS: jest.fn() };
 
@@ -64,8 +69,8 @@ describe('TtsBatchProcessor', () => {
     });
 
     it('counts every duplicate index on failure', async () => {
-      // A non-quota (non-402) error is marked failed immediately, without
-      // cascading through the provider fallback chain.
+      // The error rejects on every provider, so the paragraph exhausts the whole
+      // fallback chain and is marked failed on all its duplicate positions.
       ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
 
       const result = await processor.process(

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -1,7 +1,10 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
-import { TTS_BATCH_QUEUE_NAME } from './tts-batch-queue.constants';
+import {
+  MAX_RETRY_GENERATIONS,
+  TTS_BATCH_QUEUE_NAME,
+} from './tts-batch-queue.constants';
 import {
   TtsBatchJobData,
   TtsBatchJobResult,
@@ -13,9 +16,18 @@ import { QuotaExhaustedError } from '../errors/quota-exhausted.error';
 
 const MAX_CONCURRENT_PER_JOB = 5;
 
+/** Transient (non-quota) retries on the SAME provider before cascading */
+const MAX_ATTEMPTS_PER_PROVIDER = 2;
+
+/** Base backoff (ms) between transient retries on the same provider */
+const RETRY_BACKOFF_MS = 300;
+
 type TtsProvider = 'elevenlabs' | 'deepgram' | 'edgetts';
 
-/** Fallback chain when a provider's quota is exhausted */
+/** Provider precedence — used to only advance the shared hint forwards */
+const PROVIDER_ORDER: TtsProvider[] = ['elevenlabs', 'deepgram', 'edgetts'];
+
+/** Fallback chain when a provider fails (quota exhaustion or transient errors) */
 const PROVIDER_FALLBACK: Record<TtsProvider, TtsProvider[]> = {
   elevenlabs: ['deepgram', 'edgetts'],
   deepgram: ['edgetts'],
@@ -58,6 +70,10 @@ export class TtsBatchProcessor extends WorkerHost {
     ];
   }
 
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   async process(job: Job<TtsBatchJobData>): Promise<TtsBatchJobResult> {
     const {
       batchJobId,
@@ -67,54 +83,106 @@ export class TtsBatchProcessor extends WorkerHost {
       isPremium,
       provider,
       paragraphs,
+      totalParagraphs,
+      retryGeneration,
     } = job.data;
 
+    const generation = retryGeneration ?? 0;
+
     this.logger.log(
-      `Processing TTS batch ${batchJobId}: ${paragraphs.length} paragraphs for story ${storyId} with ${provider}`,
+      `Processing TTS batch ${batchJobId} (generation ${generation}): ${paragraphs.length} paragraphs for story ${storyId} with ${provider}`,
     );
 
     let completedCount = 0;
     let failedCount = 0;
-    let currentProvider: TtsProvider = provider;
+    // Paragraphs that exhausted the whole provider chain this run — candidates
+    // for a delayed self-heal round.
+    const failedThisRun: TtsBatchJobData['paragraphs'] = [];
+
+    // Shared hint: once we learn a provider is quota-exhausted, later paragraphs
+    // start straight from the next provider instead of re-hitting the dead one.
+    // It only ever moves forwards through PROVIDER_ORDER.
+    let preferredProvider: TtsProvider = provider;
+
+    const advancePreferred = (exhausted: TtsProvider): void => {
+      const next = PROVIDER_FALLBACK[exhausted]?.[0];
+      if (
+        next &&
+        PROVIDER_ORDER.indexOf(next) > PROVIDER_ORDER.indexOf(preferredProvider)
+      ) {
+        preferredProvider = next;
+      }
+    };
+
+    /**
+     * Generate a single paragraph, walking the provider fallback chain.
+     * - Transient errors: retried up to MAX_ATTEMPTS_PER_PROVIDER on the SAME
+     *   provider (with backoff), then cascade to the next provider.
+     * - Quota errors: no point retrying the same provider — cascade immediately.
+     * Throws the last error only after the whole chain is exhausted.
+     */
+    const generateWithFallback = async (
+      index: number,
+      text: string,
+    ): Promise<{ index: number; audioUrl: string }> => {
+      const chain: TtsProvider[] = [
+        preferredProvider,
+        ...PROVIDER_FALLBACK[preferredProvider],
+      ];
+      let lastError: unknown;
+
+      for (const activeProvider of chain) {
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS_PER_PROVIDER; attempt++) {
+          try {
+            const result = await this.ttsService.generateSingleParagraphTTS(
+              storyId,
+              text,
+              voiceId,
+              userId,
+              { isPremium, providerOverride: activeProvider },
+            );
+            return { index, audioUrl: result.audioUrl };
+          } catch (err) {
+            lastError = err;
+
+            if (this.isQuotaError(err)) {
+              // Quota exhausted — retrying the same provider is pointless.
+              this.logger.warn(
+                `TTS batch ${batchJobId}: ${activeProvider} quota exhausted for paragraph ${index}, cascading to fallback`,
+              );
+              advancePreferred(activeProvider);
+              break; // move to the next provider in the chain
+            }
+
+            const errorMessage =
+              err instanceof Error ? err.message : String(err);
+            if (attempt < MAX_ATTEMPTS_PER_PROVIDER) {
+              this.logger.warn(
+                `TTS batch ${batchJobId}: transient failure on ${activeProvider} for paragraph ${index} (attempt ${attempt}/${MAX_ATTEMPTS_PER_PROVIDER}) — ${errorMessage}; retrying`,
+              );
+              await this.delay(RETRY_BACKOFF_MS * attempt);
+            } else {
+              this.logger.warn(
+                `TTS batch ${batchJobId}: ${activeProvider} exhausted retries for paragraph ${index} — ${errorMessage}; cascading to fallback`,
+              );
+            }
+          }
+        }
+      }
+
+      throw lastError;
+    };
 
     for (let i = 0; i < paragraphs.length; i += MAX_CONCURRENT_PER_JOB) {
       const chunk = paragraphs.slice(i, i + MAX_CONCURRENT_PER_JOB);
 
       const results = await Promise.allSettled(
-        chunk.map(async ({ index, text }) => {
-          const result = await this.ttsService.generateSingleParagraphTTS(
-            storyId,
-            text,
-            voiceId,
-            userId,
-            { isPremium, providerOverride: currentProvider },
-          );
-          return { index, audioUrl: result.audioUrl };
-        }),
+        chunk.map(({ index, text }) => generateWithFallback(index, text)),
       );
-
-      // Detect quota exhaustion — switch provider for remaining chunks
-      const hasQuotaError = results.some(
-        (r) => r.status === 'rejected' && this.isQuotaError(r.reason),
-      );
-
-      if (hasQuotaError) {
-        const fallbacks = PROVIDER_FALLBACK[currentProvider] ?? [];
-        if (fallbacks.length > 0) {
-          this.logger.warn(
-            `TTS batch ${batchJobId}: ${currentProvider} quota exhausted, switching to ${fallbacks[0]} for remaining paragraphs`,
-          );
-          currentProvider = fallbacks[0];
-        }
-      }
-
-      // Collect quota-failed paragraphs for retry through the fallback chain
-      let retryParagraphs: Array<{ index: number; text: string }> = [];
 
       for (let j = 0; j < results.length; j++) {
         const result = results[j];
-        const paragraph = chunk[j];
-        const paragraphIndex = paragraph.index;
+        const paragraphIndex = chunk[j].index;
         const allIndices = this.getDuplicateIndices(paragraphs, paragraphIndex);
 
         if (result.status === 'fulfilled') {
@@ -137,15 +205,14 @@ export class TtsBatchProcessor extends WorkerHost {
             );
             throw redisErr;
           }
-        } else if (hasQuotaError && this.isQuotaError(result.reason)) {
-          retryParagraphs.push({ index: paragraphIndex, text: paragraph.text });
         } else {
+          // Only reached once every provider + retry has been exhausted.
           const errorMessage =
             result.reason instanceof Error
               ? result.reason.message
               : String(result.reason);
           this.logger.warn(
-            `TTS batch ${batchJobId}: TTS generation failed for paragraph ${paragraphIndex} — ${errorMessage}`,
+            `TTS batch ${batchJobId}: paragraph ${paragraphIndex} failed after all providers — ${errorMessage}`,
           );
           try {
             for (const idx of allIndices) {
@@ -162,135 +229,61 @@ export class TtsBatchProcessor extends WorkerHost {
           // mirroring the completed path so the counters stay consistent with
           // the failed set in Redis.
           failedCount += allIndices.length;
-        }
-      }
-
-      // Cascade quota-failed paragraphs through the remaining fallback chain
-      let retryProvider: TtsProvider | undefined = hasQuotaError
-        ? currentProvider
-        : undefined;
-
-      while (retryParagraphs.length > 0 && retryProvider) {
-        this.logger.log(
-          `TTS batch ${batchJobId}: retrying ${retryParagraphs.length} quota-failed paragraphs with ${retryProvider}`,
-        );
-
-        const retryResults = await Promise.allSettled(
-          retryParagraphs.map(async ({ index, text }) => {
-            const result = await this.ttsService.generateSingleParagraphTTS(
-              storyId,
-              text,
-              voiceId,
-              userId,
-              { isPremium, providerOverride: retryProvider! },
-            );
-            return { index, audioUrl: result.audioUrl };
-          }),
-        );
-
-        const nextRetryParagraphs: Array<{ index: number; text: string }> = [];
-
-        for (let r = 0; r < retryResults.length; r++) {
-          const retryResult = retryResults[r];
-          const retryParagraph = retryParagraphs[r];
-          const allRetryIndices = this.getDuplicateIndices(
-            paragraphs,
-            retryParagraph.index,
-          );
-
-          if (retryResult.status === 'fulfilled') {
-            try {
-              for (const idx of allRetryIndices) {
-                await this.queueService.markParagraphCompleted(
-                  batchJobId,
-                  idx,
-                  retryResult.value.audioUrl,
-                );
-              }
-              // Count each duplicate position this retried paragraph filled.
-              completedCount += allRetryIndices.length;
-            } catch (redisErr) {
-              this.logger.error(
-                `TTS batch ${batchJobId}: Redis write failed for retried paragraph ${retryParagraph.index}`,
-                redisErr,
-              );
-              throw redisErr;
-            }
-          } else if (this.isQuotaError(retryResult.reason)) {
-            // Cascade to next provider
-            nextRetryParagraphs.push({
-              index: retryParagraph.index,
-              text: retryParagraph.text,
-            });
-          } else {
-            const retryErrorMsg =
-              retryResult.reason instanceof Error
-                ? retryResult.reason.message
-                : String(retryResult.reason);
-            this.logger.warn(
-              `TTS batch ${batchJobId}: retry with ${retryProvider} failed for paragraph ${retryParagraph.index} — ${retryErrorMsg}`,
-            );
-            try {
-              for (const idx of allRetryIndices) {
-                await this.queueService.markParagraphFailed(batchJobId, idx);
-              }
-            } catch (redisErr) {
-              this.logger.error(
-                `TTS batch ${batchJobId}: Redis write failed for failed retry paragraph ${retryParagraph.index}`,
-                redisErr,
-              );
-              throw redisErr;
-            }
-            // Count each duplicate position this retried paragraph was persisted under.
-            failedCount += allRetryIndices.length;
-          }
-        }
-
-        // Advance to the next provider in the fallback chain
-        retryParagraphs = nextRetryParagraphs;
-        if (retryParagraphs.length > 0) {
-          const nextFallbacks = PROVIDER_FALLBACK[retryProvider] ?? [];
-          if (nextFallbacks.length > 0) {
-            this.logger.warn(
-              `TTS batch ${batchJobId}: ${retryProvider} quota also exhausted, cascading to ${nextFallbacks[0]}`,
-            );
-            retryProvider = nextFallbacks[0];
-            currentProvider = retryProvider;
-          } else {
-            // No more providers — mark remaining as failed
-            this.logger.error(
-              `TTS batch ${batchJobId}: all providers exhausted, marking ${retryParagraphs.length} paragraphs as failed`,
-            );
-            for (const p of retryParagraphs) {
-              const allIndices = this.getDuplicateIndices(paragraphs, p.index);
-              for (const idx of allIndices) {
-                await this.queueService.markParagraphFailed(batchJobId, idx);
-              }
-              // Count each duplicate position marked failed here.
-              failedCount += allIndices.length;
-            }
-            retryParagraphs = [];
-            retryProvider = undefined;
-          }
+          failedThisRun.push(chunk[j]);
         }
       }
     }
 
-    const success = failedCount === 0;
-    const status = success ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
+    // Self-heal: schedule a delayed follow-up for paragraphs that exhausted the
+    // whole provider chain this run, bounded by MAX_RETRY_GENERATIONS so it can
+    // never loop. The retry re-uses this batchJobId, so recovered paragraphs
+    // heal in place for anyone still polling the batch.
+    if (failedThisRun.length > 0 && generation < MAX_RETRY_GENERATIONS) {
+      try {
+        await this.queueService.queueRetryBatch(
+          job.data,
+          failedThisRun,
+          generation + 1,
+        );
+        this.logger.log(
+          `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
+        );
+      } catch (retryErr) {
+        this.logger.error(
+          `TTS batch ${batchJobId}: failed to schedule self-heal retry`,
+          retryErr,
+        );
+      }
+    }
+
+    // Derive the batch status from the AGGREGATE Redis state, not this run's
+    // local counts: a retry run only touches a subset and must never clobber an
+    // already-partially-good batch back to FAILED. A batch with ANY usable
+    // audio is COMPLETED (partial narration is playable per-paragraph); only an
+    // all-failed batch is FAILED. An empty error string clears a stale
+    // partial-failure note once the batch has fully healed.
+    const snapshot = await this.queueService.getBatchStatus(batchJobId);
+    const aggregateCompleted =
+      snapshot?.completedParagraphs.length ?? completedCount;
+    const aggregateFailed = snapshot?.failedParagraphs.length ?? failedCount;
+    const totalQueued = snapshot?.totalQueued ?? totalParagraphs;
+
+    const status =
+      aggregateCompleted > 0 ? TtsBatchStatus.COMPLETED : TtsBatchStatus.FAILED;
 
     await this.queueService.updateBatchMeta(batchJobId, {
       status,
-      ...(failedCount > 0
-        ? { error: `${failedCount}/${paragraphs.length} paragraphs failed` }
-        : {}),
+      error:
+        aggregateFailed > 0
+          ? `${aggregateFailed}/${totalQueued} paragraphs failed`
+          : '',
     });
 
     this.logger.log(
-      `TTS batch ${batchJobId} finished: ${completedCount} completed, ${failedCount} failed`,
+      `TTS batch ${batchJobId} finished (generation ${generation}): ${completedCount} completed / ${failedCount} failed this run; aggregate ${aggregateCompleted} completed / ${aggregateFailed} failed`,
     );
 
-    return { success, completedCount, failedCount };
+    return { success: aggregateFailed === 0, completedCount, failedCount };
   }
 
   @OnWorkerEvent('failed')


### PR DESCRIPTION
Closes the parity gaps found in the 2026-07-22 blue↔green audit — green (`develop-v1.2.0`) fixes the v1.3.0 refactor had dropped. Ported and adapted to blue's refactored structure, one commit per concern.

## Commits
- **infra** (`71e71b5`) — graceful shutdown (`enableShutdownHooks`+`app.close` on signals, green #395), PM2 crash-loop caps (`min_uptime`/`max_restarts`/`restart_delay`, #369) + single-instance fork mode (c40f706), Prisma `connection_limit` URL injection (#361).
- **tts** (`7960425`) — batch COMPLETED on partial success + transient-failure retry self-heal (#394); ElevenLabs quota pre-check now throws `QuotaExhaustedError` so the batch cascade recognizes it (#362).
- **payment** (`0c70c90`) — atomic CAS webhook watermark (`updateMany` guarded on `lastEventAt`, closes TOCTOU + same-ms drop) and token-guarded linked-token migration with `ConflictException` (green 28c2959 + 8504212). Adapted to blue's repository layer (`updateByIdIfToken`/`findById`).
- **story** (`6868853`) — authenticated story-progress completion made monotonic + auto-derive at 100% (green a3bab9e), mirroring blue's already-monotonic guest path. Stops a later partial ping un-completing a story.
- **notifications** (`a68b474`) — **env-scoped FCM broadcast topic** `all_users_<NODE_ENV>` + admin cross-env guard (prod-safety, #423 — stops dev/staging push bleeding to prod devices); batched/staggered broadcast (#420); admin broadcast→in-app inbox + StoryFinished on completion (#402); NewStory fan-out on story-create (#399); SubscriptionAlert on store-side cancel (#397); engagement events (BadgeEarned, PaymentSuccess) via blue's listener architecture (#396).

## Not ported (source events absent on blue — flagged, not invented)
- StreakMilestone (#396): blue emits no streak-advance event.
- PaymentFailed engagement (#396): blue's `PaymentFailed` is an email variant driven by a dormant `PAYMENT_FAILED` event; wiring it would wake unrelated listeners — out of scope.

## Verification
Local: `pnpm build` ✓, `pnpm lint` ✓ (0 errors), tests ✓ — payment **101/101**, story/notification/voice/admin **275/275**, prisma **14/14**. Health indicator + notification reminder-cron + BullMQ untouched. Will deploy prebuilt `dist` to blue (no on-box build) after merge, then re-run the parity audit to confirm gaps closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched notification broadcasts with configurable batch sizes and delivery intervals.
  * Added environment-scoped notification topics and in-app broadcast delivery tracking.
  * Added notifications for new stories, completed stories, earned badges, successful payments, and subscription cancellations.
  * Added bounded text-to-speech retries and automatic self-healing for failed batches.

* **Bug Fixes**
  * Improved progress completion handling and prevented completion status from regressing.
  * Strengthened subscription and webhook processing against stale or conflicting updates.
  * Improved graceful shutdown and protection against rapid application restart loops.

* **Tests**
  * Expanded coverage for notifications, payments, subscriptions, text-to-speech, progress, and database connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->