### PR TITLE
ci(blue): skip deploy for docs/monitoring-only pushes

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -17,6 +17,15 @@ on:
   workflow_dispatch:
   push:
     branches: ['develop-v1.3.0']
+    # Skip a blue redeploy when a push touches ONLY non-runtime files (docs,
+    # Grafana dashboard JSON, prometheus config). If a push also changes any
+    # other file, the deploy still runs. Use workflow_dispatch to force a deploy
+    # for a docs-only change if ever needed.
+    paths-ignore:
+      - '**/*.md'
+      - 'monitoring/**'
+      - 'docs/**'
+      - 'LICENSE'
 
 concurrency:
   group: blue-deploy


### PR DESCRIPTION
Adds paths-ignore (**/*.md, monitoring/**, docs/**, LICENSE) to the blue push trigger so doc/dashboard-only commits don't trigger a full blue redeploy. Any push that also changes runtime files still deploys; workflow_dispatch still forces a manual deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment behavior so non-runtime changes—such as documentation, monitoring configuration, Markdown files, and licensing content—no longer trigger an unnecessary blue deployment.
  * Manual deployment triggering remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->