### PR TITLE
feat(observability): emit deployment.environment resource attribute

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -84,7 +84,7 @@ jobs:
           # Grafana Cloud OTLP push (BLUE ONLY — green/dev intentionally omits it).
           # Strip any inherited OTEL/Grafana lines, then append blue's config so a
           # redeploy re-establishes the push instead of silently dropping telemetry.
-          sed -i -E '/^(OTEL_EXPORTER_OTLP_ENDPOINT|OTEL_EXPORTER_LOGS_ENDPOINT|OTEL_EXPORTER_METRICS_ENDPOINT|OTEL_METRICS_EXPORTER|OTEL_SERVICE_NAME|GRAFANA_CLOUD_INSTANCE_ID|GRAFANA_CLOUD_API_TOKEN)=/d' .env
+          sed -i -E '/^(OTEL_EXPORTER_OTLP_ENDPOINT|OTEL_EXPORTER_LOGS_ENDPOINT|OTEL_EXPORTER_METRICS_ENDPOINT|OTEL_METRICS_EXPORTER|OTEL_SERVICE_NAME|GRAFANA_CLOUD_INSTANCE_ID|GRAFANA_CLOUD_API_TOKEN|DEPLOYMENT_ENV)=/d' .env
           cat >> .env << 'EOF'
           OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-gb-south-1.grafana.net/otlp/v1/traces
           OTEL_EXPORTER_LOGS_ENDPOINT=https://otlp-gateway-prod-gb-south-1.grafana.net/otlp/v1/logs
@@ -92,6 +92,13 @@ jobs:
           OTEL_METRICS_EXPORTER=otlp
           OTEL_SERVICE_NAME=storytime-api-blue
           GRAFANA_CLOUD_INSTANCE_ID=1730856
+          # Telemetry deployment environment (drives the `deployment.environment`
+          # OTel resource attr → Grafana `deployment_environment` label). Blue runs
+          # on DEV infra today, so it declares `development` and alerting stays
+          # dormant. AT PROMOTION (blue becomes the stable/prod deployment): change
+          # this single line to `DEPLOYMENT_ENV=production` and un-pause the alert
+          # rules — no NODE_ENV change needed.
+          DEPLOYMENT_ENV=development
           EOF
           # token comes from the step env (never a workflow literal)
           printf 'GRAFANA_CLOUD_API_TOKEN=%s\n' "$GRAFANA_CLOUD_API_TOKEN" >> .env

--- a/src/otel-setup.ts
+++ b/src/otel-setup.ts
@@ -34,6 +34,17 @@ const serviceName = process.env.OTEL_SERVICE_NAME || 'storytime-api';
 const serviceVersion = process.env.npm_package_version || '1.0.0';
 const environment = process.env.NODE_ENV || 'development';
 
+// Deployment environment (development | staging | production) for telemetry.
+// Deliberately DECOUPLED from NODE_ENV via a dedicated var: the blue candidate
+// runs NODE_ENV=development on dev infra but should be able to declare itself
+// `production` at promotion without flipping NODE_ENV (which changes unrelated
+// app behavior). Falls back to NODE_ENV when unset, so nothing changes until a
+// deploy explicitly sets DEPLOYMENT_ENV.
+const deploymentEnvironment =
+  process.env.DEPLOYMENT_ENV ||
+  process.env.DEPLOYMENT_ENVIRONMENT ||
+  environment;
+
 // Grafana Cloud / Tempo endpoint (OTLP)
 const tempoEndpoint =
   process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318/v1/traces';
@@ -162,7 +173,15 @@ const sdkConfig: Partial<NodeSDKConfiguration> = {
   resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_VERSION]: serviceVersion,
-    environment,
+    // Semantic-convention deployment environment. Surfaces in Grafana Cloud as
+    // the `deployment_environment` label on `target_info` (and on every metric
+    // if OTLP resource-attribute promotion is enabled for the stack), so alerts
+    // can scope to `production` and stay dormant on dev. Using the string key
+    // avoids importing the incubating semconv entrypoint; the value of
+    // ATTR_DEPLOYMENT_ENVIRONMENT is exactly this string.
+    'deployment.environment': deploymentEnvironment,
+    // Legacy custom attribute kept for back-compat; aligned to the same value.
+    environment: deploymentEnvironment,
   }),
   metricReader: createMetricReader(),
   logRecordProcessor: new BatchLogRecordProcessor(


### PR DESCRIPTION
Wires up a semantic-convention `deployment.environment` OTel resource attribute so Grafana telemetry can be scoped by environment — the groundwork for **prod-only alerting**.

## Why
Grafana Cloud currently only has one live service (`storytime-api-blue`) with no way to distinguish dev from prod — its only environment signal is `environment=development` (from NODE_ENV). Alert rules can't target prod because there's no prod marker. This adds one.

## What
- `src/otel-setup.ts`: adds `deployment.environment` to the OTel resource, driven by a **dedicated `DEPLOYMENT_ENV`** var (→ `DEPLOYMENT_ENVIRONMENT` → `NODE_ENV` fallback). Decoupled from NODE_ENV on purpose: blue runs `NODE_ENV=development` on dev infra but can be declared `production` at promotion without changing NODE_ENV. Legacy `environment` attr kept + aligned. No behaviour change until a deploy sets the var.
- `.github/workflows/blue-deploy.yml`: writes `DEPLOYMENT_ENV=development` into blue's .env (strips any inherited value). Blue declares `development` today → alerting stays dormant.

## Promotion path (one-liner + un-pause)
At blue→prod promotion: change `DEPLOYMENT_ENV=development` → `production` in the workflow and un-pause the 6 (currently paused) alert rules. In Grafana the metrics then carry `deployment_environment=production` (on `target_info`; promote-to-metric-label if the stack has OTLP attribute promotion on).

Build clean.