### PR TITLE
fix(errors): port #447 error-message hardening to develop-v1.3.0

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { SuccessResponseInterceptor } from './shared/interceptors/success-respon
 import { HttpExceptionFilter } from './shared/filters/http-exception.filter';
 import { PrismaExceptionFilter } from './shared/filters/prisma-exception.filter';
 import { SentryExceptionFilter } from './shared/filters/sentry-exception.filter';
+import { ThrottlerExceptionFilter } from './shared/filters/throttler-exception.filter';
 import { requestLogger } from './shared/middleware/request-logger.middleware';
 import { swaggerCspDirectives } from './shared/config/security.config';
 import { WinstonModule } from 'nest-winston';
@@ -196,6 +197,10 @@ async function bootstrap() {
 
   // Catch standard NestJS HttpExceptions (handles validation errors, 404s, etc.)
   app.useGlobalFilters(new HttpExceptionFilter());
+  // Registered after HttpExceptionFilter so it takes precedence for
+  // ThrottlerException (429) and returns a clean, premium-aware message
+  // instead of the raw "ThrottlerException: Too Many Requests".
+  app.useGlobalFilters(new ThrottlerExceptionFilter());
 
   // Catch Prisma-specific exceptions and map them to appropriate HTTP responses
   app.useGlobalFilters(new PrismaExceptionFilter(httpAdapter));

--- a/src/shared/filters/http-exception.filter.ts
+++ b/src/shared/filters/http-exception.filter.ts
@@ -67,6 +67,26 @@ export class HttpExceptionFilter implements ExceptionFilter {
       error = HttpStatus[statusCode];
     }
 
+    // Never leak a raw framework exception class name to the client, e.g.
+    // "ThrottlerException: Too Many Requests" — strip the "SomeException:"
+    // prefix so users see a plain message.
+    const stripExceptionPrefix = (m: string): string =>
+      m.replace(/^[A-Z][A-Za-z0-9]*Exception:\s*/, '');
+    if (typeof message === 'string') {
+      message = stripExceptionPrefix(message);
+    } else if (Array.isArray(message)) {
+      message = message.map((m) =>
+        typeof m === 'string' ? stripExceptionPrefix(m) : m,
+      );
+    }
+
+    // Friendly, actionable copy for rate limiting (the dedicated
+    // ThrottlerExceptionFilter provides a premium-aware variant when it wins;
+    // this is the safety net so a 429 is never a raw framework string).
+    if (statusCode === HttpStatus.TOO_MANY_REQUESTS) {
+      message = 'Too many requests. Please wait a moment and try again.';
+    }
+
     // Log the error for debugging purposes (excluding 400s/404s which are expected client errors)
     if (statusCode >= 500) {
       // Report server-side failures to Sentry (no-op when Sentry is disabled).

--- a/src/shared/filters/throttler-exception.filter.ts
+++ b/src/shared/filters/throttler-exception.filter.ts
@@ -10,11 +10,16 @@ export class ThrottlerExceptionFilter implements ExceptionFilter {
 
     const isPremium = request.authUserData?.isPremium;
 
+    // Keep the shape consistent with the standard error envelope
+    // (statusCode/success/error/message/path/timestamp) so clients get a
+    // uniform, human-readable error instead of a raw framework string.
     response.status(429).json({
       statusCode: 429,
+      success: false,
+      error: 'Too Many Requests',
       message: isPremium
-        ? 'Rate limit exceeded. Please try again in a few moments.'
-        : 'Rate limit exceeded. Upgrade to premium for higher limits.',
+        ? 'You’ve made too many requests. Please wait a moment and try again.'
+        : 'You’ve made too many requests. Please wait a moment and try again, or upgrade to premium for higher limits.',
       upgradeUrl: '/subscription/plans',
       timestamp: new Date().toISOString(),
       path: request.url,


### PR DESCRIPTION
Port of #447 (merged to develop-v1.2.0) — the bug exists on this line too: `ThrottlerExceptionFilter` was never registered in `main.ts`, so 429s leaked the raw `ThrottlerException: Too Many Requests` string via the generic `HttpExceptionFilter`.

Clean cherry-pick of 5aa5729 apart from a trivial import conflict with this line's `SentryExceptionFilter` import (both kept; the filter registration order — Sentry → Http → Throttler → Prisma — merged cleanly).

- Register `ThrottlerExceptionFilter` globally (after `HttpExceptionFilter`, so it takes precedence for 429s); response aligned with the standard error envelope.
- Harden `HttpExceptionFilter`: strip any `SomeException:` class prefix, plain actionable 429 copy.

Validated locally: `pnpm build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit error responses with clearer, more user-friendly messaging.
  * Added consistent failure indicators and “Too Many Requests” error details.
  * Ensured throttling responses take precedence and retain relevant status, timestamp, path, and upgrade information.
  * Cleaned up technical exception prefixes from displayed error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->