### PR TITLE
fix(voice): restore guest access + green auth throttles

### DIFF
--- a/src/shared/config/throttle.config.ts
+++ b/src/shared/config/throttle.config.ts
@@ -1,10 +1,12 @@
 import { ThrottlerModuleOptions } from '@nestjs/throttler';
 
 export const THROTTLE_LIMITS = {
-  // Authentication - strict
-  AUTH_LOGIN: { ttl: 60000, limit: 10 },
+  // Authentication - strict (green parity: login 3/min, register 3/hour —
+  // the looser 10/min + 5/min values undermined multi-account/trial-farming
+  // abuse controls)
+  AUTH_LOGIN: { ttl: 60000, limit: 3 },
   AUTH_OTP: { ttl: 60000, limit: 5 },
-  AUTH_REGISTER: { ttl: 60000, limit: 5 },
+  AUTH_REGISTER: { ttl: 3600000, limit: 3 },
   AUTH_PASSWORD_RESET: { ttl: 60000, limit: 3 },
 
   // Resource creation - moderate

--- a/src/voice/voice.controller.spec.ts
+++ b/src/voice/voice.controller.spec.ts
@@ -12,6 +12,8 @@ import { TextToSpeechService } from '../story/text-to-speech.service';
 import { SpeechToTextService } from './speech-to-text.service';
 import { VoiceQuotaService } from './voice-quota.service';
 import { TtsBatchQueueService } from './queue/tts-batch-queue.service';
+import { StoryQuotaService } from '../story/story-quota.service';
+import { GuestSessionService } from '@/guest/guest-session.service';
 
 const mockVoiceService = {
   listVoices: jest.fn(),
@@ -29,10 +31,21 @@ const mockSpeechToTextService = {};
 const mockVoiceQuotaService = {
   canUseVoice: jest.fn().mockResolvedValue(true),
   getVoiceAccess: jest.fn(),
+  resolveCanonicalVoiceId: jest.fn((v: string) => Promise.resolve(v)),
 };
 const mockTtsBatchQueueService = {
   queueBatch: jest.fn(),
   getBatchStatus: jest.fn(),
+};
+const mockStoryQuotaService = {
+  checkStoryAccess: jest
+    .fn()
+    .mockResolvedValue({ canAccess: true, reason: 'premium' }),
+  recordNewStoryAccess: jest.fn(),
+};
+const mockGuestSessionService = {
+  getGuestSession: jest.fn(),
+  recordNewStoryAccess: jest.fn(),
 };
 
 describe('VoiceController', () => {
@@ -57,6 +70,8 @@ describe('VoiceController', () => {
           provide: TtsBatchQueueService,
           useValue: mockTtsBatchQueueService,
         },
+        { provide: StoryQuotaService, useValue: mockStoryQuotaService },
+        { provide: GuestSessionService, useValue: mockGuestSessionService },
       ],
     })
       .overrideGuard(AuthSessionGuard)

--- a/src/voice/voice.controller.ts
+++ b/src/voice/voice.controller.ts
@@ -1,14 +1,17 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   ForbiddenException,
   Get,
+  Headers,
   NotFoundException,
   Param,
   Patch,
   Post,
   Query,
   Req,
+  UnauthorizedException,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -32,6 +35,10 @@ import {
   AuthSessionGuard,
   AuthenticatedRequest,
 } from '@/shared/guards/auth.guard';
+import { OptionalAuth } from '@/shared/decorators/optional-auth.decorator';
+import { FREE_TIER_LIMITS } from '@/shared/constants/free-tier.constants';
+import { GuestSessionService } from '@/guest/guest-session.service';
+import { StoryQuotaService } from '../story/story-quota.service';
 import { StoryService } from '../story/story.service';
 import { UploadService } from '../upload/upload.service';
 import { TextToSpeechService } from '../story/text-to-speech.service';
@@ -54,14 +61,45 @@ import { EAGER_PARAGRAPH_COUNT } from './queue/tts-batch-queue.constants';
 export class VoiceController {
   private readonly logger = new Logger(VoiceController.name);
 
+  /**
+   * Resolves the user ID from the request, preferring authenticated users
+   * and falling back to guest session ID.
+   * @throws BadRequestException if required credentials are missing
+   */
+  private resolveRequesterUserId(
+    req: AuthenticatedRequest,
+    guestSessionId?: string,
+  ): { userId: string; isGuest: boolean } {
+    const isGuest = !req.authUserData;
+    let userId: string;
+
+    if (isGuest) {
+      if (!guestSessionId) {
+        throw new BadRequestException(
+          'x-guest-session-id header is required for guest requests',
+        );
+      }
+      userId = guestSessionId;
+    } else {
+      if (!req.authUserData?.userId) {
+        throw new BadRequestException('Authenticated user missing userId');
+      }
+      userId = req.authUserData.userId;
+    }
+
+    return { userId, isGuest };
+  }
+
   constructor(
     private readonly voiceService: VoiceService,
     private readonly storyService: StoryService,
+    private readonly storyQuotaService: StoryQuotaService,
     private readonly uploadService: UploadService,
     private readonly textToSpeechService: TextToSpeechService,
     private readonly speechToTextService: SpeechToTextService,
     private readonly voiceQuotaService: VoiceQuotaService,
     private readonly ttsBatchQueueService: TtsBatchQueueService,
+    private readonly guestSessionService: GuestSessionService,
   ) {}
 
   @Post('upload')
@@ -206,6 +244,7 @@ export class VoiceController {
 
   // --- Get voice access status ---
   @Get('access')
+  @OptionalAuth()
   @UseGuards(AuthSessionGuard)
   @ApiBearerAuth()
   @ApiOperation({
@@ -248,20 +287,34 @@ export class VoiceController {
     @Req() req: AuthenticatedRequest,
     @Query('storyId') storyId?: string,
   ) {
+    const userId = req.authUserData?.userId;
+
+    // For guests, return default access info before any DB lookups
+    if (!userId) {
+      return {
+        isPremium: false,
+        unlimited: false,
+        defaultVoice: FREE_TIER_LIMITS.VOICES.DEFAULT_VOICE,
+        maxVoices: 1,
+        lockedVoiceId: FREE_TIER_LIMITS.VOICES.DEFAULT_VOICE,
+        elevenLabsTrialStoryId: null,
+        usedVoicesForStory: [],
+        maxVoicesPerStory: 1,
+      };
+    }
+
     if (storyId) {
       const story = await this.storyService.getStoryById(storyId);
       if (!story) {
         throw new NotFoundException(`Story ${storyId} not found`);
       }
     }
-    return this.voiceQuotaService.getVoiceAccess(
-      req.authUserData.userId,
-      storyId,
-    );
+    return this.voiceQuotaService.getVoiceAccess(userId, storyId);
   }
 
   // --- List available ElevenLabs voices ---
   @Get('available')
+  @OptionalAuth()
   @UseGuards(AuthSessionGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List all available ElevenLabs voices' })
@@ -272,8 +325,9 @@ export class VoiceController {
   // --- Text to Speech ---
 
   @Post('story/audio/batch')
+  @OptionalAuth()
   @UseGuards(AuthSessionGuard)
-  @Throttle({ short: { limit: 3, ttl: 60_000 } })
+  @Throttle({ short: { limit: 10, ttl: 60_000 } })
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate audio for all paragraphs of a story' })
   @ApiResponse({
@@ -338,21 +392,92 @@ export class VoiceController {
   async batchTextToSpeech(
     @Body() dto: BatchStoryAudioDto,
     @Req() req: AuthenticatedRequest,
+    @Headers('x-guest-session-id') guestSessionId?: string,
   ) {
-    const resolvedVoice = dto.voiceId ?? DEFAULT_VOICE;
-    const canUse = await this.voiceQuotaService.canUseVoice(
-      req.authUserData.userId,
-      resolvedVoice,
+    const { userId, isGuest } = this.resolveRequesterUserId(
+      req,
+      guestSessionId,
     );
-    if (!canUse) {
-      throw new ForbiddenException(
-        'You do not have access to this voice. Upgrade to premium to unlock all voices.',
+
+    const resolvedVoice = dto.voiceId ?? DEFAULT_VOICE;
+
+    if (isGuest) {
+      // Guests may only use the default voice; compare canonical IDs so
+      // aliases of the default voice are accepted.
+      const defaultCanonical =
+        await this.voiceQuotaService.resolveCanonicalVoiceId(DEFAULT_VOICE);
+      const requestedCanonical = dto.voiceId
+        ? await this.voiceQuotaService.resolveCanonicalVoiceId(dto.voiceId)
+        : defaultCanonical;
+
+      if (requestedCanonical !== defaultCanonical) {
+        this.logger.warn(
+          `Guest user tried to use voice: ${dto.voiceId} (canonical: ${requestedCanonical}), only ${DEFAULT_VOICE} allowed`,
+        );
+        throw new ForbiddenException(
+          'Guest users can only use the default voice. Sign in to access all voices.',
+        );
+      }
+
+      // Validate guest session existence before loading the story
+      const session = await this.guestSessionService.getGuestSession(userId);
+      if (!session) {
+        throw new UnauthorizedException('Invalid or expired guest session');
+      }
+    } else {
+      const canUse = await this.voiceQuotaService.canUseVoice(
+        userId,
+        resolvedVoice,
       );
+      if (!canUse) {
+        throw new ForbiddenException(
+          'You do not have access to this voice. Upgrade to premium to unlock all voices.',
+        );
+      }
     }
 
     const story = await this.storyService.getStoryById(dto.storyId);
     if (!story || !story.textContent) {
       throw new NotFoundException('Story not found or has no content.');
+    }
+
+    // Story quota check for authenticated users
+    if (!isGuest) {
+      const storyAccess = await this.storyQuotaService.checkStoryAccess(
+        userId,
+        dto.storyId,
+      );
+      if (!storyAccess.canAccess) {
+        throw new ForbiddenException(
+          'You have reached your story limit. Upgrade to premium for unlimited stories!',
+        );
+      }
+      if (
+        storyAccess.reason !== 'already_read' &&
+        storyAccess.reason !== 'premium' &&
+        storyAccess.reason !== 'kid_created'
+      ) {
+        await this.storyQuotaService.recordNewStoryAccess(userId, dto.storyId);
+      }
+    }
+
+    // Guest access validation: check session, story, and quota atomically
+    if (isGuest) {
+      const accessResult = await this.guestSessionService.recordNewStoryAccess(
+        userId,
+        dto.storyId,
+      );
+      if (!accessResult.recorded) {
+        if (accessResult.reason === 'session_not_found') {
+          throw new UnauthorizedException('Invalid or expired guest session');
+        }
+        if (accessResult.reason === 'quota_exceeded') {
+          throw new ForbiddenException(
+            'You have reached your story limit. Sign up to continue reading!',
+          );
+        }
+        // 'already_read' → proceed
+      }
     }
 
     const {
@@ -369,7 +494,7 @@ export class VoiceController {
       dto.storyId,
       story.textContent,
       resolvedVoice,
-      req.authUserData.userId,
+      isGuest ? undefined : userId,
       EAGER_PARAGRAPH_COUNT,
     );
 
@@ -382,8 +507,8 @@ export class VoiceController {
         batchJobId = await this.ttsBatchQueueService.queueBatch({
           storyId: dto.storyId,
           voiceId: resolvedVoice,
-          userId: req.authUserData.userId,
-          isPremium,
+          userId,
+          isPremium: isGuest ? false : isPremium,
           provider: batchProvider,
           paragraphs: remainingUncached,
           totalParagraphs,
@@ -428,6 +553,7 @@ export class VoiceController {
   }
 
   @Get('story/audio/batch/status/:batchJobId')
+  @OptionalAuth()
   @UseGuards(AuthSessionGuard)
   @Throttle({ short: { limit: 30, ttl: 60_000 } })
   @ApiBearerAuth()
@@ -440,10 +566,13 @@ export class VoiceController {
   async getBatchStatus(
     @Param('batchJobId', ParseUUIDPipe) batchJobId: string,
     @Req() req: AuthenticatedRequest,
+    @Headers('x-guest-session-id') guestSessionId?: string,
   ) {
+    const { userId } = this.resolveRequesterUserId(req, guestSessionId);
+
     const status = await this.ttsBatchQueueService.getBatchStatus(
       batchJobId,
-      req.authUserData.userId,
+      userId,
     );
 
     if (!status) {

--- a/src/voice/voice.module.ts
+++ b/src/voice/voice.module.ts
@@ -6,6 +6,7 @@ import { StoryModule } from '../story/story.module';
 import { SubscriptionModule } from '../subscription/subscription.module';
 import { UploadModule } from '../upload/upload.module';
 import { NotificationModule } from '../notification/notification.module';
+import { GuestModule } from '../guest/guest.module';
 import { TextToSpeechService } from '../story/text-to-speech.service';
 import { VoiceController } from './voice.controller';
 import { VoiceService } from './voice.service';
@@ -51,6 +52,7 @@ import {
     UploadModule,
     NotificationModule,
     forwardRef(() => StoryModule),
+    forwardRef(() => GuestModule),
     BullModule.registerQueue({ name: TTS_BATCH_QUEUE_NAME }),
   ],
   controllers: [VoiceController],


### PR DESCRIPTION
Second item from the promotion audit (first: #476).

## Voice guest access (same regression class as #472)

The voice controller refactor dropped everything guest-related that green (`develop-v1.2.0`) has:

- `@OptionalAuth()` on **GET /voice/access**, **GET /voice/available**, **POST /voice/story/audio/batch**, **GET /voice/story/audio/batch/status/:batchJobId** — guests were getting 401 on all four (verified live: green 200 vs blue 401 on `/voice/access`)
- `resolveRequesterUserId` + `x-guest-session-id` handling, the guest default-voice restriction (canonical-ID comparison), guest session validation, and atomic guest story access/quota recording in the TTS batch flow
- the **authenticated story-quota check** in the batch flow — on blue, auth users could generate full story audio without consuming story quota
- batch throttle restored 3 → 10/min (green parity)

`GuestModule` wired into `VoiceModule` with `forwardRef` (mirrors the StoryModule edge; no class-level DI cycle).

## Auth throttle restore

`throttle.config.ts` had quietly loosened green's limits:
- `AUTH_LOGIN`: 10/min → restored to **3/min**
- `AUTH_REGISTER`: 5/min (=300/hour) → restored to **3/hour** — the loosened value directly undermined the multi-account/trial-farming abuse controls

The throttles blue *added* over green (google/apple/refresh/OTP/password-reset) are kept.

## Verification

- `nest build` clean; `voice.controller.spec.ts` 9/9 pass (spec updated with `StoryQuotaService`/`GuestSessionService` mocks)
- Guest handlers mirror green's logic statement-for-statement, adapted to blue's `DEFAULT_VOICE`/canonical-ID resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guest access for voice and batch text-to-speech features using a guest session.
  * Guest access uses the default voice, free-tier settings, and dedicated story quotas.
  * Batch processing and status checks now support optional authentication and guest sessions.
* **Improvements**
  * Increased batch text-to-speech limit to 10 requests per minute.
  * Tightened authentication throttling for login and registration.
  * OTP request limits remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->