### PR TITLE
fix(errors): stop leaking raw exception names; friendly rate-limit message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import helmet from 'helmet';
 import { SuccessResponseInterceptor } from './shared/interceptors/success-response.interceptor';
 import { HttpExceptionFilter } from './shared/filters/http-exception.filter';
 import { PrismaExceptionFilter } from './shared/filters/prisma-exception.filter';
+import { ThrottlerExceptionFilter } from './shared/filters/throttler-exception.filter';
 import { requestLogger } from './shared/middleware/request-logger.middleware';
 
 async function bootstrap() {
@@ -120,6 +121,10 @@ async function bootstrap() {
 
   // Catch standard NestJS HttpExceptions (handles validation errors, 404s, etc.)
   app.useGlobalFilters(new HttpExceptionFilter());
+  // Registered after HttpExceptionFilter so it takes precedence for
+  // ThrottlerException (429) and returns a clean, premium-aware message
+  // instead of the raw "ThrottlerException: Too Many Requests".
+  app.useGlobalFilters(new ThrottlerExceptionFilter());
 
   // Catch Prisma-specific exceptions and map them to appropriate HTTP responses
   app.useGlobalFilters(new PrismaExceptionFilter(httpAdapter));

--- a/src/shared/filters/http-exception.filter.ts
+++ b/src/shared/filters/http-exception.filter.ts
@@ -45,6 +45,26 @@ export class HttpExceptionFilter implements ExceptionFilter {
       error = HttpStatus[statusCode];
     }
 
+    // Never leak a raw framework exception class name to the client, e.g.
+    // "ThrottlerException: Too Many Requests" — strip the "SomeException:"
+    // prefix so users see a plain message.
+    const stripExceptionPrefix = (m: string): string =>
+      m.replace(/^[A-Z][A-Za-z0-9]*Exception:\s*/, '');
+    if (typeof message === 'string') {
+      message = stripExceptionPrefix(message);
+    } else if (Array.isArray(message)) {
+      message = message.map((m) =>
+        typeof m === 'string' ? stripExceptionPrefix(m) : m,
+      );
+    }
+
+    // Friendly, actionable copy for rate limiting (the dedicated
+    // ThrottlerExceptionFilter provides a premium-aware variant when it wins;
+    // this is the safety net so a 429 is never a raw framework string).
+    if (statusCode === HttpStatus.TOO_MANY_REQUESTS) {
+      message = 'Too many requests. Please wait a moment and try again.';
+    }
+
     // Log the error for debugging purposes (excluding 400s/404s which are expected client errors)
     if (statusCode >= 500) {
       this.logger.error(

--- a/src/shared/filters/throttler-exception.filter.ts
+++ b/src/shared/filters/throttler-exception.filter.ts
@@ -10,11 +10,16 @@ export class ThrottlerExceptionFilter implements ExceptionFilter {
 
     const isPremium = request.authUserData?.isPremium;
 
+    // Keep the shape consistent with the standard error envelope
+    // (statusCode/success/error/message/path/timestamp) so clients get a
+    // uniform, human-readable error instead of a raw framework string.
     response.status(429).json({
       statusCode: 429,
+      success: false,
+      error: 'Too Many Requests',
       message: isPremium
-        ? 'Rate limit exceeded. Please try again in a few moments.'
-        : 'Rate limit exceeded. Upgrade to premium for higher limits.',
+        ? 'You’ve made too many requests. Please wait a moment and try again.'
+        : 'You’ve made too many requests. Please wait a moment and try again, or upgrade to premium for higher limits.',
       upgradeUrl: '/subscription/plans',
       timestamp: new Date().toISOString(),
       path: request.url,


### PR DESCRIPTION
## Problem
Users saw the raw framework string **`ThrottlerException: Too Many Requests`**. The dedicated `ThrottlerExceptionFilter` (which returns a clean, premium-aware message) **was never registered** in `main.ts` — only `HttpExceptionFilter` and `PrismaExceptionFilter` are. So a `ThrottlerException` (a subclass of `HttpException`) fell through to the generic filter, which passed the exception's message through verbatim.

## Fix
- **Register `ThrottlerExceptionFilter`** globally (after `HttpExceptionFilter`, so it takes precedence for 429s) and align its JSON with the standard error envelope (`statusCode`/`success`/`error`/`message`/`path`/`timestamp`) plus friendlier copy.
- **Harden `HttpExceptionFilter`** as a safety net so a raw class name can never leak regardless of filter ordering:
  - strip any `SomeException:` prefix from string messages,
  - return a plain, actionable message for `429` ("Too many requests. Please wait a moment and try again.").

## Result
`429` now returns e.g. *"You've made too many requests. Please wait a moment and try again…"* instead of `ThrottlerException: Too Many Requests`.

## Note
Local `node_modules` in this environment is incomplete (no TS toolchain), so I couldn't run `tsc`/lint locally — changes are small and type-safe; relying on CI.