### PR TITLE
ci: bound health probes with connect/transfer timeouts (green mirror of #473)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -399,22 +399,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -395,13 +395,26 @@ jobs:
             # probe would pass a crash-loop that happens to be up at second 60, so
             # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
             # window; a crash-loop keeps resetting the streak and fails the gate.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -401,22 +401,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -397,13 +397,26 @@ jobs:
             # probe would pass a crash-loop that happens to be up at second 60, so
             # require a sustained healthy streak (>=3 = ~15s) at the end of a ~60s
             # window; a crash-loop keeps resetting the streak and fails the gate.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3500/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -384,13 +384,26 @@ jobs:
             # NOTE: staging listens on :3600 (dev/prod use :3500). This curled
             # :3500 before, so the streak never incremented and every staging
             # deploy failed the gate even when the app was healthy.
+            start_time=$(date +%s)
+            deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
-              sleep 5
-              if curl -sf http://localhost:3600/api/v1/health > /dev/null 2>&1; then
+              now=$(date +%s)
+              remaining=$((deadline - now))
+              [ "$remaining" -gt 0 ] || break
+
+              if curl -fsS --connect-timeout 5 --max-time "$remaining" \
+                http://localhost:3600/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
+              fi
+
+              if [ "$i" -lt 12 ]; then
+                next_probe=$((start_time + i * 5))
+                now=$(date +%s)
+                delay=$((next_probe - now))
+                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -388,22 +388,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3600/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then


### PR DESCRIPTION
Mirror of the probe hardening merged to `develop-v1.3.0` in #473, for green's copies of the same verify steps.

## Problem

The streak health gates in `dev-deploy.yml`, `staging-deploy.yml`, and `deploy-prod.yml` probe with `curl -sf` and no connection or transfer timeout. A server that accepts a connection but never completes the response can hang a probe far past the 60s window, until the job's timeout.

## Fix

Same bounded polling structure as #473: absolute 60s deadline, `--connect-timeout 5` and `--max-time <remaining budget>` on every probe, schedule-based pacing, streak semantics unchanged. Ports untouched (dev/prod `:3500`, staging `:3600`).

Green does not need #473's base-ref deploy gate — PRs into blue execute blue's workflow copy, so only blue's file needed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment health checks with a fixed 60-second verification window.
  * Added request time limits and more consistent five-second probe scheduling.
  * Health checks now stop promptly when the verification window expires while preserving the requirement for three consecutive successful checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->