### PR TITLE
fix(admin): preserve user search under unpaid filter; whitelist story sort

### DIFF
--- a/src/admin/admin-story.service.ts
+++ b/src/admin/admin-story.service.ts
@@ -64,12 +64,32 @@ export class AdminStoryService {
     if (maxAge) where.ageMax = { lte: maxAge };
     if (categoryId) where.categories = { some: { id: categoryId } };
 
+    // Whitelist sort fields — an arbitrary `sortBy` reaches Prisma's orderBy as
+    // an unknown key and raises a runtime error (500, admin-triggerable DoS).
+    // Mirrors the whitelist in AdminUserService.getAllUsers.
+    const VALID_STORY_SORT_FIELDS = [
+      'createdAt',
+      'updatedAt',
+      'title',
+      'language',
+      'ageMin',
+      'ageMax',
+      'recommended',
+      'aiGenerated',
+    ] as const;
+    const orderBy: Prisma.StoryOrderByWithRelationInput =
+      VALID_STORY_SORT_FIELDS.includes(
+        sortBy as (typeof VALID_STORY_SORT_FIELDS)[number],
+      )
+        ? { [sortBy]: sortOrder }
+        : { createdAt: sortOrder };
+
     const [stories, total] = await Promise.all([
       this.adminStoryRepository.findStories({
         where,
         skip,
         take: limit,
-        orderBy: { [sortBy]: sortOrder },
+        orderBy,
       }),
       this.adminStoryRepository.countStories(where),
     ]);

--- a/src/admin/admin-user.service.ts
+++ b/src/admin/admin-user.service.ts
@@ -86,9 +86,16 @@ export class AdminUserService {
       if (wantsActiveSubscription) {
         where.subscription = activeSubscriptionCriteria;
       } else {
-        where.OR = [
-          { subscription: null },
-          { subscription: { NOT: activeSubscriptionCriteria } },
+        // AND (not OR) so a concurrent `search` — which already set where.OR —
+        // is preserved. Assigning where.OR here previously clobbered the search
+        // filter, so /admin/users/unpaid?search=... silently ignored the search.
+        where.AND = [
+          {
+            OR: [
+              { subscription: null },
+              { subscription: { NOT: activeSubscriptionCriteria } },
+            ],
+          },
         ];
       }
     }


### PR DESCRIPTION
Two correctness bugs from the admin audit, fixed on the live line (develop-v1.3.0).

## 1. `getAllUsers` search clobbered by the unpaid filter
`search` sets `where.OR`; the `hasActiveSubscription=false` branch then **reassigned** `where.OR` with the subscription condition, discarding the search. Net: `GET /admin/users/unpaid?search=...` (and any list combining search + unpaid) **silently ignored the search term**. Fix: apply the subscription condition via `where.AND` so both coexist.

## 2. `getAllStories` un-whitelisted sort → 500 DoS
`orderBy: { [sortBy]: sortOrder }` forwarded arbitrary `sortBy` to Prisma; an unknown column raises a runtime error (HTTP 500 any authenticated admin can trigger, and it probes relation/JSON fields). Fix: whitelist the sort fields (default `createdAt`), mirroring the existing `AdminUserService` whitelist.

`nest build` + eslint clean. No API/response-shape change.

Remaining admin-audit items (separate, need more than a surgical fix): analytics day-grouping (groupBy on raw timestamps → per-transaction not per-day), churn >100% period-scoping, and the honest-metrics items (avgSessionTime/newUsersThisWeek/draftStories placeholders, createBackup no-op) — the last two need session-duration + a story draft/published concept respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved story sorting by safely handling unsupported sort options while preserving the selected sort direction.
  * Fixed user filtering so inactive-subscription filters work correctly alongside search criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->