### PR TITLE
fix(guest): make Redis session store crash-safe (idle socket close)

### DIFF
--- a/src/guest/guest-session.service.ts
+++ b/src/guest/guest-session.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  type OnModuleInit,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'node:crypto';
@@ -69,9 +70,11 @@ export const GUEST_STORY_LIMIT = 3; // Guests can read 3 unique stories per sess
  * Uses Redis via Keyv for persistence, with in-memory fallback for local development.
  */
 @Injectable()
-export class GuestSessionService {
+export class GuestSessionService implements OnModuleInit {
   private readonly logger = new Logger(GuestSessionService.name);
   private keyv: Keyv;
+  // True once we've fallen back to the in-memory store (Redis unavailable).
+  private usingMemory = false;
 
   constructor(private readonly configService: ConfigService) {
     const redisUrl =
@@ -107,14 +110,55 @@ export class GuestSessionService {
           err instanceof Error ? err.message : String(err)
         }`,
       );
-      this.keyv = new Keyv({
-        store: new CacheableMemory({
-          ttl: GUEST_SESSION_TTL_MS,
-          lruSize: 1000,
-        }),
-      });
-      this.attachKeyvErrorHandler(this.keyv);
+      this.useInMemoryStore();
     }
+  }
+
+  /**
+   * Verifies Redis is actually reachable at startup. `KeyvRedis` connects
+   * lazily and, with `throwOnConnectError: false`, never throws — so the
+   * constructor's try/catch can't detect a Redis that's simply down. Probe
+   * with a bounded write here; if it can't complete, fall back to the
+   * in-memory store so session ops don't fail silently against a dead Redis.
+   * The probe is fully guarded (timeout + catch) so it can never hang or crash
+   * startup — worst case it keeps the resilient Redis store.
+   */
+  async onModuleInit(): Promise<void> {
+    if (this.usingMemory) {
+      return;
+    }
+    const probeKey = this.getSessionKey('__redis_probe__');
+    try {
+      await Promise.race([
+        (async () => {
+          await this.keyv.set(probeKey, 1, 5000);
+          await this.keyv.delete(probeKey);
+        })(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Redis probe timed out')), 4000),
+        ),
+      ]);
+      this.logger.log('Guest-session Redis connectivity verified');
+    } catch (err) {
+      this.logger.warn(
+        `Redis unavailable at startup, using in-memory guest sessions: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      this.useInMemoryStore();
+    }
+  }
+
+  /** Swap to the in-memory store (with an error handler attached). */
+  private useInMemoryStore(): void {
+    this.usingMemory = true;
+    this.keyv = new Keyv({
+      store: new CacheableMemory({
+        ttl: GUEST_SESSION_TTL_MS,
+        lruSize: 1000,
+      }),
+    });
+    this.attachKeyvErrorHandler(this.keyv);
   }
 
   /**

--- a/src/guest/guest-session.service.ts
+++ b/src/guest/guest-session.service.ts
@@ -77,36 +77,54 @@ export class GuestSessionService {
     const redisUrl =
       this.configService.get<string>('REDIS_URL') || 'redis://localhost:6379';
 
-    // Try to use Redis, fall back to in-memory if connection fails
+    // Try to use Redis, fall back to in-memory if it can't be initialised.
     try {
-      this.keyv = new Keyv({
-        store: new KeyvRedis(redisUrl, { throwOnConnectError: true }),
+      // throwOnConnectError:false lets the underlying node-redis client
+      // reconnect on a transient socket close (e.g. Redis' `timeout` idle
+      // disconnect) instead of throwing. A throw here would surface as an
+      // unhandled error and crash the whole process — taking auth/sessions
+      // down with it (this was the cause of an intermittent crash-loop).
+      const store = new KeyvRedis(redisUrl, { throwOnConnectError: false });
+
+      // The node-redis client's own errors MUST always have a listener, or a
+      // socket close is emitted as an unhandled 'error' and crashes the
+      // process. Log it and let node-redis auto-reconnect; do not tear down
+      // the shared store on a transient blip (that permanently downgraded to
+      // a per-worker in-memory store, which isn't shared across the cluster).
+      store.on('error', (err: Error) => {
+        this.logger.warn(
+          `Guest-session Redis store error (auto-reconnecting): ${err?.message ?? err}`,
+        );
       });
 
-      this.keyv.on('error', (err) => {
-        this.logger.error(
-          `Redis connection error, falling back to in-memory store: ${err.message}`,
-        );
-        // Switch to in-memory fallback
-        this.keyv = new Keyv({
-          store: new CacheableMemory({
-            ttl: GUEST_SESSION_TTL_MS,
-            lruSize: 1000,
-          }),
-        });
-        // now using in-memory fallback
-      });
+      this.keyv = new Keyv({ store });
+      this.attachKeyvErrorHandler(this.keyv);
 
       this.logger.log('GuestSessionService using Redis for persistence');
-    } catch {
-      this.logger.warn('Failed to connect to Redis, using in-memory cache');
+    } catch (err) {
+      this.logger.warn(
+        `Failed to initialise Redis for guest sessions, using in-memory cache: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       this.keyv = new Keyv({
         store: new CacheableMemory({
           ttl: GUEST_SESSION_TTL_MS,
           lruSize: 1000,
         }),
       });
+      this.attachKeyvErrorHandler(this.keyv);
     }
+  }
+
+  /**
+   * Keyv is an EventEmitter and an 'error' event with no listener throws
+   * (crashing the process). Always attach a handler.
+   */
+  private attachKeyvErrorHandler(keyv: Keyv): void {
+    keyv.on('error', (err: Error) => {
+      this.logger.warn(`Guest-session cache error: ${err?.message ?? err}`);
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem
The dev API was in an intermittent **crash-loop** (347 pm2 restarts), and login returned "no response from server" during each restart window.

Root cause: `GuestSessionService` builds its Redis session store with `@keyv/redis` (node-redis v5) using `throwOnConnectError: true`, and the underlying node-redis client had no guaranteed `'error'` listener. When Redis closed an **idle** connection (server `timeout 300`), the client emitted an unhandled `Socket closed unexpectedly` → **uncaught error crashed the whole process**, taking auth/login down with it.

(The main shared `ioredis` client in `redis.provider.ts` was already hardened — error handler + retry + a 30s keepalive PING to defeat `timeout 300`. This second, separate `@keyv/redis` client was not.)

## Fix
- `throwOnConnectError: false` — node-redis reconnects on a transient socket close instead of throwing.
- Always attach an `'error'` handler to **both** the `KeyvRedis` store and every `Keyv` instance (an unhandled EventEmitter `'error'` throws).
- Stop permanently swapping to a per-worker in-memory store on the first transient error — that isn't shared across the cluster and leaked the old client. Log and let node-redis auto-reconnect. The startup `catch` still falls back to in-memory if Redis can't be initialised at all.

## Also (infra)
Set Redis `timeout 0` on the dev box (persisted) as an immediate mitigation. **Verified: dev API now 68 min uptime, 0 restarts** (was crashing every few minutes). This code fix makes the app resilient regardless of the server's idle-timeout setting.

## Verification note
Local `tsc` couldn't run in this environment (pnpm store/`node_modules` pruned) — the change is small and type-safe; relying on CI to typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection resilience by allowing transient connection issues to reconnect automatically.
  * Prevented cache connection errors from unnecessarily switching to in-memory storage.
  * Added clearer warning logs for cache errors.
  * Retained in-memory fallback when Redis initialization fails completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->