### PR TITLE
ci: probe through the end of the health window (port of #474 review fix)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -398,22 +398,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -420,22 +420,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3500/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -387,22 +387,24 @@ jobs:
             deadline=$((start_time + 60))
             streak=0
             for i in $(seq 1 12); do
+              # Wait-then-probe so probes land at t=5..60: the END of the
+              # window is observed, and a crash in the final seconds resets
+              # the streak instead of slipping through unprobed.
+              target=$((start_time + i * 5))
+              now=$(date +%s)
+              delay=$((target - now))
+              [ "$delay" -le 0 ] || sleep "$delay"
+
               now=$(date +%s)
               remaining=$((deadline - now))
-              [ "$remaining" -gt 0 ] || break
-
+              # The final probe lands at the deadline; keep it bounded
+              # (>=5s budget) rather than skipping it.
+              [ "$remaining" -ge 5 ] || remaining=5
               if curl -fsS --connect-timeout 5 --max-time "$remaining" \
                 http://localhost:3600/api/v1/health > /dev/null; then
                 streak=$((streak + 1))
               else
                 streak=0
-              fi
-
-              if [ "$i" -lt 12 ]; then
-                next_probe=$((start_time + i * 5))
-                now=$(date +%s)
-                delay=$((next_probe - now))
-                [ "$delay" -le 0 ] || sleep "$delay"
               fi
             done
             if [ "$streak" -lt 3 ]; then


### PR DESCRIPTION
Port of the review fix applied on the green mirror (#474).

The bounded polling structure merged in #473 probes immediately and then every 5s, so probes land at t=0–55 and the final ~5s of the 60s window is never observed — a process that dies after the t=55 probe still passes with a streak from t=45/50/55.

Switch to wait-then-probe so probes land at t=5–60; the final probe lands at the deadline with a bounded (>=5s) budget. Streak semantics unchanged.

**Validation:** ran the extracted loop against a mock health server — healthy path passes 12/12 in ~59s; a server that dies at t=52 resets the streak and fails the gate (exit 1). YAML parse of all three workflows passes.