### PR TITLE
ci: promote develop-v1.3.0 to the dev deploy line; retire blue auto-deploy

### DIFF
--- a/.github/workflows/blue-deploy.yml
+++ b/.github/workflows/blue-deploy.yml
@@ -8,24 +8,15 @@ name: Blue Deploy (develop-v1.3.0)
 # Reuses the existing EC2_* secrets and the green ENV_FILE secret — blue's .env
 # is derived from ENV_FILE with PORT/DATABASE_URL/REDIS_URL overridden below, and
 # the blue database is created on first deploy. No extra secret required.
-# Auto-deploys blue on every push/merge to develop-v1.3.0. Blue infra (derived
-# .env, storytime_db_blue, nginx block, PM2 app on :3601) is in place, so the
-# push trigger is enabled. workflow_dispatch is kept for manual re-runs (note:
-# it only registers on GitHub once this file reaches the default branch; the
-# push trigger works from develop-v1.3.0 directly).
+#
+# PROMOTION (2026-08): develop-v1.3.0 is now the default/primary line and
+# deploys to dev.api / storytime_dev via dev-deploy.yml. The separate blue env
+# (:3601 / storytime_db_blue) is being retired, so the automatic push trigger is
+# REMOVED to keep a single writer on storytime_dev. This workflow is kept as
+# workflow_dispatch-only for manual re-runs during the transition; delete it
+# once the :3601 footprint is torn down (Phase D).
 on:
   workflow_dispatch:
-  push:
-    branches: ['develop-v1.3.0']
-    # Skip a blue redeploy when a push touches ONLY non-runtime files (docs,
-    # Grafana dashboard JSON, prometheus config). If a push also changes any
-    # other file, the deploy still runs. Use workflow_dispatch to force a deploy
-    # for a docs-only change if ever needed.
-    paths-ignore:
-      - '**/*.md'
-      - 'monitoring/**'
-      - 'docs/**'
-      - 'LICENSE'
 
 concurrency:
   group: blue-deploy

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,6 +1,9 @@
 name: Dev CI/CD Pipeline
 
 on:
+  # Manual trigger for a controlled first cutover deploy (run it after taking
+  # the storytime_dev RDS snapshot) and for ad-hoc redeploys.
+  workflow_dispatch:
   pull_request:
     branches: ['develop-v*']
     types: [opened, synchronize, closed]
@@ -245,7 +248,9 @@ jobs:
     name: Auto-fix Formatting
     runs-on: ubuntu-latest
     needs: [quality]
-    if: github.event.action != 'closed'
+    # PRs only: relies on head_ref to check out and push the fix commit, which is
+    # empty on workflow_dispatch (would try to commit to an empty branch).
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     timeout-minutes: 5
     permissions:
       contents: write
@@ -285,12 +290,18 @@ jobs:
   deploy:
     name: Deploy to Dev
     needs: [build, test]
-    # Base-branch gate: the CI jobs above run for PRs to any develop-v* branch,
-    # but only merges into green (develop-v1.2.0) may deploy the shared dev
-    # environment (dev.api / storytime_dev). Blue merges are deployed to their
-    # own environment by blue-deploy.yml; without this gate they also
-    # overwrote green dev and applied blue migrations to storytime_dev.
-    if: success() && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop-v1.2.0'
+    # Base-branch gate: CI jobs above run for PRs to any develop-v* branch, but
+    # only merges into develop-v1.3.0 (now the default/primary line) deploy the
+    # shared dev environment (dev.api / storytime_dev). Green (develop-v1.2.0) is
+    # being retired and no longer deploys dev, so storytime_dev keeps a SINGLE
+    # writer. workflow_dispatch allows a controlled first cutover deploy (run it
+    # after taking the storytime_dev RDS snapshot).
+    if: >-
+      success() &&
+      ( github.event_name == 'workflow_dispatch' ||
+        ( github.event.action == 'closed' &&
+          github.event.pull_request.merged == true &&
+          github.event.pull_request.base.ref == 'develop-v1.3.0' ) )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -447,7 +458,7 @@ jobs:
             echo "Deployment verified successfully"
 
       - name: Comment deployment status
-        if: success()
+        if: success() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -460,7 +471,7 @@ jobs:
             });
 
       - name: Comment deployment failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Phase B of the blue→green promotion (default branch already flipped to develop-v1.3.0). Repoints the **existing, proven** dev pipeline onto the promoted line rather than rewriting blue-deploy.yml — the deploy target (dev.api / storytime_dev, :3500, pnpm deploy:dev, seed, #473 sustained-health gate) is unchanged; only the **source branch** changes.

## Changes
**dev-deploy.yml**: deploy gate base.ref `develop-v1.2.0` → `develop-v1.3.0`; add `workflow_dispatch` for a controlled first cutover deploy (run AFTER the storytime_dev RDS snapshot); guard auto-format + the PR-comment steps to `pull_request` events.
**blue-deploy.yml**: drop the push trigger (workflow_dispatch-only). The separate blue env (:3601 / storytime_db_blue) is retired → SINGLE writer on storytime_dev, avoiding the two-pipelines-one-DB race behind the July P3009 outage.

## Merging this PR does NOT deploy anything
`pull_request` events use the base-branch workflow, so this merge evaluates the OLD gate (base.ref==develop-v1.2.0 → false) and does not deploy. The first cutover is the **next** merge into develop-v1.3.0 (or a manual workflow_dispatch), to be run only after the RDS snapshot + the device_tokens.platform pre-check.

Both workflows parse; no runtime code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment**
  - Blue deployments can now be started manually instead of running automatically on pushes.
  - Development deployments support manual runs and merged pull requests targeting the development branch.
  - Deployment status and failure updates are limited to pull request runs.
  - Automatic formatting no longer runs for closed pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->