### PR TITLE
feat(observability): business + TTS-provider metrics to OTLP/Grafana

### DIFF
--- a/src/shared/events/events.module.ts
+++ b/src/shared/events/events.module.ts
@@ -3,6 +3,7 @@ import { EventListenersService } from './event-listeners.service';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { SubscriptionModule } from '@/subscription/subscription.module';
 import { AnalyticsEventListener } from '../listeners/analytics-event.listener';
+import { BusinessMetricsListener } from '../listeners/business-metrics.listener';
 import { ActivityLogEventListener } from '../listeners/activity-log-event.listener';
 import { SubscriptionCacheListener } from '../listeners/subscription-cache.listener';
 import { KidCacheListener } from '../listeners/kid-cache.listener';
@@ -32,6 +33,7 @@ import { PrismaUserCleanupRepository } from '../repositories/prisma-user-cleanup
   providers: [
     EventListenersService,
     AnalyticsEventListener,
+    BusinessMetricsListener,
     ActivityLogEventListener,
     SubscriptionCacheListener,
     KidCacheListener,
@@ -48,6 +50,7 @@ import { PrismaUserCleanupRepository } from '../repositories/prisma-user-cleanup
   exports: [
     EventListenersService,
     AnalyticsEventListener,
+    BusinessMetricsListener,
     ActivityLogEventListener,
     SubscriptionCacheListener,
     KidCacheListener,

--- a/src/shared/listeners/business-metrics.listener.ts
+++ b/src/shared/listeners/business-metrics.listener.ts
@@ -1,0 +1,222 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { metrics, Counter } from '@opentelemetry/api';
+import {
+  AppEvents,
+  UserRegisteredEvent,
+  UserDeletedEvent,
+  UserEmailVerifiedEvent,
+  KidCreatedEvent,
+  KidDeletedEvent,
+  StoryCreatedEvent,
+  StoryCompletedEvent,
+  PaymentCompletedEvent,
+  PaymentFailedEvent,
+  SubscriptionCreatedEvent,
+  SubscriptionChangedEvent,
+  SubscriptionCancelledEvent,
+  BadgeEarnedEvent,
+  StreakUpdatedEvent,
+} from '@/shared/events';
+
+/**
+ * BusinessMetricsListener
+ *
+ * Bridges domain lifecycle events (users, kids, stories, payments,
+ * subscriptions, achievements) into the OTLP pipeline as counters so business
+ * KPIs — signups, activations, revenue, churn, engagement — show up in Grafana
+ * alongside the infra/runtime metrics.
+ *
+ * Counters are created lazily in the constructor (which Nest runs during DI,
+ * after otel-setup has registered the global MeterProvider at the top of
+ * main.ts). Every handler is best-effort: an OTel add() must never break the
+ * business flow that emitted the event, so all work is wrapped in try/catch.
+ *
+ * Labels are deliberately LOW cardinality (provider, currency, result, plan
+ * change type, ai_generated) — never userId/email/storyId — so the metric
+ * series stay bounded.
+ */
+@Injectable()
+export class BusinessMetricsListener {
+  private readonly logger = new Logger(BusinessMetricsListener.name);
+
+  private readonly usersRegistered: Counter;
+  private readonly usersDeleted: Counter;
+  private readonly emailVerified: Counter;
+  private readonly kidsCreated: Counter;
+  private readonly kidsDeleted: Counter;
+  private readonly storiesCreated: Counter;
+  private readonly storiesCompleted: Counter;
+  private readonly payments: Counter;
+  private readonly paymentRevenue: Counter;
+  private readonly subscriptionsCreated: Counter;
+  private readonly subscriptionsChanged: Counter;
+  private readonly subscriptionsCancelled: Counter;
+  private readonly badgesEarned: Counter;
+  private readonly streakUpdates: Counter;
+
+  constructor() {
+    const meter = metrics.getMeter('storytime-api');
+
+    this.usersRegistered = meter.createCounter('business_users_registered_total', {
+      description: 'New user registrations',
+    });
+    this.usersDeleted = meter.createCounter('business_users_deleted_total', {
+      description: 'User account deletions',
+    });
+    this.emailVerified = meter.createCounter('business_email_verified_total', {
+      description: 'Email verifications completed',
+    });
+    this.kidsCreated = meter.createCounter('business_kids_created_total', {
+      description: 'Kid profiles created',
+    });
+    this.kidsDeleted = meter.createCounter('business_kids_deleted_total', {
+      description: 'Kid profiles deleted',
+    });
+    this.storiesCreated = meter.createCounter('business_stories_created_total', {
+      description: 'Stories created (labelled by ai_generated)',
+    });
+    this.storiesCompleted = meter.createCounter(
+      'business_stories_completed_total',
+      { description: 'Stories completed (engagement)' },
+    );
+    this.payments = meter.createCounter('business_payments_total', {
+      description: 'Payment attempts (labelled by result + provider)',
+    });
+    this.paymentRevenue = meter.createCounter('business_payment_revenue_total', {
+      description:
+        'Sum of successful payment amounts (labelled by currency + provider)',
+    });
+    this.subscriptionsCreated = meter.createCounter(
+      'business_subscriptions_created_total',
+      { description: 'New subscriptions (labelled by provider)' },
+    );
+    this.subscriptionsChanged = meter.createCounter(
+      'business_subscriptions_changed_total',
+      { description: 'Subscription plan changes (labelled by change_type)' },
+    );
+    this.subscriptionsCancelled = meter.createCounter(
+      'business_subscriptions_cancelled_total',
+      { description: 'Subscription cancellations (churn)' },
+    );
+    this.badgesEarned = meter.createCounter('business_badges_earned_total', {
+      description: 'Achievement badges earned',
+    });
+    this.streakUpdates = meter.createCounter('business_streak_updates_total', {
+      description: 'Reading-streak updates',
+    });
+  }
+
+  /** Wrap every add() so a metrics failure never disrupts the emitting flow. */
+  private safe(fn: () => void): void {
+    try {
+      fn();
+    } catch (error) {
+      this.logger.warn(
+        `Business metric emit failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  @OnEvent(AppEvents.USER_REGISTERED)
+  onUserRegistered(payload: UserRegisteredEvent): void {
+    this.safe(() =>
+      this.usersRegistered.add(1, { role: payload.role ?? 'unknown' }),
+    );
+  }
+
+  @OnEvent(AppEvents.USER_DELETED)
+  onUserDeleted(_payload: UserDeletedEvent): void {
+    this.safe(() => this.usersDeleted.add(1));
+  }
+
+  @OnEvent(AppEvents.USER_EMAIL_VERIFIED)
+  onEmailVerified(_payload: UserEmailVerifiedEvent): void {
+    this.safe(() => this.emailVerified.add(1));
+  }
+
+  @OnEvent(AppEvents.KID_CREATED)
+  onKidCreated(_payload: KidCreatedEvent): void {
+    this.safe(() => this.kidsCreated.add(1));
+  }
+
+  @OnEvent(AppEvents.KID_DELETED)
+  onKidDeleted(_payload: KidDeletedEvent): void {
+    this.safe(() => this.kidsDeleted.add(1));
+  }
+
+  @OnEvent(AppEvents.STORY_CREATED)
+  onStoryCreated(payload: StoryCreatedEvent): void {
+    this.safe(() =>
+      this.storiesCreated.add(1, {
+        ai_generated: String(payload.aiGenerated),
+      }),
+    );
+  }
+
+  @OnEvent(AppEvents.STORY_COMPLETED)
+  onStoryCompleted(_payload: StoryCompletedEvent): void {
+    this.safe(() => this.storiesCompleted.add(1));
+  }
+
+  @OnEvent(AppEvents.PAYMENT_COMPLETED)
+  onPaymentCompleted(payload: PaymentCompletedEvent): void {
+    this.safe(() => {
+      this.payments.add(1, {
+        result: 'completed',
+        provider: payload.provider ?? 'unknown',
+      });
+      if (typeof payload.amount === 'number' && Number.isFinite(payload.amount)) {
+        this.paymentRevenue.add(payload.amount, {
+          currency: payload.currency ?? 'unknown',
+          provider: payload.provider ?? 'unknown',
+        });
+      }
+    });
+  }
+
+  @OnEvent(AppEvents.PAYMENT_FAILED)
+  onPaymentFailed(payload: PaymentFailedEvent): void {
+    this.safe(() =>
+      this.payments.add(1, {
+        result: 'failed',
+        provider: payload.provider ?? 'unknown',
+      }),
+    );
+  }
+
+  @OnEvent(AppEvents.SUBSCRIPTION_CREATED)
+  onSubscriptionCreated(payload: SubscriptionCreatedEvent): void {
+    this.safe(() =>
+      this.subscriptionsCreated.add(1, {
+        provider: payload.provider ?? 'unknown',
+      }),
+    );
+  }
+
+  @OnEvent(AppEvents.SUBSCRIPTION_CHANGED)
+  onSubscriptionChanged(payload: SubscriptionChangedEvent): void {
+    this.safe(() =>
+      this.subscriptionsChanged.add(1, {
+        change_type: payload.changeType ?? 'unknown',
+      }),
+    );
+  }
+
+  @OnEvent(AppEvents.SUBSCRIPTION_CANCELLED)
+  onSubscriptionCancelled(_payload: SubscriptionCancelledEvent): void {
+    this.safe(() => this.subscriptionsCancelled.add(1));
+  }
+
+  @OnEvent(AppEvents.BADGE_EARNED)
+  onBadgeEarned(_payload: BadgeEarnedEvent): void {
+    this.safe(() => this.badgesEarned.add(1));
+  }
+
+  @OnEvent(AppEvents.STREAK_UPDATED)
+  onStreakUpdated(_payload: StreakUpdatedEvent): void {
+    this.safe(() => this.streakUpdates.add(1));
+  }
+}

--- a/src/voice/queue/tts-batch.processor.spec.ts
+++ b/src/voice/queue/tts-batch.processor.spec.ts
@@ -44,6 +44,7 @@ describe('TtsBatchProcessor', () => {
     processor = new TtsBatchProcessor(
       queueService as never,
       ttsService as never,
+      { recordAttempt: jest.fn(), recordParagraph: jest.fn() } as never,
     );
   });
 

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -11,6 +11,7 @@ import {
   TtsBatchStatus,
 } from './tts-batch-job.interface';
 import { TtsBatchQueueService } from './tts-batch-queue.service';
+import { TtsMetricsService } from './tts-metrics.service';
 import { TextToSpeechService } from '../../story/text-to-speech.service';
 import { QuotaExhaustedError } from '../errors/quota-exhausted.error';
 
@@ -41,6 +42,7 @@ export class TtsBatchProcessor extends WorkerHost {
   constructor(
     private readonly queueService: TtsBatchQueueService,
     private readonly ttsService: TextToSpeechService,
+    private readonly metrics: TtsMetricsService,
   ) {
     super();
   }
@@ -141,11 +143,13 @@ export class TtsBatchProcessor extends WorkerHost {
               userId,
               { isPremium, providerOverride: activeProvider },
             );
+            this.metrics.recordAttempt(activeProvider, 'success');
             return { index, audioUrl: result.audioUrl };
           } catch (err) {
             lastError = err;
 
             if (this.isQuotaError(err)) {
+              this.metrics.recordAttempt(activeProvider, 'quota_error');
               // Quota exhausted — retrying the same provider is pointless.
               this.logger.warn(
                 `TTS batch ${batchJobId}: ${activeProvider} quota exhausted for paragraph ${index}, cascading to fallback`,
@@ -154,6 +158,7 @@ export class TtsBatchProcessor extends WorkerHost {
               break; // move to the next provider in the chain
             }
 
+            this.metrics.recordAttempt(activeProvider, 'transient_error');
             const errorMessage =
               err instanceof Error ? err.message : String(err);
             if (attempt < MAX_ATTEMPTS_PER_PROVIDER) {
@@ -198,6 +203,7 @@ export class TtsBatchProcessor extends WorkerHost {
             // count each persisted index — otherwise the counters disagree with
             // the completed/failed sets in Redis whenever duplicates exist.
             completedCount += allIndices.length;
+            this.metrics.recordParagraph('completed');
           } catch (redisErr) {
             this.logger.error(
               `TTS batch ${batchJobId}: Redis write failed for completed paragraph ${paragraphIndex}`,
@@ -229,6 +235,7 @@ export class TtsBatchProcessor extends WorkerHost {
           // mirroring the completed path so the counters stay consistent with
           // the failed set in Redis.
           failedCount += allIndices.length;
+          this.metrics.recordParagraph('failed');
           failedThisRun.push(chunk[j]);
         }
       }

--- a/src/voice/queue/tts-metrics.service.ts
+++ b/src/voice/queue/tts-metrics.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { metrics, Counter } from '@opentelemetry/api';
+
+export type TtsProviderName = 'elevenlabs' | 'deepgram' | 'edgetts';
+export type TtsAttemptResult = 'success' | 'quota_error' | 'transient_error';
+export type TtsParagraphResult = 'completed' | 'failed';
+
+/**
+ * TtsMetricsService
+ *
+ * Emits OTLP counters for the TTS batch pipeline so provider health and
+ * fallback behaviour are visible in Grafana:
+ *
+ * - tts_provider_attempts_total{provider,result} — every synthesis attempt,
+ *   including the ones that fail over to the next provider. Lets us see
+ *   per-provider success rate, quota exhaustion, and how often the fallback
+ *   chain is exercised.
+ * - tts_paragraphs_total{result} — final per-paragraph outcome after the whole
+ *   provider chain + retries (completed vs failed), for batch success rate.
+ *
+ * Counters are created in the constructor, which Nest runs during DI (after
+ * otel-setup registered the global MeterProvider at the top of main.ts).
+ * Recording is best-effort — a metrics failure must never affect synthesis.
+ */
+@Injectable()
+export class TtsMetricsService {
+  private readonly attempts: Counter;
+  private readonly paragraphs: Counter;
+
+  constructor() {
+    const meter = metrics.getMeter('storytime-api');
+    this.attempts = meter.createCounter('tts_provider_attempts_total', {
+      description:
+        'TTS synthesis attempts per provider (labelled by provider + result)',
+    });
+    this.paragraphs = meter.createCounter('tts_paragraphs_total', {
+      description:
+        'Final per-paragraph TTS outcome after the full provider chain',
+    });
+  }
+
+  recordAttempt(provider: TtsProviderName, result: TtsAttemptResult): void {
+    try {
+      this.attempts.add(1, { provider, result });
+    } catch {
+      // best-effort: never let metrics break synthesis
+    }
+  }
+
+  recordParagraph(result: TtsParagraphResult): void {
+    try {
+      this.paragraphs.add(1, { result });
+    } catch {
+      // best-effort
+    }
+  }
+}

--- a/src/voice/voice.module.ts
+++ b/src/voice/voice.module.ts
@@ -27,6 +27,7 @@ import { VoiceIdResolverService } from './services/voice-id-resolver.service';
 import { TTS_BATCH_QUEUE_NAME } from './queue/tts-batch-queue.constants';
 import { TtsBatchQueueService } from './queue/tts-batch-queue.service';
 import { TtsBatchProcessor } from './queue/tts-batch.processor';
+import { TtsMetricsService } from './queue/tts-metrics.service';
 import { TtsBatchRedisProvider } from './queue/tts-batch-redis.provider';
 import {
   VOICE_REPOSITORY,
@@ -73,6 +74,7 @@ import {
     TtsBatchRedisProvider,
     TtsBatchQueueService,
     TtsBatchProcessor,
+    TtsMetricsService,
     // Repository Pattern (testability, decoupling)
     {
       provide: VOICE_REPOSITORY,


### PR DESCRIPTION
Adds two OTel instrumentation points so business KPIs and TTS provider health show up in Grafana Cloud alongside the existing infra/runtime/HTTP metrics.

## Business metrics — `BusinessMetricsListener`
Hooks the domain `AppEvents` into low-cardinality counters:
- `business_users_registered_total{role}`, `business_users_deleted_total`, `business_email_verified_total`
- `business_kids_created_total`, `business_kids_deleted_total`
- `business_stories_created_total{ai_generated}`, `business_stories_completed_total`
- `business_payments_total{result,provider}`, `business_payment_revenue_total{currency,provider}`
- `business_subscriptions_created_total{provider}`, `business_subscriptions_changed_total{change_type}`, `business_subscriptions_cancelled_total`
- `business_badges_earned_total`, `business_streak_updates_total`

Best-effort: a metric emit never disrupts the flow that emitted the event. Labels are bounded (provider/currency/result/change_type/role/ai_generated) — never userId/email/storyId.

## TTS provider metrics — `TtsMetricsService`
Emitted from the TTS batch processor's fallback loop:
- `tts_provider_attempts_total{provider,result}` — every synthesis attempt incl. failovers (`success`/`quota_error`/`transient_error`)
- `tts_paragraphs_total{result}` — final per-paragraph outcome (`completed`/`failed`)

Makes per-provider success rate, quota exhaustion, and how often the elevenlabs→deepgram→edgetts chain is exercised visible.

Counters are created during DI (after otel-setup registers the global MeterProvider). Build clean, processor spec updated + passing.