### PR TITLE
ci(blue): retry deploy health-verify (~60s) to stop false failures on slow boot

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -172,6 +172,16 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            sleep 10
-            curl -sf http://localhost:3601/api/v1/health || exit 1
-            echo "Blue deployment verified on :3601"
+            # Poll health for up to ~60s. A single check after a fixed sleep
+            # false-fails when the app boots slowly (seeding + fresh start can
+            # push first-response past 10s), even though blue comes up fine.
+            for i in $(seq 1 20); do
+              if curl -sf http://localhost:3601/api/v1/health >/dev/null 2>&1; then
+                echo "Blue deployment verified on :3601 (attempt $i)"
+                exit 0
+              fi
+              echo "health not ready yet (attempt $i/20), retrying in 3s..."
+              sleep 3
+            done
+            echo "Blue health check failed after ~60s"
+            exit 1


### PR DESCRIPTION
The last deploy (#456) reported failure at 'Verify blue deployment' even though blue came up healthy — the step did a single `curl` after `sleep 10`, but boot now takes longer (seed step + fresh start). Replaced with a ~60s poll (20×3s) that succeeds on the first 200. No app change.