### PR TITLE
feat: green-parity port batch (P2–P9 from promotion audit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'ci'

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -1,0 +1,188 @@
+name: malware-scan
+
+# Least privilege: this scanner only needs to read the repo.
+permissions:
+  contents: read
+
+# Guards against npm/PyPI supply-chain compromise:
+#  - on every push / PR: fast check for the global['!'] JS-injector marker + payloads disguised as fonts
+#  - weekly (and on demand): deep scan with Cobenian/shai-hulud-detect
+#
+# The deep scan exits non-zero on ANY finding, and many of its broad content
+# heuristics false-positive on legitimate AI / crypto / analytics SDKs (e.g. an
+# audio SDK's OpenAPI mock fixtures embedding REST paths that a PyPI-malware C2
+# heuristic also greps for). So we run the scanner for its data (--json), then
+# gate ourselves: a curated allowlist drops verified known-good false positives,
+# the build fails only on UNRESOLVED HIGH findings, and medium/low are reported
+# as advisory. Suppression requires BOTH a package-path AND the benign reason to
+# match, so a genuinely malicious package (hash match, compromised-package list,
+# or a real IOC string) is never silenced and will still fail the build.
+#
+# NOTE: allowlist reasons must NOT contain the detector's literal IOC search
+# strings (C2 domains/paths, beacon tokens) — the deep scan reads this very file
+# and would flag it. Match indicator *families* by prefix instead of pasting the
+# raw IOC here.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'   # Mondays 03:00 UTC
+
+jobs:
+  injector-check:
+    name: global['!'] injector + disguised-font check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Scan working tree
+        run: |
+          set -uo pipefail
+          MARK="global['!']"
+          hits=$(grep -rlF "$MARK" . \
+            --include='*.js' --include='*.mjs' --include='*.cjs' \
+            --include='*.ts' --include='*.tsx' --include='*.jsx' \
+            --include='*.json' --include='*.vue' --include='*.svelte' \
+            --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null || true)
+          fonts=$(find . -name '*.woff2' -not -path '*/node_modules/*' -not -path '*/.git/*' \
+            -exec grep -lF "$MARK" {} + 2>/dev/null || true)
+          if [ -n "${hits}${fonts}" ]; then
+            echo "::error::Malware indicators found (global['!'] injector / disguised font):"
+            [ -n "$hits" ] && printf '%s\n' "$hits"
+            [ -n "$fonts" ] && printf '%s\n' "$fonts"
+            exit 1
+          fi
+          echo "Clean — no global['!'] injector marker or disguised fonts."
+
+  shai-hulud-deep:
+    name: shai-hulud-detect (weekly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install dependencies (best effort, no lifecycle scripts)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable && (pnpm install --frozen-lockfile --ignore-scripts || pnpm install --ignore-scripts || true)
+          elif [ -f package-lock.json ]; then
+            npm ci --ignore-scripts || npm install --ignore-scripts || true
+          elif [ -f yarn.lock ]; then
+            corepack enable && (yarn install --immutable --mode=skip-builds || yarn install --ignore-scripts || true)
+          fi
+      - name: Run shai-hulud-detect (pinned commit)
+        run: |
+          set -euo pipefail
+          # Fail closed: a stale findings.json must never satisfy the check below.
+          rm -f findings.json findings.log
+          # With set -e a failed clone/checkout aborts the step (good — we must not
+          # silently skip the scan).
+          git clone --quiet https://github.com/Cobenian/shai-hulud-detect.git /tmp/shd
+          git -C /tmp/shd checkout --quiet 353143a915d63e95e9a3ab1112d95f7692729a0e
+          # The detector exits non-zero on any finding; we gate ourselves on the
+          # JSON below, so its exit code alone must not abort the step.
+          if ! bash /tmp/shd/shai-hulud-detector.sh --json findings.json --save-log findings.log .; then
+            echo "shai-hulud-detect exited non-zero (findings present); continuing to triage its JSON."
+          fi
+          if [ ! -f findings.json ]; then
+            echo "::error::shai-hulud-detect produced no findings.json — the scan failed to run."
+            exit 1
+          fi
+      - name: Triage findings (allowlist verified false positives, gate on HIGH)
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Verified known-good false positives (reviewed 2026-07-06).
+          # Each rule is "<path-substring>|<reason-glob>". A finding is suppressed
+          # ONLY when the file path contains <path-substring> AND the message
+          # matches <reason-glob> (shell glob; a trailing * matches an indicator
+          # family). The reason is the FP signature itself, so a real compromise
+          # of the same package (hash match / compromised-package / a different
+          # IOC family) has a different message and is never silenced — even when
+          # it shares the package and the HIGH severity.
+          #
+          # durabletask is a PyPI (Python) compromise; its C2 "reference" heuristic
+          # greps ALL files for generic REST-ish paths (leading-slash strings such
+          # as an API's /models or /audio route) that legitimately appear across
+          # many JS/TS API-SDK fixtures (elevenlabs, etc.). We ship no Python /
+          # durabletask dependency, so a leading-slash C2 "reference" is always a
+          # false positive here — matched globally (empty path scope) so a new SDK
+          # or a version bump can't reopen it. The SPECIFIC IOCs remain blocking:
+          # the C2 *domain*, beacon tokens, the stage-2 payload filename, and any
+          # hash / compromised-package match all have messages that do NOT start
+          # with "durabletask C2 reference (/", so none are suppressed. Matching
+          # the "(/*" shape (not the raw paths) also keeps the detector's literal
+          # IOC strings out of this file, so the scan can't flag its own config.
+          ALLOW=(
+            '|durabletask C2 reference (/*'
+            "/formdata-polyfill/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
+            "/@amplitude/analytics-core/|XMLHttpRequest prototype modification detected - MEDIUM RISK"
+            "/@noble/ed25519/|Ethereum wallet address patterns detected"
+            "/@faker-js/faker/|Ethereum wallet address patterns detected"
+          )
+
+          # Fail closed if the detector JSON is missing/malformed — never treat a
+          # broken scan as "no findings".
+          if ! jq -e 'type=="object" and (.findings|type=="array")' findings.json >/dev/null 2>&1; then
+            echo "::error::shai-hulud-detect JSON has no top-level findings array — failing closed."
+            exit 1
+          fi
+          jq -r '.findings[] | [(.severity // ""), (.file // ""), (.message // "")] | @tsv' findings.json > all.tsv
+
+          : > remaining.tsv
+          sup=0
+          while IFS=$'\t' read -r sev file msg; do
+            [ -z "${sev:-}" ] && continue
+            matched=no
+            for rule in "${ALLOW[@]}"; do
+              p="${rule%%|*}"; m="${rule#*|}"
+              # $m is an unquoted glob: exact rules (no metachars) still match
+              # literally; a trailing * matches an indicator family.
+              # shellcheck disable=SC2053
+              if [[ "$file" == *"$p"* && "$msg" == $m ]]; then matched=yes; break; fi
+            done
+            if [ "$matched" = yes ]; then
+              sup=$((sup+1))
+            else
+              printf '%s\t%s\t%s\n' "$sev" "$file" "$msg" >> remaining.tsv
+            fi
+          done < all.tsv
+
+          high=$(awk -F'\t' 'tolower($1)=="high"{c++} END{print c+0}' remaining.tsv)
+          med=$(awk -F'\t'  'tolower($1)=="medium"{c++} END{print c+0}' remaining.tsv)
+          low=$(awk -F'\t'  'tolower($1)=="low"{c++} END{print c+0}' remaining.tsv)
+
+          {
+            echo "## Malware scan (shai-hulud-detect)"
+            echo ""
+            echo "| Severity | Count (after allowlist) |"
+            echo "|---|---|"
+            echo "| 🔴 High (blocking) | $high |"
+            echo "| 🟡 Medium (advisory) | $med |"
+            echo "| ⚪ Low (advisory) | $low |"
+            echo "| ✅ Suppressed (verified false positives) | $sup |"
+            echo ""
+            if [ "$high" -gt 0 ]; then
+              echo "### 🔴 Unresolved HIGH findings — build failed"
+              echo '```'
+              awk -F'\t' 'tolower($1)=="high"{print $2" — "$3}' remaining.tsv
+              echo '```'
+            fi
+            if [ "$med" -gt 0 ] || [ "$low" -gt 0 ]; then
+              echo "### Advisory (non-blocking)"
+              echo '```'
+              awk -F'\t' 'tolower($1)=="medium"||tolower($1)=="low"{print toupper($1)": "$2" — "$3}' remaining.tsv
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+          if [ "$high" -gt 0 ]; then
+            echo "::error::$high unresolved HIGH-risk malware indicator(s) — review the job summary."
+            exit 1
+          fi
+          echo "OK — no unresolved high-risk indicators (medium=$med low=$low suppressed=$sup)."

--- a/prisma/migrations/20260804000000_add_question_answer_kid_question_index/migration.sql
+++ b/prisma/migrations/20260804000000_add_question_answer_kid_question_index/migration.sql
@@ -1,0 +1,13 @@
+-- Serve the hasKidAnswered(kidId, questionId) lookup in
+-- PrismaQuestionAnswerRepository. The table only indexed those columns
+-- separately (plus the composite (kidId, answeredAt)), so the first-answer
+-- check degrades as answer history grows.
+--
+-- Deliberately NOT unique: blue records every answer as a new row, so a kid
+-- may answer the same question more than once. See
+-- 20260802000000_reconcile_green_history_objects, which drops green's
+-- UNIQUE(userId, questionId) for the same reason.
+--
+-- Guarded so it no-ops on databases where it already exists.
+CREATE INDEX IF NOT EXISTS "question_answers_kidId_questionId_idx"
+  ON "question_answers"("kidId", "questionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -934,6 +934,9 @@ model QuestionAnswer {
   @@index([questionId])
   @@index([storyId])
   @@index([kidId, answeredAt])
+  // Non-unique on purpose: blue allows a kid to re-answer a question, so this
+  // only serves the hasKidAnswered(kidId, questionId) lookup.
+  @@index([kidId, questionId])
   @@index([isDeleted])
   @@map("question_answers")
 }

--- a/src/achievement-progress/badge-progress.engine.ts
+++ b/src/achievement-progress/badge-progress.engine.ts
@@ -107,6 +107,34 @@ export class BadgeProgressEngine implements OnModuleInit {
     }
   }
 
+  /**
+   * Whether badge progress for this kid's answer to `questionId` was already
+   * recorded. `recordActivity` swallows its own failures, so callers cannot
+   * detect a badge write that died after the answer was persisted; this reads
+   * the activity log it writes, letting a later attempt re-run the badge path
+   * instead of skipping it forever.
+   */
+  async hasRecordedQuizAnswer(
+    kidId: string,
+    questionId: string,
+  ): Promise<boolean> {
+    try {
+      return await this.streakRepository.hasKidActivityForQuestion(
+        kidId,
+        'quiz_answered',
+        questionId,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Failed to check recorded quiz activity for kid ${kidId}, question ${questionId}; assuming already recorded: ${message}`,
+      );
+      // Fail closed: on an unreadable marker prefer skipping the badge over
+      // awarding it repeatedly, which is the farming risk this guards.
+      return true;
+    }
+  }
+
   @OnEvent('story.completed')
   async handleStoryCompleted(event: BadgeEvent) {
     this.logger.log(`Story completed event: ${event.userId}`);

--- a/src/achievement-progress/repositories/prisma-streak.repository.ts
+++ b/src/achievement-progress/repositories/prisma-streak.repository.ts
@@ -69,4 +69,23 @@ export class PrismaStreakRepository implements IStreakRepository {
       select: { createdAt: true },
     });
   }
+
+  async hasKidActivityForQuestion(
+    kidId: string,
+    action: string,
+    questionId: string,
+  ): Promise<boolean> {
+    // `details` stores JSON.stringify(metadata), so match the questionId field
+    // inside it. questionId is a UUID, so a substring match cannot collide with
+    // another id, and `contains` is order-independent across metadata keys.
+    const existing = await this.prisma.activityLog.findFirst({
+      where: {
+        kidId,
+        action,
+        details: { contains: `"questionId":"${questionId}"` },
+      },
+      select: { id: true },
+    });
+    return existing !== null;
+  }
 }

--- a/src/achievement-progress/repositories/streak.repository.interface.ts
+++ b/src/achievement-progress/repositories/streak.repository.interface.ts
@@ -31,6 +31,15 @@ export interface IStreakRepository {
 
   // Find the most recent activity log for a kid
   findLastKidActivity(kidId: string): Promise<ActivityLogCreatedAt | null>;
+
+  // Whether an activity log already records `action` for this kid and question.
+  // Used as the durable marker that badge progress was actually recorded, so a
+  // run that died after persisting the answer can self-heal on a later attempt.
+  hasKidActivityForQuestion(
+    kidId: string,
+    action: string,
+    questionId: string,
+  ): Promise<boolean>;
 }
 
 export const STREAK_REPOSITORY = Symbol('STREAK_REPOSITORY');

--- a/src/auth/services/onboarding.service.ts
+++ b/src/auth/services/onboarding.service.ts
@@ -92,6 +92,17 @@ export class OnboardingService {
       registeredAt: user.createdAt,
     } satisfies UserRegisteredEvent);
 
+    // Feed the superadmin live dashboard (green parity: the LOGIN emitter
+    // survived the refactor but the SIGNUP one was dropped, so new-user
+    // activity and stats never reached the admin SSE stream).
+    this.eventEmitter.emit('admin.sse.activity', {
+      type: 'SIGNUP',
+      userId: user.id,
+      email: user.email,
+      timestamp: new Date().toISOString(),
+    });
+    this.eventEmitter.emit('admin.sse.stats', { trigger: 'user_created' });
+
     const tokenData = await this.tokenService.createTokenPair(user);
 
     return {

--- a/src/guest/guest-session.service.ts
+++ b/src/guest/guest-session.service.ts
@@ -106,16 +106,27 @@ export class GuestSessionService implements OnModuleInit {
   async onModuleInit(): Promise<void> {
     let redisKeyv: Keyv | undefined;
     try {
-      redisKeyv = new Keyv({
-        store: new KeyvRedis(this.redisUrl, { throwOnConnectError: true }),
+      // throwOnConnectError:false lets the underlying node-redis client
+      // reconnect on a transient socket close (e.g. Redis' `timeout` idle
+      // disconnect) instead of throwing. A throw here would surface as an
+      // unhandled error and crash the whole process (this was the cause of an
+      // intermittent crash-loop on green).
+      const store = new KeyvRedis(this.redisUrl, {
+        throwOnConnectError: false,
       });
-      // Keep an 'error' listener so redis client errors never become an
-      // unhandled 'error' event (which would crash the process).
-      redisKeyv.on('error', (err) => {
-        this.logger.error(
-          `Guest session Redis error: ${(err as Error)?.message ?? err}`,
+
+      // The node-redis client's own errors MUST always have a listener, or a
+      // socket close is emitted as an unhandled 'error' and crashes the
+      // process. Log it and let node-redis auto-reconnect; do not tear down
+      // the shared store on a transient blip.
+      store.on('error', (err: Error) => {
+        this.logger.warn(
+          `Guest-session Redis store error (auto-reconnecting): ${err?.message ?? err}`,
         );
       });
+
+      redisKeyv = new Keyv({ store });
+      this.attachKeyvErrorHandler(redisKeyv);
 
       const probeKey = `${GUEST_SESSION_PREFIX}__healthcheck__`;
       await redisKeyv.set(probeKey, '1', 10_000);
@@ -147,11 +158,23 @@ export class GuestSessionService implements OnModuleInit {
   }
 
   private createMemoryKeyv(): Keyv {
-    return new Keyv({
+    const keyv = new Keyv({
       store: new CacheableMemory({
         ttl: GUEST_SESSION_TTL_MS,
         lruSize: 1000,
       }),
+    });
+    this.attachKeyvErrorHandler(keyv);
+    return keyv;
+  }
+
+  /**
+   * Keyv is an EventEmitter and an 'error' event with no listener throws
+   * (crashing the process). Always attach a handler.
+   */
+  private attachKeyvErrorHandler(keyv: Keyv): void {
+    keyv.on('error', (err: Error) => {
+      this.logger.warn(`Guest-session cache error: ${err?.message ?? err}`);
     });
   }
 

--- a/src/notification/notification.registry.ts
+++ b/src/notification/notification.registry.ts
@@ -152,6 +152,7 @@ export const NotificationRegistry: Record<
     subject: 'New Story Available!',
     validate: (data) => {
       if (!data.storyTitle) return 'Story title is required';
+      if (!data.storyId) return 'Story id is required';
       return null;
     },
     getTemplate: (data) => {

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -105,10 +105,25 @@ export class ReportsService {
       // Checked BEFORE persisting the new row: re-answers are allowed (every
       // attempt is stored) but only the first answer to a question may advance
       // badge progress — otherwise badges can be farmed by re-answering.
+      // This indexed lookup is the fast path for the common first-answer case.
       isFirstKidAnswer = !(await this.questionAnswerRepository.hasKidAnswered(
         dto.kidId,
         dto.questionId,
       ));
+
+      // An answer row alone is not proof the badge was recorded: recordActivity
+      // below swallows its failures, so a previous attempt could have persisted
+      // the answer and then lost the badge write. Fall back to the durable
+      // badge marker so that attempt self-heals instead of being skipped
+      // forever. Only runs on re-answers, and once the marker exists the badge
+      // is never advanced again, so re-answer farming stays blocked.
+      if (!isFirstKidAnswer) {
+        isFirstKidAnswer =
+          !(await this.badgeProgressEngine.hasRecordedQuizAnswer(
+            dto.kidId,
+            dto.questionId,
+          ));
+      }
     }
 
     const answer = await this.questionAnswerRepository.createAnswer({

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -91,6 +91,7 @@ export class ReportsService {
     // Kid attribution requires an authenticated parent who owns the kid —
     // otherwise anyone could persist answers (and advance badge progress)
     // against an arbitrary kidId.
+    let isFirstKidAnswer = false;
     if (dto.kidId) {
       if (!userId) {
         throw new UnauthorizedException(
@@ -101,6 +102,13 @@ export class ReportsService {
       if (!kid || kid.parentId !== userId) {
         throw new ForbiddenException('Kid does not belong to this user');
       }
+      // Checked BEFORE persisting the new row: re-answers are allowed (every
+      // attempt is stored) but only the first answer to a question may advance
+      // badge progress — otherwise badges can be farmed by re-answering.
+      isFirstKidAnswer = !(await this.questionAnswerRepository.hasKidAnswered(
+        dto.kidId,
+        dto.questionId,
+      ));
     }
 
     const answer = await this.questionAnswerRepository.createAnswer({
@@ -114,18 +122,16 @@ export class ReportsService {
       isCorrect,
     });
 
-    // Badge progress is kid-scoped — only advance it for kid-attributed answers.
-    if (dto.kidId) {
-      const kid = await this.kidRepository.findParentIdByKidId(dto.kidId);
-
-      if (kid?.parentId) {
-        await this.badgeProgressEngine.recordActivity(
-          kid.parentId,
-          'quiz_answered',
-          dto.kidId,
-          { questionId: dto.questionId, isCorrect },
-        );
-      }
+    // Badge progress is kid-scoped — only advance it for kid-attributed
+    // answers, and only for the kid's FIRST answer to this question.
+    // Ownership was validated above, so the parent is the authenticated user.
+    if (dto.kidId && userId && isFirstKidAnswer) {
+      await this.badgeProgressEngine.recordActivity(
+        userId,
+        'quiz_answered',
+        dto.kidId,
+        { questionId: dto.questionId, isCorrect },
+      );
     }
 
     return {

--- a/src/reports/repositories/prisma-question-answer.repository.ts
+++ b/src/reports/repositories/prisma-question-answer.repository.ts
@@ -35,4 +35,12 @@ export class PrismaQuestionAnswerRepository
       },
     });
   }
+
+  async hasKidAnswered(kidId: string, questionId: string): Promise<boolean> {
+    const existing = await this.prisma.questionAnswer.findFirst({
+      where: { kidId, questionId },
+      select: { id: true },
+    });
+    return existing !== null;
+  }
 }

--- a/src/reports/repositories/question-answer.repository.interface.ts
+++ b/src/reports/repositories/question-answer.repository.interface.ts
@@ -14,6 +14,9 @@ export interface IQuestionAnswerRepository {
 
   // Find all answers for a kid answered on/after the given date
   findAnswersByKidSince(kidId: string, since: Date): Promise<QuestionAnswer[]>;
+
+  // Whether the kid has already answered this question (any attempt)
+  hasKidAnswered(kidId: string, questionId: string): Promise<boolean>;
 }
 
 export const QUESTION_ANSWER_REPOSITORY = Symbol('QUESTION_ANSWER_REPOSITORY');

--- a/src/story/story-core.controller.ts
+++ b/src/story/story-core.controller.ts
@@ -202,16 +202,24 @@ export class StoryCoreController {
     const { cursor: safeCursor, limit: safeLimit } =
       PaginationUtil.sanitizeCursorParams(cursor, limitParam);
 
+    // Seasonal requests are ordered by season recency, which cursor pagination
+    // (createdAt/id only) cannot reproduce, so they fall back to offset mode.
+    const seasonalOrdering =
+      cursor !== undefined
+        ? await this.storyService.usesSeasonalOrdering(baseFilter)
+        : false;
+
     const useCursorMode =
       cursor !== undefined &&
       topPicksFromUs !== 'true' &&
       isMostLiked !== 'true' &&
       recommended !== 'true' &&
-      shuffle !== 'true';
+      shuffle !== 'true' &&
+      !seasonalOrdering;
 
     if (cursor !== undefined && !useCursorMode) {
       this.logger.warn(
-        `Cursor pagination ignored: cursor="${cursor}" bypassed because topPicksFromUs=${topPicksFromUs}, isMostLiked=${isMostLiked}, recommended=${recommended}, shuffle=${shuffle}. Falling back to offset pagination.`,
+        `Cursor pagination ignored: cursor="${cursor}" bypassed because topPicksFromUs=${topPicksFromUs}, isMostLiked=${isMostLiked}, recommended=${recommended}, shuffle=${shuffle}, seasonalOrdering=${seasonalOrdering}. Falling back to offset pagination.`,
       );
     }
 

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -200,6 +200,27 @@ export class StoryFeedService {
     return { where, recommendedStoryIds };
   }
 
+  /**
+   * Whether a request is ordered by season recency (active seasons first, then
+   * most recently ended) rather than the default `createdAt`/`id` ordering. The
+   * Holiday/Seasonal category behaves like `isSeasonal` for ordering purposes.
+   *
+   * Cursor pagination orders only by `createdAt`/`id`, so callers must route
+   * seasonal requests through offset pagination to keep page boundaries stable.
+   */
+  async usesSeasonalOrdering(filter: {
+    category?: string;
+    isSeasonal?: boolean;
+  }): Promise<boolean> {
+    if (filter.isSeasonal) return true;
+    if (!filter.category) return false;
+
+    const [category] = await this.storyRepository.findCategoriesByIds([
+      filter.category,
+    ]);
+    return category?.name === this.CATEGORY_HOLIDAY_SEASONAL;
+  }
+
   async getStories(filter: {
     userId?: string;
     guestSessionId?: string;
@@ -224,18 +245,7 @@ export class StoryFeedService {
 
     const { where } = await this.buildStoryWhereClause(filter);
 
-    // Seasonal requests are ordered by season recency (active seasons first,
-    // then most recently ended). The Holiday/Seasonal category behaves like
-    // isSeasonal for ordering purposes.
-    let shouldSortBySeason = !!filter.isSeasonal;
-    if (filter.category && !shouldSortBySeason) {
-      const [category] = await this.storyRepository.findCategoriesByIds([
-        filter.category,
-      ]);
-      if (category?.name === this.CATEGORY_HOLIDAY_SEASONAL) {
-        shouldSortBySeason = true;
-      }
-    }
+    const shouldSortBySeason = await this.usesSeasonalOrdering(filter);
 
     // Shuffle only applies on page 1 (home screen carousels).
     // Beyond page 1 (paginated "See All"), disable shuffle to avoid overlapping pages.
@@ -583,7 +593,7 @@ export class StoryFeedService {
       } else {
         isActive = currentDateStr >= s.startDate && currentDateStr <= s.endDate;
       }
-      if (isActive) return -1;
+      if (s.isActive && isActive) return -1;
 
       const [endMonth, endDay] = s.endDate.split('-').map(Number);
       const thisYearEnd = new Date(today.getFullYear(), endMonth - 1, endDay);
@@ -603,17 +613,18 @@ export class StoryFeedService {
       return diffDays;
     };
 
-    allSeasons.sort((a, b) => getScore(a) - getScore(b));
-    const rankMap = new Map(allSeasons.map((s, idx) => [s.id, idx]));
+    const scoreMap = new Map<string, number>(
+      allSeasons.map((s): [string, number] => [s.id, getScore(s)]),
+    );
 
     stories.sort((a, b) => {
-      const rankA = a.seasons?.length
-        ? Math.min(...a.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
+      const scoreA = a.seasons?.length
+        ? Math.min(...a.seasons.map((s) => scoreMap.get(s.id) ?? Infinity))
         : Infinity;
-      const rankB = b.seasons?.length
-        ? Math.min(...b.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
+      const scoreB = b.seasons?.length
+        ? Math.min(...b.seasons.map((s) => scoreMap.get(s.id) ?? Infinity))
         : Infinity;
-      return rankA - rankB;
+      return scoreA === scoreB ? 0 : scoreA - scoreB;
     });
   }
 

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -6,7 +6,7 @@ import {
   PaginatedStoriesDto,
   CursorPaginatedStoriesDto,
 } from './dto/story.dto';
-import { Category, Story } from '@prisma/client';
+import { Category, Season, Story } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import {
   BadRequestException,
@@ -224,6 +224,19 @@ export class StoryFeedService {
 
     const { where } = await this.buildStoryWhereClause(filter);
 
+    // Seasonal requests are ordered by season recency (active seasons first,
+    // then most recently ended). The Holiday/Seasonal category behaves like
+    // isSeasonal for ordering purposes.
+    let shouldSortBySeason = !!filter.isSeasonal;
+    if (filter.category && !shouldSortBySeason) {
+      const [category] = await this.storyRepository.findCategoriesByIds([
+        filter.category,
+      ]);
+      if (category?.name === this.CATEGORY_HOLIDAY_SEASONAL) {
+        shouldSortBySeason = true;
+      }
+    }
+
     // Shuffle only applies on page 1 (home screen carousels).
     // Beyond page 1 (paginated "See All"), disable shuffle to avoid overlapping pages.
     const shouldShuffle = filter.shuffle === true && page === 1;
@@ -261,13 +274,16 @@ export class StoryFeedService {
 
     // Run count and findMany in parallel to reduce latency by ~50%
     // For topPicksFromUs, pagination is handled in the raw SQL query
-    const [totalCount, stories] = await Promise.all([
+    const [totalCount, queriedStories] = await Promise.all([
       filter.topPicksFromUs
         ? this.storyRepository.countStoriesRaw({ isDeleted: false })
         : this.storyRepository.countStoriesRaw(where),
       this.storyRepository.findManyStoriesRaw({
         where,
-        ...(filter.topPicksFromUs
+        // Season-recency ordering must rank the full result set before
+        // paginating, so skip/take are applied after the sort (as with
+        // topPicksFromUs, whose pagination happens in the raw id query).
+        ...(filter.topPicksFromUs || shouldSortBySeason
           ? {}
           : {
               skip,
@@ -290,6 +306,12 @@ export class StoryFeedService {
         },
       }),
     ]);
+
+    let stories = queriedStories;
+    if (shouldSortBySeason) {
+      await this.sortStoriesBySeasonRecency(stories);
+      stories = stories.slice(skip, skip + limit);
+    }
 
     const totalPages = Math.ceil(totalCount / limit);
 
@@ -529,6 +551,69 @@ export class StoryFeedService {
         ...story,
         readStatus: deriveReadStatus(progress?.progress, progress?.completed),
       };
+    });
+  }
+
+  private readonly CATEGORY_HOLIDAY_SEASONAL = 'Holiday/Seasonal';
+
+  /**
+   * Order stories in place by season recency: stories in currently-active
+   * seasons first, then by how recently their season ended (most recent
+   * first). Stories with no season rank last.
+   */
+  private async sortStoriesBySeasonRecency(
+    stories: Array<{ seasons?: Array<{ id: string }>; [key: string]: unknown }>,
+  ) {
+    const allSeasons = await this.storyRepository.findManySeasonsRaw({
+      where: { isDeleted: false },
+    });
+
+    const today = new Date();
+    const currentMonth = today.getMonth() + 1; // 1-12
+    const currentDay = today.getDate(); // 1-31
+    const currentDateStr = `${currentMonth
+      .toString()
+      .padStart(2, '0')}-${currentDay.toString().padStart(2, '0')}`;
+
+    const getScore = (s: Season) => {
+      if (!s.startDate || !s.endDate) return Infinity;
+      let isActive = false;
+      if (s.startDate > s.endDate) {
+        isActive = currentDateStr >= s.startDate || currentDateStr <= s.endDate;
+      } else {
+        isActive = currentDateStr >= s.startDate && currentDateStr <= s.endDate;
+      }
+      if (isActive) return -1;
+
+      const [endMonth, endDay] = s.endDate.split('-').map(Number);
+      const thisYearEnd = new Date(today.getFullYear(), endMonth - 1, endDay);
+      const diffTime = today.getTime() - thisYearEnd.getTime();
+      let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+      if (diffDays < 0) {
+        const lastYearEnd = new Date(
+          today.getFullYear() - 1,
+          endMonth - 1,
+          endDay,
+        );
+        diffDays = Math.ceil(
+          (today.getTime() - lastYearEnd.getTime()) / (1000 * 60 * 60 * 24),
+        );
+      }
+      return diffDays;
+    };
+
+    allSeasons.sort((a, b) => getScore(a) - getScore(b));
+    const rankMap = new Map(allSeasons.map((s, idx) => [s.id, idx]));
+
+    stories.sort((a, b) => {
+      const rankA = a.seasons?.length
+        ? Math.min(...a.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
+        : Infinity;
+      const rankB = b.seasons?.length
+        ? Math.min(...b.seasons.map((s) => rankMap.get(s.id) ?? Infinity))
+        : Infinity;
+      return rankA - rankB;
     });
   }
 

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -161,6 +161,13 @@ export class StoryService {
     return this.storyFeedService.getStoriesCursor(filter);
   }
 
+  async usesSeasonalOrdering(filter: {
+    category?: string;
+    isSeasonal?: boolean;
+  }): Promise<boolean> {
+    return this.storyFeedService.usesSeasonalOrdering(filter);
+  }
+
   async getHomePageStories(
     userId: string | undefined,
     limitRecommended: number = 5,

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -8,7 +8,11 @@ import {
 import { Role } from '@prisma/client';
 import { SUBSCRIPTION_STATUS, PLANS } from './subscription.constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { AppEvents, SubscriptionCancelledEvent } from '@/shared/events';
+import {
+  AppEvents,
+  SubscriptionCancelledEvent,
+  SubscriptionCreatedEvent,
+} from '@/shared/events';
 import { CACHE_KEYS } from '@/shared/constants/cache-keys.constants';
 import { CacheMetricsService } from '@/shared/services/cache-metrics.service';
 import {
@@ -107,6 +111,21 @@ export class SubscriptionService {
 
     // Invalidate cache after subscription change
     await this.invalidateCache(userId);
+
+    // Tell the user their subscription is active (green parity: green emitted
+    // a SubscriptionAlert here; blue routes activation through the
+    // SUBSCRIPTION_CREATED -> SubscriptionWelcome pipeline instead). The paid
+    // path notifies from PaymentService.verifyPurchase; this covers the free
+    // plan path, which was silent.
+    const createdEvent: SubscriptionCreatedEvent = {
+      subscriptionId: subscription.id,
+      userId,
+      planId: planKey,
+      planName: plan.display,
+      provider: 'internal',
+      createdAt: now,
+    };
+    this.eventEmitter.emit(AppEvents.SUBSCRIPTION_CREATED, createdEvent);
 
     return { subscription };
   }

--- a/src/voice/queue/tts-batch-queue.service.spec.ts
+++ b/src/voice/queue/tts-batch-queue.service.spec.ts
@@ -1,0 +1,49 @@
+import { TtsBatchQueueService } from './tts-batch-queue.service';
+import { TtsBatchJobData } from './tts-batch-job.interface';
+
+const makePipeline = () => {
+  const pipeline = {
+    hset: jest.fn().mockReturnThis(),
+    sadd: jest.fn().mockReturnThis(),
+    srem: jest.fn().mockReturnThis(),
+    expire: jest.fn().mockReturnThis(),
+    del: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([]),
+  };
+  return pipeline;
+};
+
+describe('TtsBatchQueueService', () => {
+  let queue: { add: jest.Mock };
+  let redis: { pipeline: jest.Mock; del: jest.Mock; quit: jest.Mock };
+  let service: TtsBatchQueueService;
+
+  beforeEach(() => {
+    queue = { add: jest.fn().mockResolvedValue(undefined) };
+    redis = {
+      pipeline: jest.fn(() => makePipeline()),
+      del: jest.fn().mockResolvedValue(undefined),
+      quit: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new TtsBatchQueueService(queue as never, redis as never);
+  });
+
+  const original: TtsBatchJobData = {
+    batchJobId: 'batch-abc',
+    storyId: 'story-1',
+    voiceId: 'voice-1',
+    userId: 'user-1',
+    isPremium: false,
+    provider: 'elevenlabs',
+    paragraphs: [{ index: 0, text: 'hi', hash: 'h0' }],
+    totalParagraphs: 1,
+  };
+
+  it('builds a retry job id without the reserved BullMQ colon separator', async () => {
+    await service.queueRetryBatch(original, original.paragraphs, 1);
+
+    const addOptions = queue.add.mock.calls[0][2];
+    expect(addOptions.jobId).not.toContain(':');
+    expect(addOptions.jobId).toBe('batch-abc-retry-1');
+  });
+});

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -117,11 +117,25 @@ export class TtsBatchQueueService implements OnModuleDestroy {
     const metaKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:meta`;
     const completedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:completed`;
     const failedKey = `${TTS_BATCH_REDIS_PREFIX}:${batchJobId}:failed`;
-    const pipeline = this.redis.pipeline();
-    pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
-    pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
-    pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
-    await pipeline.exec();
+    // The retry job is durably enqueued above, so a TTL-refresh failure must NOT
+    // propagate: the caller treats a throw from this method as "retry was never
+    // scheduled" and fails the batch terminally (emitting a failure SSE) even
+    // though the delayed job would still run. Worst case the status keys expire
+    // on their original TTL and polling clients lose the snapshot, which the
+    // aggregate-state read already tolerates.
+    try {
+      const pipeline = this.redis.pipeline();
+      pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
+      pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
+      pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
+      await pipeline.exec();
+    } catch (ttlErr) {
+      this.logger.warn(
+        `TTS batch retry ${batchJobId} (generation ${generation}) was enqueued, but refreshing Redis TTLs failed: ${
+          ttlErr instanceof Error ? ttlErr.message : String(ttlErr)
+        }`,
+      );
+    }
 
     this.logger.log(
       `TTS batch retry queued: ${batchJobId} (generation ${generation}) — ${failedParagraphs.length} paragraph(s), delay ${TTS_BATCH_RETRY_DELAY_MS}ms`,

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -106,7 +106,10 @@ export class TtsBatchQueueService implements OnModuleDestroy {
       jobData,
       {
         ...TTS_BATCH_QUEUE_OPTIONS,
-        jobId: `${batchJobId}:retry:${generation}`,
+        // BullMQ (>=5.61) rejects ':' in custom job IDs — it is the reserved
+        // internal key separator — so use hyphens or the enqueue throws and the
+        // retry is never scheduled.
+        jobId: `${batchJobId}-retry-${generation}`,
         delay: TTS_BATCH_RETRY_DELAY_MS,
       },
     );

--- a/src/voice/queue/tts-batch-queue.service.ts
+++ b/src/voice/queue/tts-batch-queue.service.ts
@@ -128,7 +128,12 @@ export class TtsBatchQueueService implements OnModuleDestroy {
       pipeline.expire(metaKey, TTS_BATCH_REDIS_TTL);
       pipeline.expire(completedKey, TTS_BATCH_REDIS_TTL);
       pipeline.expire(failedKey, TTS_BATCH_REDIS_TTL);
-      await pipeline.exec();
+      // ioredis resolves exec() with one [error, result] tuple per command, so
+      // an EXPIRE that failed does NOT reject — surface the first command error
+      // to the catch below rather than silently reporting success.
+      const results = await pipeline.exec();
+      const commandError = results?.find(([error]) => error)?.[0];
+      if (commandError) throw commandError;
     } catch (ttlErr) {
       this.logger.warn(
         `TTS batch retry ${batchJobId} (generation ${generation}) was enqueued, but refreshing Redis TTLs failed: ${

--- a/src/voice/queue/tts-batch.processor.spec.ts
+++ b/src/voice/queue/tts-batch.processor.spec.ts
@@ -174,4 +174,38 @@ describe('TtsBatchProcessor', () => {
       expect(jobEvents.emitFailed).not.toHaveBeenCalled();
     });
   });
+
+  describe('transient-only retry', () => {
+    it('does NOT retry the same provider on a non-transient (4xx) error', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 400 });
+
+      const result = await processor.process(makeJob({ totalParagraphs: 1 }));
+
+      // 3 providers in the chain, one attempt each — no same-provider retries.
+      expect(ttsService.generateSingleParagraphTTS).toHaveBeenCalledTimes(3);
+      expect(result.failedCount).toBe(1);
+    });
+
+    it('retries the same provider on a transient (5xx) error', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 503 });
+
+      await processor.process(makeJob({ totalParagraphs: 1 }));
+
+      // 3 providers x 2 attempts each = 6 calls.
+      expect(ttsService.generateSingleParagraphTTS).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('self-heal scheduling failures', () => {
+    it('propagates a queueRetryBatch failure instead of swallowing it', async () => {
+      ttsService.generateSingleParagraphTTS.mockRejectedValue({ status: 503 });
+      queueService.queueRetryBatch.mockRejectedValue(
+        new Error('redis TTL write failed'),
+      );
+
+      await expect(
+        processor.process(makeJob({ totalParagraphs: 1, retryGeneration: 0 })),
+      ).rejects.toThrow('redis TTL write failed');
+    });
+  });
 });

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -76,18 +76,44 @@ export class TtsBatchProcessor extends WorkerHost {
     }
   }
 
