### PR TITLE
ci(blue): run deploy job in development environment (fix empty EC2 secrets)

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -30,6 +30,12 @@ jobs:
     name: Deploy Blue
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # The EC2_HOST/EC2_USERNAME/EC2_SSH_KEY (and green's ENV_FILE) secrets live
+    # at the `development` environment level, not the repo level — same as green's
+    # deploy job. Without this, those secrets resolve empty and the SSH steps fail.
+    environment:
+      name: development
+      url: https://blue.dev.api.storytimeapp.me
     permissions:
       contents: read
 


### PR DESCRIPTION
The first live blue-deploy run (#454 merge) failed at 'Add server host key' — `EC2_HOST` resolved empty because the `EC2_HOST`/`EC2_USERNAME`/`EC2_SSH_KEY` secrets are scoped to the `development` GitHub environment (where green's deploy job reads them), not repo-level. Adds `environment: development` to the `deploy-blue` job so it inherits those secrets and green's environment-scoped `ENV_FILE`. Merging re-triggers the blue deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment details to the blue deployment workflow.
  * Deployment status now includes a direct link to the development API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->