### PR TITLE
feat(voice): stream TTS batch progress over SSE + paragraph outline

### DIFF
--- a/src/notification/services/job-events.service.ts
+++ b/src/notification/services/job-events.service.ts
@@ -24,6 +24,12 @@ export interface JobEvent {
     storyId?: string;
     title?: string;
     audioUrl?: string;
+    // Voice batch fields: which paragraph became ready, and (on completion) the
+    // batch tally so a reader knows whether every position was narrated.
+    paragraphIndex?: number;
+    totalParagraphs?: number;
+    completedParagraphs?: number;
+    failedParagraphs?: number;
   };
   error?: string;
   timestamp: Date;
@@ -110,6 +116,61 @@ export class JobEventsService {
       jobType: 'voice',
       progress: 100,
       result: { audioUrl },
+      timestamp: new Date(),
+    });
+  }
+
+  /**
+   * Emit a per-paragraph readiness event for a voice batch.
+   *
+   * The reader consumes these to append playable audio to its playlist as each
+   * paragraph finishes, rather than waiting for the whole batch. `progress` is
+   * the batch-level percentage so a progress bar can advance alongside.
+   */
+  emitVoiceParagraphReady(
+    jobId: string,
+    userId: string,
+    paragraphIndex: number,
+    audioUrl: string,
+    progress: number,
+  ): void {
+    this.emit({
+      type: JobEventType.PROGRESS,
+      jobId,
+      userId,
+      jobType: 'voice',
+      progress,
+      result: { paragraphIndex, audioUrl },
+      timestamp: new Date(),
+    });
+  }
+
+  /**
+   * Emit the terminal completion event for a voice batch. Carries the tally so
+   * the reader can tell full narration from a partial one (some paragraphs may
+   * have exhausted every provider). Emit ONLY when no self-heal retry remains,
+   * otherwise the reader would stop listening before healed paragraphs arrive.
+   */
+  emitVoiceBatchCompleted(
+    jobId: string,
+    userId: string,
+    summary: {
+      totalParagraphs: number;
+      completedParagraphs: number;
+      failedParagraphs: number;
+    },
+  ): void {
+    this.emit({
+      type: JobEventType.COMPLETED,
+      jobId,
+      userId,
+      jobType: 'voice',
+      progress: 100,
+      result: {
+        totalParagraphs: summary.totalParagraphs,
+        completedParagraphs: summary.completedParagraphs,
+        failedParagraphs: summary.failedParagraphs,
+      },
       timestamp: new Date(),
     });
   }

