### PR TITLE
ci(security): catch config-file injection the marker grep missed

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -57,6 +57,37 @@ jobs:
           fi
           echo "Clean — no global['!'] injector marker or disguised fonts."
 
+      # Marker-agnostic backstop for the injector above. The 2026-08 org-wide
+      # incident used this same worm family but MUTATED its marker (global.o=
+      # instead of global['!']), so the literal-string grep missed it. Auto-run
+      # config files (jest/postcss/next/babel/metro/tailwind/vite/nuxt) are the
+      # injection target and must stay small + unobfuscated; detect the injection
+      # structurally rather than by a specific marker string.
+      - name: Config-file injection check
+        run: |
+          set -uo pipefail
+          mapfile -t configs < <(find . \( -path '*/node_modules/*' -o -path '*/.git/*' \) -prune -o \
+            -type f \( -name 'jest.config.*' -o -name 'postcss.config.*' -o -name 'next.config.*' \
+              -o -name 'babel.config.*' -o -name 'metro.config.*' -o -name 'tailwind.config.*' \
+              -o -name 'vite.config.*' -o -name 'nuxt.config.*' \) -print 2>/dev/null)
+          bad=""
+          for f in "${configs[@]}"; do
+            # (a) an obfuscated blob is a single absurdly long line; real configs never are
+            if ! awk '{ if (length($0) > 500) exit 1 }' "$f"; then
+              bad="${bad}${f}: obfuscated blob (>500-char line)\n"; continue
+            fi
+            # (b) require-hook / char-code obfuscation hallmarks of the stager
+            if grep -qE "String\.fromCharCode\(|global\[[^]]+\][[:space:]]*=[[:space:]]*require|global\.[A-Za-z_\$][A-Za-z0-9_\$]*[[:space:]]*=[[:space:]]*require|_\\\$_def|_\\\$jso" "$f"; then
+              bad="${bad}${f}: require-hook / char-code obfuscation\n"
+            fi
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::Config-file code injection detected (auto-run config poisoned):"
+            printf '%b' "$bad"
+            exit 1
+          fi
+          echo "Clean — auto-run config files are unobfuscated."
+
   shai-hulud-deep:
     name: shai-hulud-detect (weekly)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Closes the malware-scan gap exposed by the 2026-08 org-wide incident.

## The gap
`injector-check` greps for the literal marker `global['!']`. The worm that wiped every repo used the **same family but a mutated marker** (`global.o=`), so the grep never fired and the poisoned push showed a ✅ scan.

## The fix
A marker-agnostic backstop step in the same per-push job: scan the auto-run config files (`jest`/`postcss`/`next`/`babel`/`metro`/`tailwind`/`vite`/`nuxt`.config.*) and fail on **structural** injection hallmarks — a single >500-char line (the obfuscated blob) or `require`-hook / `String.fromCharCode` obfuscation. Marker-independent, so future marker mutations still trip it.

Verified: **detects the real incident sample** (the poisoned `jest.config.js`); **no false positive** on the clean configs. Uses no `${{ }}` interpolation (no injection surface).

Needs replicating to the other 5 repos' `malware-scan.yml` — especially `storytime_superadmin`/`fe`/`waitlist-*`, which (being private on a plan without rulesets) have **no branch protection** and rely on this scan as their primary defense.