### PR TITLE
feat(user): app-rating state + rate-app endpoints

### DIFF
--- a/prisma/migrations/20260729105930_add_app_rating_fields/migration.sql
+++ b/prisma/migrations/20260729105930_add_app_rating_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: add per-user app-rating state
+ALTER TABLE "users" ADD COLUMN "hasRatedApp" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "users" ADD COLUMN "rateAppDismissedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,9 @@ model User {
   // SUSPENSION FIELDS
   isSuspended             Boolean                  @default(false)
   suspendedAt             DateTime?
+  // APP RATING FIELDS
+  hasRatedApp             Boolean                  @default(false)
+  rateAppDismissedAt      DateTime?
   profile                 Profile?
   auth                    Session[]
   Token                   Token[]

--- a/src/user/dto/parent-profile-response.dto.ts
+++ b/src/user/dto/parent-profile-response.dto.ts
@@ -53,6 +53,21 @@ export class ParentProfileResponseDto {
   @ApiProperty({ example: true })
   enableBiometrics?: boolean;
 
+  @ApiProperty({
+    example: false,
+    description:
+      'Whether the user has rated the app (stops the rate-us prompt)',
+  })
+  hasRatedApp?: boolean;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description:
+      'When the user dismissed the rate-us popup; drives the profile "Rate Us" card',
+  })
+  rateAppDismissedAt?: Date | null;
+
   @ApiProperty({ example: '2023-10-01T12:00:00Z' })
   createdAt: Date;
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -141,6 +141,30 @@ export class UserController {
     return this.userService.updateParentProfile(req.authUserData.userId, body);
   }
 
+  @Patch('me/rate-app')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Mark that the current user has rated the app',
+    description:
+      'Called when the user taps "Rate Us" and is sent to the store. Sets hasRatedApp so the rate-us prompt and profile card stop showing.',
+  })
+  async markAppRated(@Req() req: AuthenticatedRequest) {
+    return this.userService.markAppRated(req.authUserData.userId);
+  }
+
+  @Patch('me/rate-app/dismiss')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Dismiss the rate-us prompt for the current user',
+    description:
+      'Called when the user cancels the rate-us popup. Records rateAppDismissedAt so the popup stops but the profile "Rate Us" card is shown instead.',
+  })
+  async dismissAppRating(@Req() req: AuthenticatedRequest) {
+    return this.userService.dismissAppRating(req.authUserData.userId);
+  }
+
   @Post('me/avatar')
   @UseGuards(AuthSessionGuard)
   @ApiBearerAuth()

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -524,6 +524,24 @@ export class UserService {
     });
   }
 
+  async markAppRated(userId: string) {
+    const user = await this.prisma.user.update({
+      where: { id: userId, isDeleted: false },
+      data: { hasRatedApp: true },
+      select: { hasRatedApp: true, rateAppDismissedAt: true },
+    });
+    return { success: true, ...user };
+  }
+
+  async dismissAppRating(userId: string) {
+    const user = await this.prisma.user.update({
+      where: { id: userId, isDeleted: false },
+      data: { rateAppDismissedAt: new Date() },
+      select: { hasRatedApp: true, rateAppDismissedAt: true },
+    });
+    return { success: true, ...user };
+  }
+
   async updateAvatarForParent(userId: string, body: UpdateAvatarDto) {
     return this.prisma.user.update({
       where: {

--- a/src/user/utils/parent-profile.mapper.ts
+++ b/src/user/utils/parent-profile.mapper.ts
@@ -21,6 +21,8 @@ export interface UserWithRelations {
   kids?: { id: string }[];
   pinHash?: string | null;
   biometricsEnabled?: boolean;
+  hasRatedApp?: boolean;
+  rateAppDismissedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
   subscription?: Subscription | null;
@@ -53,6 +55,8 @@ export function mapParentProfile(user: UserWithRelations | null) {
     numberOfKids: Array.isArray(user.kids) ? user.kids.length : 0,
     pinSet: !!user.pinHash,
     biometricsEnabled: !!user.biometricsEnabled,
+    hasRatedApp: !!user.hasRatedApp,
+    rateAppDismissedAt: user.rateAppDismissedAt ?? null,
     createdAt: user.createdAt,
     updatedAt: user.updatedAt,
     subscriptionStatus: getSubscriptionStatus(


### PR DESCRIPTION
Adds per-user app-rating state so the mobile "Rate Us" feature can persist across devices/reinstalls.

## Changes
- `User.hasRatedApp` (Boolean, default false) + `User.rateAppDismissedAt` (DateTime?) — migration `..._add_app_rating_fields`.
- `PATCH /user/me/rate-app` → marks the user as rated (sets `hasRatedApp`). Called when the user taps "Rate Us".
- `PATCH /user/me/rate-app/dismiss` → records dismissal (`rateAppDismissedAt`). Called when the user cancels the popup.
- Both fields surfaced on `GET /user/me` (mapper + response DTO + Swagger).

## Behavior these fields drive (mobile)
- Popup shows only while `!hasRatedApp && !rateAppDismissedAt`.
- Profile "Rate Us" card shows while `!hasRatedApp && rateAppDismissedAt != null`.
- Once `hasRatedApp` → neither shows again.

## Notes
- Migration is hand-authored (plain `ALTER TABLE ADD COLUMN`, additive/safe); applied by the deploy pipeline via `db:migrate:deploy` — not run against shared RDS from local.
- tsc + eslint clean.
- Parity: should also be ported to the blue line (develop-v1.3.0) per the green→blue invariant — follow-up.