+  /** Extract an HTTP status code from a provider error, if present. */
+  private extractHttpStatus(reason: unknown): number | undefined {
+    if (!reason || typeof reason !== 'object') return undefined;
+    const err = reason as Record<string, unknown>;
+    if (typeof err.status === 'number') return err.status;
+    if (typeof err.statusCode === 'number') return err.statusCode;
+    // Axios errors store status on response.status
+    const response = err.response as Record<string, unknown> | undefined;
+    if (response && typeof response.status === 'number') return response.status;
+    return undefined;
+  }
+
   /** Check if a rejection reason indicates quota/payment exhaustion */
   private isQuotaError(reason: unknown): boolean {
     if (reason instanceof QuotaExhaustedError) return true;
-    if (reason && typeof reason === 'object') {
-      const err = reason as Record<string, unknown>;
-      // Raw HTTP 402 from providers that don't wrap in QuotaExhaustedError
-      if (err.status === 402 || err.statusCode === 402) return true;
-      // Axios errors store status on response.status
-      const response = err.response as Record<string, unknown> | undefined;
-      if (response?.status === 402) return true;
+    return this.extractHttpStatus(reason) === 402;
+  }
+
+  /**
+   * Decide whether an error is worth a same-provider retry. Permanent client
+   * errors — bad auth, invalid/unsupported input, etc. (HTTP 4xx other than
+   * rate-limiting) — will fail identically on retry, so we cascade immediately.
+   * Everything else (network blips, timeouts, 5xx, 429 rate limits, and
+   * unclassified provider errors) is treated as potentially transient. Quota
+   * errors are handled separately by isQuotaError and are never "transient".
+   */
+  private isTransientError(reason: unknown): boolean {
+    if (this.isQuotaError(reason)) return false;
+    const status = this.extractHttpStatus(reason);
+    if (
+      status !== undefined &&
+      status >= 400 &&
+      status < 500 &&
+      status !== 429
+    ) {
+      return false;
     }
-    return false;
+    return true;
   }
 
   /** Resolve duplicate indices for a paragraph from the original job data */
@@ -187,9 +213,21 @@ export class TtsBatchProcessor extends WorkerHost {
               break; // move to the next provider in the chain
             }
 
-            this.metrics.recordAttempt(activeProvider, 'transient_error');
             const errorMessage =
               err instanceof Error ? err.message : String(err);
+
+            if (!this.isTransientError(err)) {
+              // Permanent failure (auth/validation/unsupported input) — a
+              // same-provider retry would fail identically, so skip the backoff
+              // and cascade straight to the next provider.
+              this.metrics.recordAttempt(activeProvider, 'permanent_error');
+              this.logger.warn(
+                `TTS batch ${batchJobId}: non-transient failure on ${activeProvider} for paragraph ${index} — ${errorMessage}; cascading to fallback without retry`,
+              );
+              break; // move to the next provider in the chain
+            }
+
+            this.metrics.recordAttempt(activeProvider, 'transient_error');
             if (attempt < MAX_ATTEMPTS_PER_PROVIDER) {
               this.logger.warn(
                 `TTS batch ${batchJobId}: transient failure on ${activeProvider} for paragraph ${index} (attempt ${attempt}/${MAX_ATTEMPTS_PER_PROVIDER}) — ${errorMessage}; retrying`,
@@ -311,10 +349,15 @@ export class TtsBatchProcessor extends WorkerHost {
           `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
         );
       } catch (retryErr) {
+        // queueRetryBatch performs Redis TTL writes; if it fails the retry was
+        // NOT safely scheduled. Rethrow so the batch fails loudly instead of
+        // appearing finalized (with a "completed" SSE emit) while paragraphs
+        // silently never self-heal.
         this.logger.error(
           `TTS batch ${batchJobId}: failed to schedule self-heal retry`,
           retryErr,
         );
+        throw retryErr;
       }
     }
 

--- a/src/voice/queue/tts-batch.processor.ts
+++ b/src/voice/queue/tts-batch.processor.ts
@@ -349,10 +349,11 @@ export class TtsBatchProcessor extends WorkerHost {
           `TTS batch ${batchJobId}: scheduled self-heal (generation ${generation + 1}) for ${failedThisRun.length} paragraph(s)`,
         );
       } catch (retryErr) {
-        // queueRetryBatch performs Redis TTL writes; if it fails the retry was
-        // NOT safely scheduled. Rethrow so the batch fails loudly instead of
-        // appearing finalized (with a "completed" SSE emit) while paragraphs
-        // silently never self-heal.
+        // queueRetryBatch only throws when the enqueue itself failed (its
+        // best-effort Redis TTL refresh is caught internally), so reaching here
+        // means the retry was NOT scheduled. Rethrow so the batch fails loudly
+        // instead of appearing finalized (with a "completed" SSE emit) while
+        // paragraphs silently never self-heal.
         this.logger.error(
           `TTS batch ${batchJobId}: failed to schedule self-heal retry`,
           retryErr,

--- a/src/voice/queue/tts-metrics.service.ts
+++ b/src/voice/queue/tts-metrics.service.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { metrics, Counter } from '@opentelemetry/api';
 
 export type TtsProviderName = 'elevenlabs' | 'deepgram' | 'edgetts';
-export type TtsAttemptResult = 'success' | 'quota_error' | 'transient_error';
+export type TtsAttemptResult =
+  | 'success'
+  | 'quota_error'
+  | 'transient_error'
+  | 'permanent_error';
 export type TtsParagraphResult = 'completed' | 'failed';
 
 /**

--- a/src/voice/services/voice-id-resolver.service.ts
+++ b/src/voice/services/voice-id-resolver.service.ts
@@ -1,8 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import {
-  ELEVEN_LABS_TO_VOICE_TYPE,
-  VOICE_CONFIG,
-} from '../voice.constants';
+import { ELEVEN_LABS_TO_VOICE_TYPE, VOICE_CONFIG } from '../voice.constants';
 import { VoiceType, VOICE_TYPE_MIGRATION_MAP } from '../dto/voice.dto';
 import { VOICE_REPOSITORY, IVoiceRepository } from '../repositories';
 

--- a/src/voice/services/voice-id-resolver.service.ts
+++ b/src/voice/services/voice-id-resolver.service.ts
@@ -1,5 +1,8 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { VOICE_CONFIG } from '../voice.constants';
+import {
+  ELEVEN_LABS_TO_VOICE_TYPE,
+  VOICE_CONFIG,
+} from '../voice.constants';
 import { VoiceType, VOICE_TYPE_MIGRATION_MAP } from '../dto/voice.dto';
 import { VOICE_REPOSITORY, IVoiceRepository } from '../repositories';
 
@@ -56,12 +59,11 @@ export class VoiceIdResolverService {
     if (voice) return voice.id;
 
     // Auto-seed from VOICE_CONFIG if this is a known system voice
-    const configEntry = Object.entries(VOICE_CONFIG).find(
-      ([, config]) => config.elevenLabsId === elevenLabsVoiceId,
-    );
-    if (!configEntry) return null;
+    const voiceTypeKey = ELEVEN_LABS_TO_VOICE_TYPE.get(elevenLabsVoiceId);
+    if (!voiceTypeKey) return null;
 
-    const [key, config] = configEntry;
+    const key = voiceTypeKey;
+    const config = VOICE_CONFIG[voiceTypeKey];
     const created = await this.voiceRepository.createVoiceReturningId({
       elevenLabsVoiceId: config.elevenLabsId,
       name: key,

--- a/src/voice/services/voice-response.mapper.ts
+++ b/src/voice/services/voice-response.mapper.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import type { Voice } from '@prisma/client';
 import { VoiceResponseDto, VoiceSourceType } from '../dto/voice.dto';
-import {
-  ELEVEN_LABS_TO_VOICE_TYPE,
-  VOICE_CONFIG,
-} from '../voice.constants';
+import { ELEVEN_LABS_TO_VOICE_TYPE, VOICE_CONFIG } from '../voice.constants';
 
 /**
  * Maps persisted {@link Voice} records to the API-facing {@link VoiceResponseDto}.

--- a/src/voice/services/voice-response.mapper.ts
+++ b/src/voice/services/voice-response.mapper.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import type { Voice } from '@prisma/client';
 import { VoiceResponseDto, VoiceSourceType } from '../dto/voice.dto';
-import { VOICE_CONFIG } from '../voice.constants';
+import {
+  ELEVEN_LABS_TO_VOICE_TYPE,
+  VOICE_CONFIG,
+} from '../voice.constants';
 
 /**
  * Maps persisted {@link Voice} records to the API-facing {@link VoiceResponseDto}.
@@ -14,10 +17,8 @@ export class VoiceResponseMapper {
   // Find the VOICE_CONFIG entry and VoiceType key for a given elevenLabsId.
   findVoiceConfig(elevenLabsId: string | null) {
     if (!elevenLabsId) return undefined;
-    const entry = Object.entries(VOICE_CONFIG).find(
-      ([, config]) => config.elevenLabsId === elevenLabsId,
-    );
-    return entry ? { key: entry[0], config: entry[1] } : undefined;
+    const key = ELEVEN_LABS_TO_VOICE_TYPE.get(elevenLabsId);
+    return key ? { key, config: VOICE_CONFIG[key] } : undefined;
   }
 
   // Resolve DB UUID to VoiceType key so mobile can match against available voices.

--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -2,7 +2,10 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SubscriptionService } from '../subscription/subscription.service';
 import { VOICE_CONFIG_SETTINGS } from './voice.config';
 import { FREE_TIER_LIMITS } from '@/shared/constants/free-tier.constants';
-import { VOICE_CONFIG } from './voice.constants';
+import {
+  ELEVEN_LABS_TO_VOICE_TYPE,
+  VOICE_CONFIG,
+} from './voice.constants';
 import { VoiceType, VOICE_TYPE_MIGRATION_MAP } from './dto/voice.dto';
 import { VoiceUsageService } from './services/voice-usage.service';
 import { VoiceIdResolverService } from './services/voice-id-resolver.service';
@@ -127,11 +130,8 @@ export class VoiceQuotaService {
 
       // UUID or elevenLabsId → look up the elevenLabsId, then find VoiceType key
       const elevenLabsId = uuidToElevenLabs.get(v.voiceId) ?? v.voiceId;
-      const entry = Object.entries(VOICE_CONFIG).find(
-        ([, config]) => config.elevenLabsId === elevenLabsId,
-      );
       // Keep non-system voices in canonical form for downstream comparison
-      return entry ? entry[0] : elevenLabsId;
+      return ELEVEN_LABS_TO_VOICE_TYPE.get(elevenLabsId) ?? elevenLabsId;
     });
 
     return [...new Set(voiceTypeKeys)];
@@ -421,9 +421,7 @@ export class VoiceQuotaService {
       const elevenLabsId = lockedVoice?.elevenLabsVoiceId;
       // Find the VoiceType key whose config matches this elevenLabsId
       const voiceTypeKey = elevenLabsId
-        ? (Object.entries(VOICE_CONFIG).find(
-            ([, config]) => config.elevenLabsId === elevenLabsId,
-          )?.[0] ?? null)
+        ? (ELEVEN_LABS_TO_VOICE_TYPE.get(elevenLabsId) ?? null)
         : null;
 
       // Report the locked voice — free users get ONE voice total

--- a/src/voice/voice-quota.service.ts
+++ b/src/voice/voice-quota.service.ts
@@ -2,10 +2,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SubscriptionService } from '../subscription/subscription.service';
 import { VOICE_CONFIG_SETTINGS } from './voice.config';
 import { FREE_TIER_LIMITS } from '@/shared/constants/free-tier.constants';
-import {
-  ELEVEN_LABS_TO_VOICE_TYPE,
-  VOICE_CONFIG,
-} from './voice.constants';
+import { ELEVEN_LABS_TO_VOICE_TYPE, VOICE_CONFIG } from './voice.constants';
 import { VoiceType, VOICE_TYPE_MIGRATION_MAP } from './dto/voice.dto';
 import { VoiceUsageService } from './services/voice-usage.service';
 import { VoiceIdResolverService } from './services/voice-id-resolver.service';

--- a/src/voice/voice.constants.ts
+++ b/src/voice/voice.constants.ts
@@ -196,3 +196,10 @@ export const VOICE_CONFIG: Record<VoiceType, VoiceConfigEntry> = {
     },
   }),
 };
+
+/** Reverse lookup: elevenLabsId → VoiceType key (built once at module load). */
+export const ELEVEN_LABS_TO_VOICE_TYPE = new Map<string, VoiceType>(
+  (Object.entries(VOICE_CONFIG) as [VoiceType, VoiceConfigEntry][]).map(
+    ([key, config]) => [config.elevenLabsId, key],
+  ),
+);


### PR DESCRIPTION
Ports the small/medium items from the green→blue reverse-parity audit (P1, the fresh-first feed, follows as its own PR).

## Fixes

- **P2 — TTS batch self-heal was broken** (regression, not a missing port): the retry `jobId` used `:` which BullMQ ≥5.61 rejects, so every self-heal enqueue **threw**; the failure was then swallowed and the client received a `completed` SSE while failed paragraphs never healed. Hyphenated job ids, scheduling failures now rethrow, and green's transient/permanent error classifier is reinstated (permanent 4xx cascades providers immediately instead of burning backoff). Green's queue spec + transient-retry/self-heal-propagation processor tests ported; new `permanent_error` metrics label.
- **P3 — badge farming closed**: re-answers remain allowed (blue's design — every attempt stored), but kid badge progress only advances on the **first** answer to a question, checked before the new row is persisted.
- **P4 — subscription activation notice**: free-plan `subscribe()` now emits `SUBSCRIPTION_CREATED`, activating the existing-but-dormant `SubscriptionWelcome` pipeline. Paid path already notified via `verifyPurchase`.
- **P5 — admin live dashboard**: `SIGNUP` activity + stats SSE events restored on registration.
- **P6 — guest Redis store crash-safety**: `throwOnConnectError: false` (node-redis auto-reconnects after idle socket close instead of crashing the process — green's prod incident), error listeners on the raw store, the Keyv wrapper, and the in-memory fallback.
- **P7 — seasonal ordering**: `sortStoriesBySeasonRecency` ported — active seasons first, then most-recently-ended; pagination applied after the sort; Holiday/Seasonal category included.
- **P8 — CI**: `malware-scan.yml` (injector gate + weekly shai-hulud scan with the curated FP allowlist) and `dependabot.yml` copied from green. Triggers are branch-agnostic.
- **P9 — hardening**: `NewStory` registry requires `storyId`; four O(n) `VOICE_CONFIG` scans replaced with a module-load `ELEVEN_LABS_TO_VOICE_TYPE` reverse map. (Green's batched-broadcast spec was NOT ported — blue's `notification-device.topic.spec.ts` already covers dedup/chunk/stagger; watermark webhook tests verified already identical.)

## Validation

Dev-box validation was interrupted (the box is currently down), so **CI is the validation gate for this PR** — Build + Test run on GitHub runners. Voice/TTS spec suites were extended as part of the port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Seasonal and holiday stories are now prioritized by current and recently ended seasons.
  - New registrations and subscriptions trigger timely activity updates.
- **Bug Fixes**
  - Badge progress advances only for a child’s first valid answer.
  - Voice retries, fallback handling, quota detection, and voice identification are more reliable.
  - Guest sessions recover more gracefully from temporary connection issues.
  - Story notifications now require complete story details.
- **Security**
  - Added automated malware scanning for repository changes.
- **Chores**
  - Configured Dependabot for automated dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->