--- a/src/voice/queue/tts-batch.processor.spec.ts
+++ b/src/voice/queue/tts-batch.processor.spec.ts
@@ -29,6 +29,11 @@ describe('TtsBatchProcessor', () => {
     queueRetryBatch: jest.Mock;
   };
   let ttsService: { generateSingleParagraphTTS: jest.Mock };
+  let jobEvents: {
+    emitVoiceParagraphReady: jest.Mock;
+    emitVoiceBatchCompleted: jest.Mock;
+    emitFailed: jest.Mock;
+  };
 
   beforeEach(() => {
     queueService = {
@@ -40,11 +45,17 @@ describe('TtsBatchProcessor', () => {
       queueRetryBatch: jest.fn().mockResolvedValue(undefined),
     };
     ttsService = { generateSingleParagraphTTS: jest.fn() };
+    jobEvents = {
+      emitVoiceParagraphReady: jest.fn(),
+      emitVoiceBatchCompleted: jest.fn(),
+      emitFailed: jest.fn(),
+    };
 
     processor = new TtsBatchProcessor(
       queueService as never,
       ttsService as never,
       { recordAttempt: jest.fn(), recordParagraph: jest.fn() } as never,
+      jobEvents as never,
     );
   });
 
@@ -85,6 +96,82 @@ describe('TtsBatchProcessor', () => {
 
       expect(queueService.markParagraphFailed).toHaveBeenCalledTimes(3);
       expect(result.failedCount).toBe(3);
+    });
+  });
+
+  describe('SSE emission', () => {
+    it('announces each ready position (including duplicates) then completes', async () => {
+      ttsService.generateSingleParagraphTTS.mockResolvedValue({
+        audioUrl: 'https://audio/0',
+      });
+
+      await processor.process(
+        makeJob({
+          paragraphs: [
+            { index: 0, text: 'hi', hash: 'h0', duplicateIndices: [1, 2] },
+          ],
+          totalParagraphs: 3,
+        }),
+      );
+
+      // One generated paragraph lights up all three positions on the stream.
+      expect(jobEvents.emitVoiceParagraphReady).toHaveBeenCalledTimes(3);
+      for (const idx of [0, 1, 2]) {
+        expect(jobEvents.emitVoiceParagraphReady).toHaveBeenCalledWith(
+          'batch-1',
+          'user-1',
+          idx,
+          'https://audio/0',
+          expect.any(Number),
+        );
+      }
+      // Terminal completion carries the batch tally; no failure emitted.
+      expect(jobEvents.emitVoiceBatchCompleted).toHaveBeenCalledWith(
+        'batch-1',
+        'user-1',
+        { totalParagraphs: 3, completedParagraphs: 3, failedParagraphs: 0 },
+      );
+      expect(jobEvents.emitFailed).not.toHaveBeenCalled();
+    });
+
+    it('emits a terminal failure when every paragraph fails and no retry remains', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
+
+      await processor.process(
+        makeJob({
+          paragraphs: [{ index: 0, text: 'hi', hash: 'h0' }],
+          totalParagraphs: 1,
+          // Already at the retry ceiling → no self-heal, so terminal fires now.
+          retryGeneration: 2,
+        }),
+      );
+
+      expect(jobEvents.emitVoiceParagraphReady).not.toHaveBeenCalled();
+      expect(jobEvents.emitVoiceBatchCompleted).not.toHaveBeenCalled();
+      expect(jobEvents.emitFailed).toHaveBeenCalledWith(
+        'batch-1',
+        'user-1',
+        'voice',
+        expect.any(String),
+      );
+    });
+
+    it('withholds the terminal event while a self-heal retry is scheduled', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
+
+      await processor.process(
+        makeJob({
+          paragraphs: [{ index: 0, text: 'hi', hash: 'h0' }],
+          totalParagraphs: 1,
+          // generation 0 with a failure → a retry is queued, so neither
+          // terminal event may fire yet (the retry generation will send it).
+          retryGeneration: 0,
+        }),
+      );
+
+      expect(queueService.queueRetryBatch).toHaveBeenCalled();
+      expect(jobEvents.emitVoiceBatchCompleted).not.toHaveBeenCalled();
+      expect(jobEvents.emitFailed).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -234,13 +234,18 @@ export class TtsBatchProcessor extends WorkerHost {
             completedCount += allIndices.length;
             this.metrics.recordParagraph('completed');
             // Announce each ready position so a live reader can append it to its
-            // playlist immediately. Cap at 99 so the bar never reads 100 before
+            // playlist immediately. Base progress on paragraphs PROCESSED
+            // (completed + failed), not just completed — a failed paragraph
+            // still advances the batch, so excluding it would stall the bar on
+            // a high-failure run. Cap at 99 so the bar never reads 100 before
             // the terminal `completed` event fires.
             const progress =
               totalParagraphs > 0
                 ? Math.min(
                     99,
-                    Math.round((completedCount / totalParagraphs) * 100),
+                    Math.round(
+                      ((completedCount + failedCount) / totalParagraphs) * 100,
+                    ),
                   )
                 : 0;
             for (const idx of allIndices) {

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -14,6 +14,7 @@ import { TtsBatchQueueService } from './tts-batch-queue.service';
 import { TtsMetricsService } from './tts-metrics.service';
 import { TextToSpeechService } from '../../story/text-to-speech.service';
 import { QuotaExhaustedError } from '../errors/quota-exhausted.error';
+import { JobEventsService } from '@/notification/services/job-events.service';
 
 const MAX_CONCURRENT_PER_JOB = 5;
 
@@ -43,8 +44,36 @@ export class TtsBatchProcessor extends WorkerHost {
     private readonly queueService: TtsBatchQueueService,
     private readonly ttsService: TextToSpeechService,
     private readonly metrics: TtsMetricsService,
+    private readonly jobEvents: JobEventsService,
   ) {
     super();
+  }
+
+  /**
+   * Push a paragraph-ready event onto the user's SSE stream. Best-effort: a
+   * broadcast failure must never abort the batch, so we only log.
+   */
+  private emitParagraphReady(
+    batchJobId: string,
+    userId: string,
+    index: number,
+    audioUrl: string,
+    progress: number,
+  ): void {
+    try {
+      this.jobEvents.emitVoiceParagraphReady(
+        batchJobId,
+        userId,
+        index,
+        audioUrl,
+        progress,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `TTS batch ${batchJobId}: failed to emit SSE paragraph-ready for ${index}`,
+        err,
+      );
+    }
   }
 
   /** Check if a rejection reason indicates quota/payment exhaustion */
@@ -204,6 +233,25 @@ export class TtsBatchProcessor extends WorkerHost {
             // the completed/failed sets in Redis whenever duplicates exist.
             completedCount += allIndices.length;
             this.metrics.recordParagraph('completed');
+            // Announce each ready position so a live reader can append it to its
+            // playlist immediately. Cap at 99 so the bar never reads 100 before
+            // the terminal `completed` event fires.
+            const progress =
+              totalParagraphs > 0
+                ? Math.min(
+                    99,
+                    Math.round((completedCount / totalParagraphs) * 100),
+                  )
+                : 0;
+            for (const idx of allIndices) {
+              this.emitParagraphReady(
+                batchJobId,
+                userId,
+                idx,
+                result.value.audioUrl,
+                progress,
+              );
+            }
           } catch (redisErr) {
             this.logger.error(
               `TTS batch ${batchJobId}: Redis write failed for completed paragraph ${paragraphIndex}`,
@@ -245,6 +293,7 @@ export class TtsBatchProcessor extends WorkerHost {
     // whole provider chain this run, bounded by MAX_RETRY_GENERATIONS so it can
     // never loop. The retry re-uses this batchJobId, so recovered paragraphs
     // heal in place for anyone still polling the batch.
+    let retryScheduled = false;
     if (failedThisRun.length > 0 && generation < MAX_RETRY_GENERATIONS) {
       try {
         await this.queueService.queueRetryBatch(
@@ -252,6 +301,7 @@ export class TtsBatchProcessor extends WorkerHost {
           failedThisRun,
           generation + 1,
         );
+        retryScheduled = true;
         this.logger.log(
           `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
         );
@@ -286,6 +336,34 @@ export class TtsBatchProcessor extends WorkerHost {
           : '',
     });
 
+    // Terminal SSE, emitted ONLY when no self-heal retry is still pending —
+    // otherwise the reader would stop listening before the healed paragraphs
+    // arrive in the next generation. The final generation always fires this,
+    // so a reader is never left waiting forever.
+    if (!retryScheduled) {
+      try {
+        if (aggregateCompleted > 0) {
+          this.jobEvents.emitVoiceBatchCompleted(batchJobId, userId, {
+            totalParagraphs: totalQueued,
+            completedParagraphs: aggregateCompleted,
+            failedParagraphs: aggregateFailed,
+          });
+        } else {
+          this.jobEvents.emitFailed(
+            batchJobId,
+            userId,
+            'voice',
+            `All ${totalQueued} paragraphs failed to synthesize`,
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          `TTS batch ${batchJobId}: failed to emit terminal SSE`,
+          err,
+        );
+      }
+    }
+
     this.logger.log(
       `TTS batch ${batchJobId} finished (generation ${generation}): ${completedCount} completed / ${failedCount} failed this run; aggregate ${aggregateCompleted} completed / ${aggregateFailed} failed`,
     );
@@ -300,7 +378,7 @@ export class TtsBatchProcessor extends WorkerHost {
       return;
     }
 
-    const { batchJobId } = job.data;
+    const { batchJobId, userId } = job.data;
     this.logger.error(
       `TTS batch ${batchJobId} permanently failed: ${error.message}`,
       error.stack,
@@ -314,6 +392,17 @@ export class TtsBatchProcessor extends WorkerHost {
       .catch((err) =>
         this.logger.error(`Failed to update batch meta for ${batchJobId}`, err),
       );
+
+    // Close out any live reader — otherwise it waits on a stream that will
+    // never deliver another paragraph.
+    try {
+      this.jobEvents.emitFailed(batchJobId, userId, 'voice', error.message);
+    } catch (err) {
+      this.logger.warn(
+        `TTS batch ${batchJobId}: failed to emit terminal failure SSE`,
+        err,
+      );
+    }
   }
 
   @OnWorkerEvent('error')

--- a/src/voice/voice.controller.ts
+++ b/src/voice/voice.controller.ts
@@ -295,6 +295,20 @@ export class VoiceController {
           },
         },
         totalParagraphs: { type: 'number' },
+        outline: {
+          type: 'array',
+          description:
+            'Every paragraph in reading order (ready AND pending), so a reader ' +
+            'can render per-paragraph text up-front and sync it to audio that ' +
+            'arrives later over SSE. Audio is NOT included here.',
+          items: {
+            type: 'object',
+            properties: {
+              index: { type: 'number' },
+              text: { type: 'string' },
+            },
+          },
+        },
         wasTruncated: { type: 'boolean' },
         voiceId: { type: 'string' },
         usedProvider: {
@@ -383,10 +397,25 @@ export class VoiceController {
       }
     }
 
+    // Full reading-order outline (ready + pending), deduped by index. Lets a
+    // reader lay out every paragraph's text immediately and light up audio per
+    // index as it streams in over SSE, keeping text and narration in sync.
+    const textByIndex = new Map<number, string>();
+    for (const p of paragraphs) {
+      if (typeof p.text === 'string') textByIndex.set(p.index, p.text);
+    }
+    for (const p of remainingUncached) {
+      if (!textByIndex.has(p.index)) textByIndex.set(p.index, p.text);
+    }
+    const outline = [...textByIndex.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([index, text]) => ({ index, text }));
+
     return {
       message: 'Batch audio generated successfully',
       paragraphs,
       totalParagraphs,
+      outline,
       wasTruncated,
       voiceId: resolvedVoice,
       usedProvider,

--- a/src/voice/voice.module.ts
+++ b/src/voice/voice.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from '@/auth/auth.module';
 import { StoryModule } from '../story/story.module';
 import { SubscriptionModule } from '../subscription/subscription.module';
 import { UploadModule } from '../upload/upload.module';
+import { NotificationModule } from '../notification/notification.module';
 import { TextToSpeechService } from '../story/text-to-speech.service';
 import { VoiceController } from './voice.controller';
 import { VoiceService } from './voice.service';
@@ -48,6 +49,7 @@ import {
     HttpModule,
     SubscriptionModule,
     UploadModule,
+    NotificationModule,
     forwardRef(() => StoryModule),
     BullModule.registerQueue({ name: TTS_BATCH_QUEUE_NAME }),
   ],


### PR DESCRIPTION
## What & why

The TTS batch processor persisted paragraph audio to Redis but emitted **no SSE**, so readers had to poll `GET /voice/story/audio/batch/status/:id` for readiness — costly, and it only surfaced a single "first paragraph" URL. This wires voice batches onto the **same job-events SSE stream** story generation already uses, so a reader can play a real per-paragraph playlist that fills in as narration completes.

## Changes

- **`JobEventsService`**: `emitVoiceParagraphReady(batchJobId, userId, index, audioUrl, progress)`, `emitVoiceBatchCompleted(...summary)`, extended `result` with paragraph fields. (`result` is serialized as-is, so no formatter change needed.)
- **`TtsBatchProcessor`**: emits a paragraph-ready event for every completed position (including duplicate indices) as it lands; emits the terminal `completed` (with total/completed/failed tally) or `failed`. **Terminal events are withheld while a self-heal retry is still scheduled** — otherwise a reader would stop listening before healed paragraphs arrive in a later generation. `onFailed` also closes the stream on a hard job failure. All emits are best-effort (a broadcast failure never aborts the batch).
- **Batch response `outline`**: additive `{index,text}[]` covering every paragraph in reading order (ready + pending, deduped). Lets a reader lay out per-paragraph text up-front and sync it to audio streaming in over SSE. Audio stays out of the outline.
- **Module wiring**: `VoiceModule` imports `NotificationModule` (exports `JobEventsService`; no dependency cycle).

Readers now subscribe to `GET /events/jobs/:batchJobId` instead of polling.

## Tests

- 3 new specs: per-paragraph emit (incl. duplicates) + terminal completion; terminal failure when all fail and no retry remains; terminal withheld while a self-heal retry is scheduled.
- Full voice + notification suites: **109/109 pass** (in-band). `tsc --noEmit` clean.

## Consumer

Paired web PR (storytime-fe #115) swaps the reader from polling to this SSE stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time progress updates as voice batch paragraphs become ready.
  * Added completion summaries showing total, completed, and failed paragraphs.
  * Voice batch responses now include an ordered outline of all paragraphs.

* **Bug Fixes**
  * Live progress remains open while automatic retries are pending.
  * Permanent processing failures now properly close live progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->