### PR TITLE
fix(config,ci): require Google client IDs + seed blue catalog on deploy

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -153,7 +153,16 @@ jobs:
             psql "$ADMIN_URL" -tAc "SELECT 1 FROM pg_database WHERE datname='storytime_db_blue'" | grep -q 1 \
               || psql "$ADMIN_URL" -c 'CREATE DATABASE storytime_db_blue'
 
-            # migrate BLUE db (from this dir's .env) + build + (re)start blue PM2 app on :3601
+            # Migrate the schema first, then seed the blue catalog (parity with
+            # green's deploy, which seeds every run). Seeding is idempotent —
+            # stories skip existing titles, categories/themes use skipDuplicates,
+            # the rest upsert — so re-running never duplicates. Seed BEFORE the
+            # app (re)starts so a fresh blue DB serves data from first boot.
+            pnpm db:migrate:deploy
+            pnpm db:seed
+
+            # generate client + (re)start blue PM2 app on :3601. deploy:blue also
+            # runs db:migrate:deploy again — a harmless no-op the second time.
             pnpm deploy:blue
 
       - name: Verify blue deployment

--- a/src/shared/config/env.validation.ts
+++ b/src/shared/config/env.validation.ts
@@ -37,11 +37,14 @@ export const envSchema = z
     WEB_APP_BASE_URL: z.string().url('WEB_APP_BASE_URL must be a valid URL'),
     GOOGLE_CLIENT_ID: z.string().min(1, 'GOOGLE_CLIENT_ID is required'),
     GOOGLE_CLIENT_SECRET: z.string().min(1, 'GOOGLE_CLIENT_SECRET is required'),
-    // Optional per design: extra OAuth audiences for web/android/ios clients.
-    // Undefined entries are filtered out where the audience list is built.
-    GOOGLE_WEB_CLIENT_ID: z.string().optional(),
-    GOOGLE_ANDROID_CLIENT_ID: z.string().optional(),
-    GOOGLE_IOS_CLIENT_ID: z.string().optional(),
+    // OAuth audiences for the web/android/ios clients. Required — these must be
+    // configured on the server (parity with green); the audience list is built
+    // from them for Google token verification.
+    GOOGLE_WEB_CLIENT_ID: z.string().min(1, 'GOOGLE_WEB_CLIENT_ID is required'),
+    GOOGLE_ANDROID_CLIENT_ID: z
+      .string()
+      .min(1, 'GOOGLE_ANDROID_CLIENT_ID is required'),
+    GOOGLE_IOS_CLIENT_ID: z.string().min(1, 'GOOGLE_IOS_CLIENT_ID is required'),
     BACKEND_BASE_URL: z.string().url('BACKEND_BASE_URL must be a valid URL'),
     // Deepgram API key (used for STT and TTS)
     DEEPGRAM_API_KEY: z.string().min(1, 'DEEPGRAM_API_KEY is required'),


### PR DESCRIPTION
Two follow-ups from the post-deploy review:

**1. Require the Google client IDs (parity with green).** `GOOGLE_WEB/ANDROID/IOS_CLIENT_ID` were `.optional()` on blue; green requires them. Made them `.min(1)` required. Verified all three are set on the server (blue `.env`, 72 chars each), so this can't break boot.

**2. Seed the blue catalog on deploy.** Green's deploy seeds every run; blue's never did, so its catalog had to be seeded by hand. Added `db:migrate:deploy && db:seed` before `deploy:blue`, seeding before the app (re)starts so a fresh blue DB serves data from first boot. Idempotent — stories skip existing titles, categories/themes use `skipDuplicates`, others upsert — so re-running never duplicates.

Merging re-deploys blue and exercises the new seed step.