### PR TITLE
fix(reports): user-scoped quiz answers (unblock mobile + fix 400)

### DIFF
--- a/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
+++ b/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "question_answers" ADD COLUMN     "userId" TEXT,
+ALTER COLUMN "kidId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "question_answers_userId_idx" ON "question_answers"("userId");
+
+-- AddForeignKey
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model User {
   kids                    Kid[]
   parentFavorites         ParentFavorite[]
   userStoryProgress       UserStoryProgress[]
+  questionAnswers         QuestionAnswer[]
   voices                  Voice[]
   preferredVoiceId        String?
   preferredVoice          Voice?                   @relation("PreferredVoice", fields: [preferredVoiceId], references: [id])
@@ -907,8 +908,13 @@ model ScreenTimeSession {
 
 model QuestionAnswer {
   id             String        @id @default(uuid())
-  kidId          String
-  kid            Kid           @relation(fields: [kidId], references: [id], onDelete: Cascade)
+  // Attribution is EITHER kid-scoped (kidId) OR user-scoped (userId). Kid-scoped
+  // answers drive per-kid badge progress; user-scoped answers come from clients
+  // that read as the logged-in user without a kid context (e.g. mobile).
+  kidId          String?
+  kid            Kid?          @relation(fields: [kidId], references: [id], onDelete: Cascade)
+  userId         String?
+  user           User?         @relation(fields: [userId], references: [id], onDelete: Cascade)
   questionId     String
   question       StoryQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
   storyId        String
@@ -920,6 +926,7 @@ model QuestionAnswer {
   deletedAt      DateTime?
 
   @@index([kidId])
+  @@index([userId])
   @@index([questionId])
   @@index([storyId])
   @@index([kidId, answeredAt])

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Req, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiParam,
   ApiBody,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { ReportsService } from './reports.service';
 import { ScreenTimeService } from './services/screen-time.service';
@@ -15,7 +16,12 @@ import {
   EndScreenTimeSessionDto,
   DailyLimitDto,
 } from './dto/reports.dto';
-import { QuestionAnswerDto } from '../story/dto/story.dto';
+import { SubmitQuestionAnswerDto } from '../story/dto/story.dto';
+import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
+import {
+  AuthSessionGuard,
+  OptionalAuthRequest,
+} from '@/shared/guards/auth.guard';
 
 @ApiTags('reports')
 @Controller('reports')
@@ -70,10 +76,23 @@ export class ReportsController {
 
   // ============== QUIZ TRACKING ==============
   @Post('answer')
-  @ApiOperation({ summary: 'Record a question answer' })
-  @ApiBody({ type: QuestionAnswerDto })
+  @OptionalAuth()
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Record a question answer',
+    description:
+      'Attribution: pass kidId for kid-scoped answers (drives that kid’s ' +
+      'badge progress), or omit it and authenticate to record a user-scoped ' +
+      'answer. Guests (no auth, no kidId) get the correctness result back but ' +
+      'nothing is persisted.',
+  })
+  @ApiBody({ type: SubmitQuestionAnswerDto })
   @ApiResponse({ status: 201, description: 'Returns if answer is correct' })
-  async recordAnswer(@Body() dto: QuestionAnswerDto) {
-    return this.reportsService.recordAnswer(dto);
+  async recordAnswer(
+    @Req() req: OptionalAuthRequest,
+    @Body() dto: SubmitQuestionAnswerDto,
+  ) {
+    return this.reportsService.recordAnswer(dto, req.authUserData?.userId);
   }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -4,7 +4,7 @@ import {
   KidDetailedReportDto,
   WeeklyReportDto,
 } from './dto/reports.dto';
-import { QuestionAnswerDto } from '../story/dto/story.dto';
+import { SubmitQuestionAnswerDto } from '../story/dto/story.dto';
 import { BadgeProgressEngine } from '../achievement-progress/badge-progress.engine';
 import { ScreenTimeService } from './services/screen-time.service';
 import {
@@ -46,9 +46,15 @@ export class ReportsService {
   ) {}
 
   /**
-   * Record a question answer
+   * Record a question answer.
+   *
+   * Attribution is EITHER kid-scoped (dto.kidId) OR user-scoped (userId):
+   * - kidId present  -> persist against the kid and advance that kid's badges.
+   * - no kidId, user authenticated -> persist against the user (no badges;
+   *   badges are kid-scoped).
+   * - neither (guest) -> return the correctness result without persisting.
    */
-  async recordAnswer(dto: QuestionAnswerDto) {
+  async recordAnswer(dto: SubmitQuestionAnswerDto, userId?: string) {
     const question = await this.storyQuestionRepository.findQuestionForAnswer(
       dto.questionId,
     );
@@ -66,29 +72,41 @@ export class ReportsService {
 
     const isCorrect = question.correctOption === dto.selectedOption;
 
+    // Guest with no kid context: nothing to attribute the answer to. Return the
+    // correctness result so the client can still render feedback.
+    if (!dto.kidId && !userId) {
+      return { answerId: null, isCorrect, persisted: false };
+    }
+
     const answer = await this.questionAnswerRepository.createAnswer({
-      kidId: dto.kidId,
+      // Prefer kid attribution when a kidId is supplied; otherwise attribute to
+      // the authenticated user.
+      kidId: dto.kidId ?? null,
+      userId: dto.kidId ? null : userId,
       questionId: dto.questionId,
       storyId: dto.storyId,
       selectedOption: dto.selectedOption,
       isCorrect,
     });
 
-    // Trigger badge progress for quiz answered
-    const kid = await this.kidRepository.findParentIdByKidId(dto.kidId);
+    // Badge progress is kid-scoped — only advance it for kid-attributed answers.
+    if (dto.kidId) {
+      const kid = await this.kidRepository.findParentIdByKidId(dto.kidId);
 
-    if (kid?.parentId) {
-      await this.badgeProgressEngine.recordActivity(
-        kid.parentId,
-        'quiz_answered',
-        dto.kidId,
-        { questionId: dto.questionId, isCorrect },
-      );
+      if (kid?.parentId) {
+        await this.badgeProgressEngine.recordActivity(
+          kid.parentId,
+          'quiz_answered',
+          dto.kidId,
+          { questionId: dto.questionId, isCorrect },
+        );
+      }
     }
 
     return {
       answerId: answer.id,
       isCorrect,
+      persisted: true,
     };
   }
 

--- a/src/story/dto/story.dto.ts
+++ b/src/story/dto/story.dto.ts
@@ -517,6 +517,16 @@ export class SubmitQuestionAnswerDto {
   @ApiProperty()
   @IsInt()
   selectedOption: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Attribute the answer to a specific kid (drives that kid’s badge ' +
+      'progress). Omit for user-scoped clients (e.g. mobile) that read as the ' +
+      'logged-in user without a kid context.',
+  })
+  @IsOptional()
+  @IsString()
+  kidId?: string;
 }
 
 export class PaginationMetaDto {


### PR DESCRIPTION
## Problem
`POST /reports/answer` bound the response-shaped `QuestionAnswerDto`, which has **only `@ApiProperty`, no class-validator decorators**. Under blue's global `forbidNonWhitelisted: true` pipe, every property is non-whitelisted → **any body 400s**, so quiz answers were never recorded. Mobile's submit is fire-and-forget, so it failed silently. (Pre-existing; green has the same DTO.)

Also blocks mobile specifically: the mobile app is a **user/guest-scoped reader with no current-kid concept**, but the old flow required `kidId`.

## Fix
- Bind the already-validated `SubmitQuestionAnswerDto` (was unused); add an optional `kidId`.
- **Attribution** is now EITHER kid-scoped (`kidId` → that kid's badge progress, unchanged) OR user-scoped (authenticated user, no kid). Guests (no auth, no kidId) get the correctness result back without persisting.
- `reports.controller`: `@OptionalAuth() + @UseGuards(AuthSessionGuard)` so `userId` is available without rejecting guests.
- **Schema**: `QuestionAnswer.kidId` → nullable, new nullable `userId` (FK to User, cascade) + index. Safe widening migration (`20260725224929_quiz_answer_user_scoped`), no data rewrite.

Part of the blue-mobile integration work. tsc + build clean; migration applied + verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Answers can now be recorded for either a selected child profile or the signed-in user.
  - Guest users can submit answers and receive correctness results without saving responses.
  - Answer responses indicate whether the submission was saved.
  - Badge progress continues to advance for child-profile answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->