### PR TITLE
fix(story): restore guest access to story browsing endpoints (green parity)

### DIFF
--- a/src/story/story-core.controller.ts
+++ b/src/story/story-core.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   BadRequestException,
+  Headers,
   Logger,
   Param,
   Patch,
@@ -29,6 +30,8 @@ import {
   AuthSessionGuard,
   AuthenticatedRequest,
 } from '@/shared/guards/auth.guard';
+import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
+import { Public } from '@/shared/decorators/public.decorator';
 
 import {
   CategoryDto,
@@ -61,6 +64,7 @@ export class StoryCoreController {
   ) {}
 
   @Get()
+  @OptionalAuth()
   @ApiOperation({
     summary:
       'Get stories (optionally filtered by theme, category, recommended, kidId, and age)',
@@ -124,6 +128,7 @@ export class StoryCoreController {
   }) // 100 per minute
   async getStories(
     @Req() req: AuthenticatedRequest,
+    @Headers('x-guest-session-id') guestSessionId?: string,
     @Query('theme') theme?: string,
     @Query('category') category?: string,
     @Query('season') season?: string,
@@ -166,20 +171,24 @@ export class StoryCoreController {
       throw new BadRequestException('maxAge must be a non-negative number');
     }
 
-    if (kidId) {
+    const authenticatedUserId = req.authUserData?.userId;
+    // kidId is only meaningful for authenticated users; guests can't own kids.
+    const resolvedKidId = kidId && authenticatedUserId ? kidId : undefined;
+
+    if (resolvedKidId && authenticatedUserId) {
       await this.kidOwnership.getOwnedKidOrThrow(
-        kidId,
-        req.authUserData.userId,
+        resolvedKidId,
+        authenticatedUserId,
       );
     }
 
     const baseFilter = {
-      userId: req.authUserData.userId,
+      userId: authenticatedUserId,
       theme,
       category,
       season,
       isSeasonal: isSeasonal === 'true',
-      kidId,
+      kidId: resolvedKidId,
       age: parsedAge,
       minAge: parsedMinAge,
       maxAge: parsedMaxAge,
@@ -209,6 +218,7 @@ export class StoryCoreController {
     if (useCursorMode) {
       return this.storyService.getStoriesCursor({
         ...baseFilter,
+        guestSessionId,
         cursor: safeCursor,
         limit: safeLimit,
       });
@@ -219,6 +229,7 @@ export class StoryCoreController {
 
     return this.storyService.getStories({
       ...baseFilter,
+      guestSessionId,
       recommended: recommended === 'true',
       isMostLiked: isMostLiked === 'true',
       topPicksFromUs: topPicksFromUs === 'true',
@@ -229,6 +240,7 @@ export class StoryCoreController {
   }
 
   @Get('homepage/parent')
+  @OptionalAuth()
   @ApiOperation({
     summary: 'Get parent homepage stories (Recommended, Seasonal, Top Liked)',
   })
@@ -252,7 +264,7 @@ export class StoryCoreController {
     const safeLimitSeasonal = Math.max(1, Math.min(limitSeasonal, 50));
     const safeLimitTopLiked = Math.max(1, Math.min(limitTopLiked, 50));
     return this.storyService.getHomePageStories(
-      req.authUserData.userId,
+      req.authUserData?.userId,
       safeLimitRecommended,
       safeLimitSeasonal,
       safeLimitTopLiked,
@@ -260,6 +272,7 @@ export class StoryCoreController {
   }
 
   @Get('categories')
+  @Public()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('categories:all')
   @CacheTTL(4 * 60 * 60 * 1000)
@@ -289,6 +302,7 @@ export class StoryCoreController {
   }
 
   @Get('themes')
+  @Public()
   @ApiOperation({ summary: 'Get all themes' })
   @ApiOkResponse({
     description: 'List of themes',
@@ -315,6 +329,7 @@ export class StoryCoreController {
   }
 
   @Get('seasons')
+  @Public()
   @ApiOperation({ summary: 'Get all seasons' })
   @ApiOkResponse({
     description: 'List of seasons',

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -19,6 +19,8 @@ import {
   DEFAULT_CURSOR_LIMIT,
   PaginationUtil,
 } from '@/shared/utils/pagination.util';
+import { GuestSessionService } from '@/guest/guest-session.service';
+import { deriveReadStatus } from '@/shared/utils/read-status.util';
 
 @Injectable()
 export class StoryFeedService {
@@ -26,6 +28,7 @@ export class StoryFeedService {
     @Inject(STORY_REPOSITORY)
     private readonly storyRepository: IStoryRepository,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private readonly guestSessionService: GuestSessionService,
   ) {}
 
   /** Wraps a Prisma query to handle invalid cursor IDs gracefully */
@@ -198,7 +201,8 @@ export class StoryFeedService {
   }
 
   async getStories(filter: {
-    userId: string;
+    userId?: string;
+    guestSessionId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -288,10 +292,22 @@ export class StoryFeedService {
     ]);
 
     const totalPages = Math.ceil(totalCount / limit);
-    const enrichedStories = await this.enrichWithReadStatus(
-      filter.userId,
-      stories,
-    );
+
+    // Enrich with read status based on user or guest session
+    let enrichedStories;
+    if (filter.userId) {
+      enrichedStories = await this.enrichWithReadStatus(filter.userId, stories);
+    } else if (filter.guestSessionId) {
+      enrichedStories = await this.enrichWithGuestReadStatus(
+        filter.guestSessionId,
+        stories,
+      );
+    } else {
+      enrichedStories = stories.map((s) => ({
+        ...s,
+        readStatus: null as 'done' | 'reading' | null,
+      }));
+    }
 
     let sortedStories = this.sortByReadStatus(enrichedStories, {
       shuffleUnseen: shouldShuffle,
@@ -337,7 +353,8 @@ export class StoryFeedService {
   }
 
   async getStoriesCursor(filter: {
-    userId: string;
+    userId?: string;
+    guestSessionId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -375,7 +392,22 @@ export class StoryFeedService {
       stories,
       limit,
     );
-    const enriched = await this.enrichWithReadStatus(filter.userId, data);
+
+    // Enrich with read status based on user or guest session
+    let enriched;
+    if (filter.userId) {
+      enriched = await this.enrichWithReadStatus(filter.userId, data);
+    } else if (filter.guestSessionId) {
+      enriched = await this.enrichWithGuestReadStatus(
+        filter.guestSessionId,
+        data,
+      );
+    } else {
+      enriched = data.map((s) => ({
+        ...s,
+        readStatus: null as 'done' | 'reading' | null,
+      }));
+    }
 
     return {
       data: this.sortByReadStatus(enriched),
@@ -467,6 +499,39 @@ export class StoryFeedService {
     });
   }
 
+  /**
+   * Enrich stories with readStatus from guest session
+   */
+  private async enrichWithGuestReadStatus<T extends { id: string }>(
+    guestSessionId: string,
+    stories: T[],
+  ): Promise<(T & { readStatus: 'done' | 'reading' | null })[]> {
+    const storyIds = [...new Set(stories.map((s) => s.id))];
+    if (storyIds.length === 0)
+      return stories.map((s) => ({
+        ...s,
+        readStatus: null as 'done' | 'reading' | null,
+      }));
+
+    const session =
+      await this.guestSessionService.getGuestSession(guestSessionId);
+    if (!session) {
+      return stories.map((s) => ({
+        ...s,
+        readStatus: null as 'done' | 'reading' | null,
+      }));
+    }
+
+    const readingHistory = session.readingHistory;
+    return stories.map((story) => {
+      const progress = readingHistory[story.id];
+      return {
+        ...story,
+        readStatus: deriveReadStatus(progress?.progress, progress?.completed),
+      };
+    });
+  }
+
   // Threshold in days to consider a past season as "recent" for backfill
   private readonly RECENT_SEASON_THRESHOLD_DAYS = 45;
 
@@ -531,29 +596,32 @@ export class StoryFeedService {
   }
 
   async getHomePageStories(
-    userId: string,
+    userId: string | undefined,
     limitRecommended: number = 5,
     limitSeasonal: number = 5,
     limitTopLiked: number = 5,
   ) {
-    const user = await this.storyRepository.findUniqueUserRaw({
-      where: { id: userId, isDeleted: false },
-      include: { preferredCategories: true },
-    });
+    const user = userId
+      ? await this.storyRepository.findUniqueUserRaw({
+          where: { id: userId, isDeleted: false },
+          include: { preferredCategories: true },
+        })
+      : null;
 
-    if (!user) {
+    if (userId && !user) {
       throw new NotFoundException('User not found');
     }
 
     // 1. Recommended Stories (based on preferred categories)
     let recommended: Story[] = [];
-    if (user.preferredCategories.length > 0) {
+    const preferredCategories = user?.preferredCategories ?? [];
+    if (preferredCategories.length > 0) {
       recommended = await this.storyRepository.findManyStoriesRaw({
         where: {
           isDeleted: false,
           categories: {
             some: {
-              id: { in: user.preferredCategories.map((c: Category) => c.id) },
+              id: { in: preferredCategories.map((c: Category) => c.id) },
             },
           },
         },
@@ -630,7 +698,12 @@ export class StoryFeedService {
 
     // Enrich all stories with readStatus in a single DB query
     const allStories = [...recommended, ...seasonal, ...topLiked];
-    const enriched = await this.enrichWithReadStatus(userId, allStories);
+    const enriched = userId
+      ? await this.enrichWithReadStatus(userId, allStories)
+      : allStories.map((s) => ({
+          ...s,
+          readStatus: null as 'done' | 'reading' | null,
+        }));
 
     const recLen = recommended.length;
     const seaLen = seasonal.length;

--- a/src/story/story-read.controller.ts
+++ b/src/story/story-read.controller.ts
@@ -8,6 +8,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthSessionGuard } from '@/shared/guards/auth.guard';
+import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
 
 import { CreateStoryDto, ErrorResponseDto } from './dto/story.dto';
 import { StoryService } from './story.service';
@@ -30,6 +31,7 @@ export class StoryReadController {
   ) {}
 
   @Get(':id')
+  @OptionalAuth()
   @UseGuards(StoryAccessGuard)
   @CheckStoryQuota()
   @ApiOperation({ summary: 'Get a story by id' })

--- a/src/story/story.module.ts
+++ b/src/story/story.module.ts
@@ -27,6 +27,7 @@ import { DailyChallengeService } from './daily-challenge.service';
 import { StoryGenerationService } from './story-generation.service';
 import { StoryQuotaService } from './story-quota.service';
 import { VoiceModule } from '../voice/voice.module';
+import { GuestModule } from '../guest/guest.module';
 import { StoryAccessGuard } from '@/shared/guards/story-access.guard';
 import { SubscriptionThrottleGuard } from '@/shared/guards/subscription-throttle.guard';
 import { STORY_QUEUE_NAME, StoryQueueService, StoryProcessor } from './queue';
@@ -69,6 +70,7 @@ import { PrismaStoryRecommendationRepository } from './repositories/prisma-story
     NotificationModule,
     PrismaModule,
     forwardRef(() => VoiceModule),
+    forwardRef(() => GuestModule),
     // Register story generation queue
     BullModule.registerQueue({
       name: STORY_QUEUE_NAME,

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { StoryService } from './story.service';
 import { StoryFeedService } from './story-feed.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 import { NotificationService } from '../notification/notification.service';
 import { STORY_REPOSITORY } from './repositories/story.repository.interface';
 import { GeminiService } from './gemini.service';
@@ -68,6 +69,10 @@ describe('StoryService - Library & Generation', () => {
       providers: [
         StoryService,
         StoryFeedService,
+        {
+          provide: GuestSessionService,
+          useValue: { getGuestSession: jest.fn().mockResolvedValue(null) },
+        },
         { provide: STORY_REPOSITORY, useValue: mockStoryRepository },
         { provide: GeminiService, useValue: mockGeminiService },
         {

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -21,6 +21,10 @@ import { StoryGenerationService } from './story-generation.service';
 
 // Mock dependencies — StoryService now routes all DB access through
 // STORY_REPOSITORY, so we mock the repository methods it calls.
+const mockGuestSessionService = {
+  getGuestSession: jest.fn(),
+};
+
 const mockStoryRepository = {
   findUniqueKidRaw: jest.fn(),
   findManyKidsRaw: jest.fn(),
@@ -71,7 +75,7 @@ describe('StoryService - Library & Generation', () => {
         StoryFeedService,
         {
           provide: GuestSessionService,
-          useValue: { getGuestSession: jest.fn().mockResolvedValue(null) },
+          useValue: mockGuestSessionService,
         },
         { provide: STORY_REPOSITORY, useValue: mockStoryRepository },
         { provide: GeminiService, useValue: mockGeminiService },
@@ -119,6 +123,9 @@ describe('StoryService - Library & Generation', () => {
     prisma = module.get(STORY_REPOSITORY);
     generation = module.get(StoryGenerationService);
     jest.clearAllMocks();
+    // Unknown/expired guest sessions resolve to null by default; individual
+    // tests override this to simulate a populated guest reading history.
+    mockGuestSessionService.getGuestSession.mockResolvedValue(null);
   });
 
   // --- 1. GENERATION TESTS (The Fix): delegate to canonical service ---
@@ -381,6 +388,141 @@ describe('StoryService - Library & Generation', () => {
 
       // Verify only 1 DB call for progress (not 1 per section)
       expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --- 3b. GUEST & ANONYMOUS ACCESS (OptionalAuth browse routes) ---
+  describe('Guest & anonymous access', () => {
+    const stories = [
+      { id: 'story-1', title: 'Finished Story' },
+      { id: 'story-2', title: 'Partially Read Story' },
+      { id: 'story-3', title: 'Unseen Story' },
+    ];
+
+    describe('getStories', () => {
+      it('should enrich readStatus from the guest reading history when only guestSessionId is given', async () => {
+        prisma.countStoriesRaw.mockResolvedValue(3);
+        prisma.findManyStoriesRaw.mockResolvedValue(stories);
+        mockGuestSessionService.getGuestSession.mockResolvedValue({
+          readingHistory: {
+            'story-1': { progress: 100, completed: true },
+            'story-2': { progress: 40 },
+          },
+        });
+
+        const result = await service.getStories({ guestSessionId: 'guest-1' });
+
+        expect(mockGuestSessionService.getGuestSession).toHaveBeenCalledWith(
+          'guest-1',
+        );
+        // sortByReadStatus orders: null (unseen) first, then reading, then done
+        expect(result.data[0]).toEqual(
+          expect.objectContaining({ id: 'story-3', readStatus: null }),
+        );
+        expect(result.data[1]).toEqual(
+          expect.objectContaining({ id: 'story-2', readStatus: 'reading' }),
+        );
+        expect(result.data[2]).toEqual(
+          expect.objectContaining({ id: 'story-1', readStatus: 'done' }),
+        );
+        // Guest enrichment must not query user progress
+        expect(prisma.findManyUserStoryProgressRaw).not.toHaveBeenCalled();
+      });
+
+      it('should fall back to null readStatus when the guest session is unknown/expired', async () => {
+        prisma.countStoriesRaw.mockResolvedValue(3);
+        prisma.findManyStoriesRaw.mockResolvedValue(stories);
+        // default mock: getGuestSession resolves null
+
+        const result = await service.getStories({ guestSessionId: 'stale' });
+
+        expect(result.data).toHaveLength(3);
+        for (const story of result.data) {
+          expect(story).toEqual(expect.objectContaining({ readStatus: null }));
+        }
+      });
+
+      it('should return null readStatus for fully anonymous requests (no userId, no guestSessionId)', async () => {
+        prisma.countStoriesRaw.mockResolvedValue(3);
+        prisma.findManyStoriesRaw.mockResolvedValue(stories);
+
+        const result = await service.getStories({});
+
+        expect(mockGuestSessionService.getGuestSession).not.toHaveBeenCalled();
+        expect(prisma.findManyUserStoryProgressRaw).not.toHaveBeenCalled();
+        expect(result.data).toHaveLength(3);
+        for (const story of result.data) {
+          expect(story).toEqual(expect.objectContaining({ readStatus: null }));
+        }
+      });
+    });
+
+    describe('getStoriesCursor', () => {
+      it('should enrich cursor pages from the guest reading history', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue(stories);
+        mockGuestSessionService.getGuestSession.mockResolvedValue({
+          readingHistory: {
+            'story-1': { progress: 100, completed: true },
+            'story-2': { progress: 40 },
+          },
+        });
+
+        const result = await service.getStoriesCursor({
+          guestSessionId: 'guest-1',
+        });
+
+        expect(mockGuestSessionService.getGuestSession).toHaveBeenCalledWith(
+          'guest-1',
+        );
+        expect(result.data[0]).toEqual(
+          expect.objectContaining({ id: 'story-3', readStatus: null }),
+        );
+        expect(result.data[1]).toEqual(
+          expect.objectContaining({ id: 'story-2', readStatus: 'reading' }),
+        );
+        expect(result.data[2]).toEqual(
+          expect.objectContaining({ id: 'story-1', readStatus: 'done' }),
+        );
+        expect(prisma.findManyUserStoryProgressRaw).not.toHaveBeenCalled();
+      });
+
+      it('should return null readStatus on anonymous cursor pages', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue(stories);
+
+        const result = await service.getStoriesCursor({});
+
+        expect(mockGuestSessionService.getGuestSession).not.toHaveBeenCalled();
+        expect(result.data).toHaveLength(3);
+        for (const story of result.data) {
+          expect(story).toEqual(expect.objectContaining({ readStatus: null }));
+        }
+      });
+    });
+
+    describe('getHomePageStories', () => {
+      it('should serve guests without a user lookup and with null readStatus', async () => {
+        const recommended = [{ id: 'story-1', title: 'Fresh' }];
+        const topLiked = [{ id: 'story-2', title: 'Liked' }];
+        // 1st call = recommended fallback (no preferences), 2nd = topLiked
+        // (no seasonal call since findManySeasonsRaw returns [])
+        prisma.findManyStoriesRaw
+          .mockResolvedValueOnce(recommended)
+          .mockResolvedValueOnce(topLiked);
+        prisma.findManySeasonsRaw.mockResolvedValue([]);
+
+        const result = await service.getHomePageStories(undefined);
+
+        // No user lookup, no NotFoundException, no progress query for guests
+        expect(prisma.findUniqueUserRaw).not.toHaveBeenCalled();
+        expect(prisma.findManyUserStoryProgressRaw).not.toHaveBeenCalled();
+        expect(result.recommended[0]).toEqual(
+          expect.objectContaining({ id: 'story-1', readStatus: null }),
+        );
+        expect(result.seasonal).toEqual([]);
+        expect(result.topLiked[0]).toEqual(
+          expect.objectContaining({ id: 'story-2', readStatus: null }),
+        );
+      });
     });
   });
 

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -124,7 +124,8 @@ export class StoryService {
   }
 
   async getStories(filter: {
-    userId: string;
+    userId?: string;
+    guestSessionId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -144,7 +145,8 @@ export class StoryService {
   }
 
   async getStoriesCursor(filter: {
-    userId: string;
+    userId?: string;
+    guestSessionId?: string;
     theme?: string;
     category?: string;
     season?: string;
@@ -160,7 +162,7 @@ export class StoryService {
   }
 
   async getHomePageStories(
-    userId: string,
+    userId: string | undefined,
     limitRecommended: number = 5,
     limitSeasonal: number = 5,
     limitTopLiked: number = 5,


### PR DESCRIPTION
## Problem

Guest sessions get **401 `Missing or invalid authorization header`** on the mobile home screen against blue (`blue.dev.api`). Reproduced live: `GET /stories/categories` and all `GET /stories?...` carousel calls 401 for guests, while `/guest/session`, `/guest/quota`, `/guest/history` work fine.

## Root cause

The v1.3.0 refactor split `story.controller.ts` into `story-core`/`story-read`/etc., and the guest support that `develop-v1.2.0` (green) has on the browse routes did not survive the split: no `@OptionalAuth()`/`@Public()` anywhere in the story controllers, class-level `AuthSessionGuard`, and unconditional `req.authUserData.userId` dereferences.

## Fix (port from green)

- `@OptionalAuth()` on `GET /stories`, `GET /stories/homepage/parent`, `GET /stories/:id`
- `@Public()` on `GET /stories/categories`, `/stories/themes`, `/stories/seasons`
- `GET /stories` accepts `x-guest-session-id` and enriches `readStatus` from the guest session (`enrichWithGuestReadStatus`, same as green); `kidId` is ignored for guests
- `userId` made optional through `StoryService` → `StoryFeedService`, incl. guest-safe `getHomePageStories`
- `GuestModule` wired into `StoryModule` with `forwardRef` (mirror of the existing `GuestModule → StoryModule` edge; no class-level DI cycle)
- spec: `GuestSessionService` mock added where the real `StoryFeedService` is constructed

Authenticated behaviour is unchanged — all guards and quota checks (`StoryAccessGuard`, `@CheckStoryQuota`) still apply; both were already null-safe for guests.

## Verification

- CodeRabbit review on the diff: clean (0 findings)
- Live repro confirmed pre-fix: guest curl against `blue.dev.api` → 401 on `/stories/*`, 200 on `/guest/*`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story listings and homepage content are now available to visitors without signing in.
  * Guest sessions can retain story reading status across browsing.
  * Story detail pages support optional authentication while preserving existing access controls.
  * Categories, themes, and seasons are publicly accessible.
* **Bug Fixes**
  * Anonymous viewers now receive consistent story read-status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->