### PR TITLE
fix(migrations): make quiz_answer_user_scoped idempotent for green-history DBs

### DIFF
--- a/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
+++ b/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
@@ -1,9 +1,24 @@
+-- Guarded rewrite: green (develop-v1.2.0) databases already have all of these
+-- objects from 20260314011049_make_question_answer_kid_optional, so the
+-- original unguarded statements fail there (42701 duplicate column — the dev
+-- P3009 incident). Every statement is idempotent so this applies cleanly on
+-- green-history DBs, fresh DBs, and half-applied DBs alike.
+
 -- AlterTable
-ALTER TABLE "question_answers" ADD COLUMN     "userId" TEXT,
-ALTER COLUMN "kidId" DROP NOT NULL;
+ALTER TABLE "question_answers" ADD COLUMN IF NOT EXISTS "userId" TEXT;
+ALTER TABLE "question_answers" ALTER COLUMN "kidId" DROP NOT NULL;
 
 -- CreateIndex
-CREATE INDEX "question_answers_userId_idx" ON "question_answers"("userId");
+CREATE INDEX IF NOT EXISTS "question_answers_userId_idx" ON "question_answers"("userId");
 
 -- AddForeignKey
-ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'question_answers_userId_fkey'
+      AND conrelid = '"question_answers"'::regclass
+  ) THEN
+    ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
+++ b/prisma/migrations/20260725224929_quiz_answer_user_scoped/migration.sql
@@ -17,6 +17,7 @@ DO $$ BEGIN
     SELECT 1 FROM pg_constraint
     WHERE conname = 'question_answers_userId_fkey'
       AND conrelid = '"question_answers"'::regclass
+      AND contype = 'f'
   ) THEN
     ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_userId_fkey"
       FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
First item of the blue→promotion migration remediation.

## Problem

Green databases (staging, prod — and dev before it was manually resolved) already contain every object `20260725224929_quiz_answer_user_scoped` creates, via green's `20260314011049_make_question_answer_kid_optional`. The unguarded `ADD COLUMN` fails with 42701, records the migration as failed, and P3009-locks every subsequent `migrate deploy` — this is exactly what blocked all dev deploys Jul 25–31, and it would repeat on staging and prod during promotion.

## Fix

Guard every statement so the migration is idempotent:
- `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`
- FK wrapped in a `DO $$` block checking `pg_constraint` scoped by `conrelid = '"question_answers"'::regclass` (constraint-name-only checks can match another schema on a shared server)

Rewriting an already-applied migration is safe here: `prisma migrate deploy` does not re-verify checksums of applied migrations.

## Verification (rolled-back transactions on the dev RDS)

- **Green-history schema** (`storytime_dev.storytime`): applies with zero errors, pure no-op.
- **Fresh schema simulation**: creates the column, drops the NOT NULL, creates the index and the FK — end state identical to the original migration.

## Remaining remediation (separate decisions, not in this PR)

- Three green-only objects blue's schema dropped (`UNIQUE(userId, questionId)`, `question_answers_owner_check`, activity-log index) need an intentional keep-or-drop decision.
- Optional: guard the `CREATE TYPE "DevicePlatform"` in `20260717171216` the same way.
- Staging/prod pre-check before deploy: `SELECT DISTINCT platform FROM device_tokens;` must be only ios/android/web/NULL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of quiz answer data updates during database upgrades.
  * Preserved existing quiz answer relationships and cascade behavior while applying schema changes safely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->