### PR TITLE
ci: fix false-failing deploy verification + stop blue merges deploying green dev

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -394,13 +394,26 @@ jobs:
             # probe would pass a crash-loop that happens to be up at second 60, so
             # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
             # window; a crash-loop keeps resetting the streak and fails the gate.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,11 +390,22 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            streak=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
+            done
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
 
             echo "Production deployment verified successfully"
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -406,13 +406,18 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
-
-            echo "Deployment verified successfully"
+            # Health check with retry: cold start regularly exceeds a fixed
+            # 10s wait, which false-failed otherwise-successful deploys.
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost:3500/api/v1/health; then
+                echo "Deployment verified successfully"
+                exit 0
+              fi
+              echo "Health check attempt $i/12 failed; retrying in 10s..."
+              sleep 10
+            done
+            echo "App did not become healthy within 120s"
+            exit 1
 
       - name: Comment deployment status
         if: success()

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -285,7 +285,12 @@ jobs:
   deploy:
     name: Deploy to Dev
     needs: [build, test]
-    if: success() && github.event.action == 'closed' && github.event.pull_request.merged == true
+    # Base-branch gate: the CI jobs above run for PRs to any develop-v* branch,
+    # but only merges into green (develop-v1.2.0) may deploy the shared dev
+    # environment (dev.api / storytime_dev). Blue merges are deployed to their
+    # own environment by blue-deploy.yml; without this gate they also
+    # overwrote green dev and applied blue migrations to storytime_dev.
+    if: success() && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop-v1.2.0'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -406,18 +411,25 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Health check with retry: cold start regularly exceeds a fixed
-            # 10s wait, which false-failed otherwise-successful deploys.
+            # Verify the app starts AND *stays* healthy. A single probe 10s
+            # after restart false-failed successful deploys (cold start takes
+            # ~16s), and checking only a final probe would pass a crash-loop
+            # that happens to be up at second 60 — so require a sustained
+            # healthy streak (>=3 = ~15s) at the end of a ~60s window.
+            streak=0
             for i in $(seq 1 12); do
-              if curl -sf http://localhost:3500/api/v1/health; then
-                echo "Deployment verified successfully"
-                exit 0
+              sleep 5
+              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
               fi
-              echo "Health check attempt $i/12 failed; retrying in 10s..."
-              sleep 10
             done
-            echo "App did not become healthy within 120s"
-            exit 1
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
+
+            echo "Deployment verified successfully"
 
       - name: Comment deployment status
         if: success()

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -416,13 +416,26 @@ jobs:
             # ~16s), and checking only a final probe would pass a crash-loop
             # that happens to be up at second 60 — so require a sustained
             # healthy streak (>=3 = ~15s) at the end of a ~60s window.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -376,11 +376,25 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Wait for app to start
-            sleep 10
-
-            # Health check
-            curl -sf http://localhost:3500/api/v1/health || exit 1
+            # Verify the app starts AND *stays* healthy. Checking only the final
+            # probe would pass a crash-loop that happens to be up at second 60, so
+            # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
+            # window; a crash-loop keeps resetting the streak and fails the gate.
+            # NOTE: staging listens on :3600 (dev/prod use :3500). This curled
+            # :3500 before, so the streak never incremented and every staging
+            # deploy failed the gate even when the app was healthy.
+            streak=0
+            for i in $(seq 1 12); do
+              sleep 5
+              if curl -sf http://localhost:3600/api/v1/health > /dev/null 2>&1; then
+                streak=$((streak + 1))
+              else
+                streak=0
+              fi
+            done
+            if [ "$streak" -lt 3 ]; then
+              echo "App not consistently healthy at end of 60s window (streak=$streak) - possible crash-loop"; exit 1
+            fi
 
             echo "Staging deployment verified successfully"
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -383,13 +383,26 @@ jobs:
             # NOTE: staging listens on :3600 (dev/prod use :3500). This curled
             # :3500 before, so the streak never incremented and every staging
             # deploy failed the gate even when the app was healthy.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3600/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3600/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then


### PR DESCRIPTION
## Problems

1. **False-failing deploy verification.** `Deploy to Dev` probes `/health` exactly 10s after the pm2 restart; cold start regularly takes longer (last run: probe at 13:08:04, app up at 13:08:10), so successful deploys were marked failed. Staging and prod share the same single-probe pattern, and staging's copy probed `:3500` even though staging listens on `:3600`.
2. **Blue merges deploy the green dev environment.** `dev-deploy.yml` triggers on PRs to `develop-v*`, so merges into `develop-v1.3.0` (blue) also deployed blue code + blue migrations onto the shared green dev environment (`dev.api` / `storytime_dev`). That cross-contamination is what left the stuck P3009 migration record (`20260725224929_quiz_answer_user_scoped`) that blocked all dev deploys Jul 25–31 (resolved on the DB by marking it applied after verifying the schema objects already existed).

## Fixes

- **dev/staging/prod verify steps**: port the sustained-healthy-streak gate from `develop-v1.2.0` (>=3 consecutive healthy probes at the end of a ~60s window) — tolerates slow cold starts and catches crash-loops. Staging now probes `:3600`.
- **dev-deploy deploy job**: gated on `github.event.pull_request.base.ref == 'develop-v1.2.0'`. CI jobs (Code Quality / Build / Test) still run for PRs to every `develop-v*` branch; only green merges deploy `dev.api`. Blue merges are already deployed to their own environment (`blue.dev.api` / `storytime_db_blue`) by `blue-deploy.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment verification across development, staging, and production environments.
  - Deployments now perform repeated health checks and require consecutive successful results before completing.
  - Failed checks reset verification and cause the deployment to stop, helping detect crashes or unstable releases earlier.
  - Development deployments now run only after pull requests are merged into the designated development release branch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->