### PR TITLE
feat(user): app-rating state + rate-app endpoints (blue port)

### DIFF
--- a/prisma/migrations/20260729105930_add_app_rating_fields/migration.sql
+++ b/prisma/migrations/20260729105930_add_app_rating_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: add per-user app-rating state
+ALTER TABLE "users" ADD COLUMN "hasRatedApp" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "users" ADD COLUMN "rateAppDismissedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,9 @@ model User {
   // SOFT DELETE FIELDS
   isDeleted               Boolean                  @default(false)
   deletedAt               DateTime?
+  // APP RATING FIELDS
+  hasRatedApp             Boolean                  @default(false)
+  rateAppDismissedAt      DateTime?
   profile                 Profile?
   auth                    Session[]
   Token                   Token[]

--- a/src/user/dto/parent-profile-response.dto.ts
+++ b/src/user/dto/parent-profile-response.dto.ts
@@ -53,6 +53,21 @@ export class ParentProfileResponseDto {
   @ApiProperty({ example: true })
   enableBiometrics?: boolean;
 
+  @ApiProperty({
+    example: false,
+    description:
+      'Whether the user has rated the app (stops the rate-us prompt)',
+  })
+  hasRatedApp?: boolean;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description:
+      'When the user dismissed the rate-us popup; drives the profile "Rate Us" card',
+  })
+  rateAppDismissedAt?: Date | null;
+
   @ApiProperty({ example: '2023-10-01T12:00:00Z' })
   createdAt: Date;
 

--- a/src/user/repositories/prisma-user.repository.ts
+++ b/src/user/repositories/prisma-user.repository.ts
@@ -100,6 +100,8 @@ export class PrismaUserRepository implements IUserRepository {
       avatarId: string | null;
       pinHash: string;
       onboardingStatus: string;
+      hasRatedApp: boolean;
+      rateAppDismissedAt: Date | null;
     }>,
   ): Promise<User> {
     return this.prisma.user.update({

--- a/src/user/repositories/user.repository.interface.ts
+++ b/src/user/repositories/user.repository.interface.ts
@@ -135,6 +135,8 @@ export interface IUserRepository {
       avatarId: string | null;
       pinHash: string;
       onboardingStatus: string;
+      hasRatedApp: boolean;
+      rateAppDismissedAt: Date | null;
     }>,
   ): Promise<User>;
   updateUserWithProfileUpsert(

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -145,6 +145,30 @@ export class UserController {
     return this.userService.updateParentProfile(req.authUserData.userId, body);
   }
 
+  @Patch('me/rate-app')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Mark that the current user has rated the app',
+    description:
+      'Called when the user taps "Rate Us" and is sent to the store. Sets hasRatedApp so the rate-us prompt and profile card stop showing.',
+  })
+  async markAppRated(@Req() req: AuthenticatedRequest) {
+    return this.userService.markAppRated(req.authUserData.userId);
+  }
+
+  @Patch('me/rate-app/dismiss')
+  @UseGuards(AuthSessionGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Dismiss the rate-us prompt for the current user',
+    description:
+      'Called when the user cancels the rate-us popup. Records rateAppDismissedAt so the popup stops but the profile "Rate Us" card is shown instead.',
+  })
+  async dismissAppRating(@Req() req: AuthenticatedRequest) {
+    return this.userService.dismissAppRating(req.authUserData.userId);
+  }
+
   @Post('me/avatar')
   @UseGuards(AuthSessionGuard)
   @ApiBearerAuth()

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -422,8 +422,11 @@ export class UserService {
   }
 
   async markAppRated(userId: string) {
+    // Rating supersedes any prior dismissal — clear the dismissal timestamp so
+    // the two fields can't disagree (rated with a stale dismissedAt).
     const user = await this.userRepository.updateActiveUserSimple(userId, {
       hasRatedApp: true,
+      rateAppDismissedAt: null,
     });
     return {
       success: true,
@@ -433,6 +436,16 @@ export class UserService {
   }
 
   async dismissAppRating(userId: string) {
+    // Once rated, dismissal is a no-op — never record a dismissal timestamp on
+    // an already-rated account.
+    const existing = await this.getUser(userId);
+    if (existing?.hasRatedApp) {
+      return {
+        success: true,
+        hasRatedApp: true,
+        rateAppDismissedAt: existing.rateAppDismissedAt ?? null,
+      };
+    }
     const user = await this.userRepository.updateActiveUserSimple(userId, {
       rateAppDismissedAt: new Date(),
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -421,6 +421,28 @@ export class UserService {
     );
   }
 
+  async markAppRated(userId: string) {
+    const user = await this.userRepository.updateActiveUserSimple(userId, {
+      hasRatedApp: true,
+    });
+    return {
+      success: true,
+      hasRatedApp: user.hasRatedApp,
+      rateAppDismissedAt: user.rateAppDismissedAt,
+    };
+  }
+
+  async dismissAppRating(userId: string) {
+    const user = await this.userRepository.updateActiveUserSimple(userId, {
+      rateAppDismissedAt: new Date(),
+    });
+    return {
+      success: true,
+      hasRatedApp: user.hasRatedApp,
+      rateAppDismissedAt: user.rateAppDismissedAt,
+    };
+  }
+
   async updateAvatarForParent(userId: string, body: UpdateAvatarDto) {
     return this.userRepository.updateParentAvatar(userId, body.avatarId);
   }

--- a/src/user/utils/parent-profile.mapper.ts
+++ b/src/user/utils/parent-profile.mapper.ts
@@ -21,6 +21,8 @@ export interface UserWithRelations {
   kids?: { id: string }[];
   pinHash?: string | null;
   biometricsEnabled?: boolean;
+  hasRatedApp?: boolean;
+  rateAppDismissedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
   subscription?: Subscription | null;
@@ -53,6 +55,8 @@ export function mapParentProfile(user: UserWithRelations | null) {
     numberOfKids: Array.isArray(user.kids) ? user.kids.length : 0,
     pinSet: !!user.pinHash,
     biometricsEnabled: !!user.biometricsEnabled,
+    hasRatedApp: !!user.hasRatedApp,
+    rateAppDismissedAt: user.rateAppDismissedAt ?? null,
     createdAt: user.createdAt,
     updatedAt: user.updatedAt,
     subscriptionStatus: getSubscriptionStatus(


### PR DESCRIPTION
Blue-line (`develop-v1.3.0`) port of the app-rating backend from green (#468), per the green→blue parity invariant.

Same feature as #468: `User.hasRatedApp` + `rateAppDismissedAt`, `PATCH /user/me/rate-app` + `.../rate-app/dismiss`, both surfaced on `GET /user/me`.

## Blue-specific reconciliation
- Cherry-picked from green; resolved the `schema.prisma` conflict (kept blue's soft-delete fields **and** the new rating fields).
- Blue's `UserService` uses the **repository pattern** (no `this.prisma`), so `markAppRated`/`dismissAppRating` were rewired to `userRepository.updateActiveUserSimple(...)`, and that method's accepted-field type was widened (interface + impl) to include the two rating fields.
- Migration is additive `ALTER TABLE ... ADD COLUMN` (applied by the deploy pipeline, not run against shared RDS locally).

tsc + eslint clean against blue's dependency set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking whether users have rated the app.
  * Added controls to dismiss the app-rating prompt.
  * Added rating status and dismissal information to parent profiles.
  * Added authenticated actions for marking the app as rated or dismissing the prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->