### PR TITLE
feat(story): fresh-first feed with read backfill (green parity, P1)

### DIFF
--- a/src/story/repositories/prisma-story.repository.ts
+++ b/src/story/repositories/prisma-story.repository.ts
@@ -1122,6 +1122,14 @@ export class PrismaStoryRepository implements IStoryRepository {
     return this.prisma.userStoryProgress.findMany(args);
   }
 
+  async findFirstUserStoryProgressRaw<
+    T extends Prisma.UserStoryProgressFindFirstArgs,
+  >(
+    args: Prisma.SelectSubset<T, Prisma.UserStoryProgressFindFirstArgs>,
+  ): Promise<Prisma.UserStoryProgressGetPayload<T> | null> {
+    return this.prisma.userStoryProgress.findFirst(args);
+  }
+
   async findManyDailyChallengeAssignmentsRaw<
     T extends Prisma.DailyChallengeAssignmentFindManyArgs,
   >(

--- a/src/story/repositories/story.repository.interface.ts
+++ b/src/story/repositories/story.repository.interface.ts
@@ -517,6 +517,12 @@ export interface IStoryRepository {
     args: Prisma.SelectSubset<T, Prisma.UserStoryProgressFindManyArgs>,
   ): Promise<Prisma.UserStoryProgressGetPayload<T>[]>;
 
+  findFirstUserStoryProgressRaw<
+    T extends Prisma.UserStoryProgressFindFirstArgs,
+  >(
+    args: Prisma.SelectSubset<T, Prisma.UserStoryProgressFindFirstArgs>,
+  ): Promise<Prisma.UserStoryProgressGetPayload<T> | null>;
+
   findManyDailyChallengeAssignmentsRaw<
     T extends Prisma.DailyChallengeAssignmentFindManyArgs,
   >(

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -552,13 +552,12 @@ export class StoryFeedService {
     // read stream begins on the next request via the `r:` sentinel cursor.
     const deficit = limit - freshPage.length;
     if (deficit <= 0) {
-      const readProbe = await this.storyRepository.findFirstUserStoryProgressRaw(
-        {
+      const readProbe =
+        await this.storyRepository.findFirstUserStoryProgressRaw({
           where: { userId, isDeleted: false, story: { ...where } },
           orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
           select: { id: true },
-        },
-      );
+        });
       return {
         data: freshEnriched,
         pagination: {
@@ -590,7 +589,9 @@ export class StoryFeedService {
         ...(readEnriched as unknown as Record<string, unknown>[]),
       ] as CursorPaginatedStoriesDto['data'],
       pagination: {
-        nextCursor: readHasNext ? `r:${readPage[readPage.length - 1].id}` : null,
+        nextCursor: readHasNext
+          ? `r:${readPage[readPage.length - 1].id}`
+          : null,
         hasNextPage: readHasNext,
         previousCursor: null,
         hasPreviousPage: !!filter.cursor,

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -31,6 +31,15 @@ export class StoryFeedService {
     private readonly guestSessionService: GuestSessionService,
   ) {}
 
+  private readonly storyListInclude: Prisma.StoryInclude = {
+    images: true,
+    branches: true,
+    categories: true,
+    themes: true,
+    seasons: true,
+    questions: true,
+  };
+
   /** Wraps a Prisma query to handle invalid cursor IDs gracefully */
   private async withCursorErrorHandling<T>(fn: () => Promise<T>): Promise<T> {
     try {
@@ -282,6 +291,13 @@ export class StoryFeedService {
         ]
       : [{ createdAt: 'desc' as const }, { id: 'asc' as const }];
 
+    // Fresh-first: authenticated users fetch FRESH stories only here (no
+    // non-deleted progress row). Read stories are added afterwards as backfill.
+    // Guests get `where` unchanged (byte-for-byte identical responses).
+    // totalCount is still counted on the unfiltered `where` so it reflects the
+    // full result set (fresh + read) and pagination metadata stays correct.
+    const freshWhere = this.withUserReadFilter(where, filter.userId, 'fresh');
+
     // Run count and findMany in parallel to reduce latency by ~50%
     // For topPicksFromUs, pagination is handled in the raw SQL query
     const [totalCount, queriedStories] = await Promise.all([
@@ -289,7 +305,7 @@ export class StoryFeedService {
         ? this.storyRepository.countStoriesRaw({ isDeleted: false })
         : this.storyRepository.countStoriesRaw(where),
       this.storyRepository.findManyStoriesRaw({
-        where,
+        where: freshWhere,
         // Season-recency ordering must rank the full result set before
         // paginating, so skip/take are applied after the sort (as with
         // topPicksFromUs, whose pagination happens in the raw id query).
@@ -373,8 +389,49 @@ export class StoryFeedService {
           }) as typeof sortedStories)
         : sortedStories;
 
+    // Fresh-first backfill (authenticated users only): the page above is drawn
+    // from FRESH stories only. If the fresh pool cannot fill the requested
+    // limit, top up with already-read stories ranked last (most recently
+    // accessed first). For page 1 (and the page-1 carousels) readSkip is 0; for
+    // deeper offset pages we compute how many read rows earlier pages already
+    // consumed via `skip - freshCount` so there is no overlap or gap.
+    let pageData = cleanedStories as unknown as Record<string, unknown>[];
+    if (filter.userId) {
+      const deficit = limit - pageData.length;
+      if (deficit > 0) {
+        // For topPicksFromUs the page is already scoped by a per-page id window
+        // (where.id in randomStoryIds), so applying the global read offset would
+        // skip inside that small window and leave the page short — backfill from
+        // the start of the window instead.
+        const freshCount =
+          !filter.topPicksFromUs && skip > 0
+            ? await this.storyRepository.countStoriesRaw(freshWhere)
+            : 0;
+        const readSkip = filter.topPicksFromUs
+          ? 0
+          : Math.max(0, skip - freshCount);
+        const backfill = await this.fetchReadBackfill(
+          where,
+          filter.userId,
+          readSkip,
+          deficit,
+          this.storyListInclude,
+        );
+        if (backfill.length > 0) {
+          const enrichedBackfill = await this.enrichWithReadStatus(
+            filter.userId,
+            backfill,
+          );
+          pageData = [
+            ...pageData,
+            ...(enrichedBackfill as unknown as Record<string, unknown>[]),
+          ];
+        }
+      }
+    }
+
     return {
-      data: cleanedStories,
+      data: pageData as PaginatedStoriesDto['data'],
       pagination: {
         currentPage: page,
         totalPages,
@@ -403,53 +460,276 @@ export class StoryFeedService {
 
     const orderBy = [{ createdAt: 'desc' as const }, { id: 'asc' as const }];
 
-    const stories = await this.withCursorErrorHandling(() =>
-      this.storyRepository.findManyStoriesRaw({
-        where,
-        take: limit + 1,
-        ...(filter.cursor ? { cursor: { id: filter.cursor }, skip: 1 } : {}),
-        orderBy,
-        include: {
-          images: true,
-          branches: true,
-          categories: true,
-          themes: true,
-          seasons: true,
-          questions: true,
+    // GUEST / PUBLIC PATH — unchanged behaviour (byte-for-byte identical).
+    if (!filter.userId) {
+      const stories = await this.withCursorErrorHandling(() =>
+        this.storyRepository.findManyStoriesRaw({
+          where,
+          take: limit + 1,
+          ...(filter.cursor ? { cursor: { id: filter.cursor }, skip: 1 } : {}),
+          orderBy,
+          include: this.storyListInclude,
+        }),
+      );
+
+      const { data, pagination } = PaginationUtil.buildCursorResponse(
+        stories,
+        limit,
+      );
+
+      const enriched = filter.guestSessionId
+        ? await this.enrichWithGuestReadStatus(filter.guestSessionId, data)
+        : data.map((s) => ({
+            ...s,
+            readStatus: null as 'done' | 'reading' | null,
+          }));
+
+      return {
+        data: this.sortByReadStatus(enriched),
+        pagination: {
+          ...pagination,
+          previousCursor: null,
+          hasPreviousPage: !!filter.cursor,
+          limit,
         },
+      };
+    }
+
+    // AUTHENTICATED PATH — fresh-first with read backfill across a composite
+    // cursor. Format: `r:<progressId>` continues the READ stream; anything else
+    // (a bare story id or `f:<storyId>`, incl. legacy raw cursors) continues the
+    // FRESH stream. Fresh stories are served first; once the fresh pool is
+    // exhausted we backfill with read stories ordered by lastAccessed desc.
+    // NOTE: the cursor stays a single opaque string for the client.
+    const userId = filter.userId;
+    const rawCursor = filter.cursor;
+
+    // READ stream continuation.
+    if (rawCursor?.startsWith('r:')) {
+      const progressCursor = rawCursor.slice(2) || undefined;
+      return this.fetchReadStreamPage(userId, where, progressCursor, limit);
+    }
+
+    // FRESH stream (default / start). Tolerate legacy bare story-id cursors.
+    const freshCursor = rawCursor?.startsWith('f:')
+      ? rawCursor.slice(2) || undefined
+      : rawCursor;
+    const freshWhere = this.withUserReadFilter(where, userId, 'fresh');
+
+    const freshRows = await this.withCursorErrorHandling(() =>
+      this.storyRepository.findManyStoriesRaw({
+        where: freshWhere,
+        take: limit + 1,
+        ...(freshCursor ? { cursor: { id: freshCursor }, skip: 1 } : {}),
+        orderBy,
+        include: this.storyListInclude,
       }),
     );
 
-    const { data, pagination } = PaginationUtil.buildCursorResponse(
-      stories,
-      limit,
-    );
+    const freshHasNext = freshRows.length > limit;
+    const freshPage = freshHasNext ? freshRows.slice(0, limit) : freshRows;
+    const freshEnriched = freshPage.map((s) => ({
+      ...s,
+      readStatus: null as 'done' | 'reading' | null,
+    }));
 
-    // Enrich with read status based on user or guest session
-    let enriched;
-    if (filter.userId) {
-      enriched = await this.enrichWithReadStatus(filter.userId, data);
-    } else if (filter.guestSessionId) {
-      enriched = await this.enrichWithGuestReadStatus(
-        filter.guestSessionId,
-        data,
-      );
-    } else {
-      enriched = data.map((s) => ({
-        ...s,
-        readStatus: null as 'done' | 'reading' | null,
-      }));
+    // Fresh stories still remain — keep serving fresh first.
+    if (freshHasNext) {
+      return {
+        data: freshEnriched,
+        pagination: {
+          nextCursor: `f:${freshPage[freshPage.length - 1].id}`,
+          hasNextPage: true,
+          previousCursor: null,
+          hasPreviousPage: !!filter.cursor,
+          limit,
+        },
+      };
     }
 
+    // Fresh pool exhausted on this page. Backfill the remainder of the page from
+    // the start of the READ stream; if the page is already full, signal that the
+    // read stream begins on the next request via the `r:` sentinel cursor.
+    const deficit = limit - freshPage.length;
+    if (deficit <= 0) {
+      const readProbe = await this.storyRepository.findFirstUserStoryProgressRaw(
+        {
+          where: { userId, isDeleted: false, story: { ...where } },
+          orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+          select: { id: true },
+        },
+      );
+      return {
+        data: freshEnriched,
+        pagination: {
+          nextCursor: readProbe ? 'r:' : null,
+          hasNextPage: !!readProbe,
+          previousCursor: null,
+          hasPreviousPage: !!filter.cursor,
+          limit,
+        },
+      };
+    }
+
+    const readRows = await this.storyRepository.findManyUserStoryProgressRaw({
+      where: { userId, isDeleted: false, story: { ...where } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      take: deficit + 1,
+      include: { story: { include: this.storyListInclude } },
+    });
+    const readHasNext = readRows.length > deficit;
+    const readPage = readHasNext ? readRows.slice(0, deficit) : readRows;
+    const readEnriched = await this.enrichWithReadStatus(
+      userId,
+      readPage.map((r) => r.story as unknown as { id: string }),
+    );
+
     return {
-      data: this.sortByReadStatus(enriched),
+      data: [
+        ...(freshEnriched as unknown as Record<string, unknown>[]),
+        ...(readEnriched as unknown as Record<string, unknown>[]),
+      ] as CursorPaginatedStoriesDto['data'],
       pagination: {
-        ...pagination,
+        nextCursor: readHasNext ? `r:${readPage[readPage.length - 1].id}` : null,
+        hasNextPage: readHasNext,
         previousCursor: null,
         hasPreviousPage: !!filter.cursor,
         limit,
       },
     };
+  }
+
+  /**
+   * Serves a page of the READ stream for the fresh-first cursor pagination.
+   * Records come from the progress join table ordered by lastAccessed desc, so
+   * the cursor is the UserStoryProgress id (prefixed `r:` by the caller).
+   * Only reached with an `r:` cursor, so hasPreviousPage is always true.
+   */
+  private async fetchReadStreamPage(
+    userId: string,
+    baseWhere: Prisma.StoryWhereInput,
+    progressCursor: string | undefined,
+    limit: number,
+  ): Promise<CursorPaginatedStoriesDto> {
+    const rows = await this.withCursorErrorHandling(() =>
+      this.storyRepository.findManyUserStoryProgressRaw({
+        where: { userId, isDeleted: false, story: { ...baseWhere } },
+        orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+        take: limit + 1,
+        ...(progressCursor ? { cursor: { id: progressCursor }, skip: 1 } : {}),
+        include: { story: { include: this.storyListInclude } },
+      }),
+    );
+
+    const hasNextPage = rows.length > limit;
+    const page = hasNextPage ? rows.slice(0, limit) : rows;
+    const enriched = await this.enrichWithReadStatus(
+      userId,
+      page.map((r) => r.story as unknown as { id: string }),
+    );
+
+    return {
+      data: enriched as unknown as CursorPaginatedStoriesDto['data'],
+      pagination: {
+        nextCursor: hasNextPage ? `r:${page[page.length - 1].id}` : null,
+        hasNextPage,
+        previousCursor: null,
+        hasPreviousPage: true,
+        limit,
+      },
+    };
+  }
+
+  /**
+   * Wraps a story `where` clause with a user read/fresh filter at the TOP LEVEL
+   * (AND), so it is never bypassed by the recommended-OR rewrite or the
+   * topPicks `id.in` / restricted `id.notIn` rewrites inside
+   * buildStoryWhereClause. A story counts as "read" when the user has any
+   * non-deleted UserStoryProgress row for it (in-progress OR done); "fresh"
+   * means no such row.
+   *
+   * - mode 'fresh' -> stories the user has NOT read (userProgress none)
+   * - mode 'read'  -> stories the user HAS read (userProgress some)
+   *
+   * Guests / unauthenticated callers (no userId) get the clause back unchanged,
+   * so their responses stay byte-for-byte identical.
+   */
+  private withUserReadFilter(
+    where: Prisma.StoryWhereInput,
+    userId: string | undefined,
+    mode: 'fresh' | 'read',
+  ): Prisma.StoryWhereInput {
+    if (!userId) return where;
+    const relation: Prisma.StoryWhereInput =
+      mode === 'fresh'
+        ? { userProgress: { none: { userId, isDeleted: false } } }
+        : { userProgress: { some: { userId, isDeleted: false } } };
+    return { AND: [where, relation] };
+  }
+
+  /**
+   * Fetches already-read stories for the fresh-first backfill, ranked
+   * most-recently-accessed first. Reads the progress join table so we can order
+   * by `lastAccessed` (not orderable as a Story to-many relation) and returns
+   * the underlying Story rows. `baseWhere` is the catalog filter WITHOUT any
+   * user read filter applied.
+   */
+  private async fetchReadBackfill(
+    baseWhere: Prisma.StoryWhereInput,
+    userId: string,
+    skip: number,
+    take: number,
+    include: Prisma.StoryInclude,
+  ): Promise<Array<{ id: string }>> {
+    if (take <= 0) return [];
+    const rows = await this.storyRepository.findManyUserStoryProgressRaw({
+      where: { userId, isDeleted: false, story: { ...baseWhere } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      ...(skip > 0 ? { skip } : {}),
+      take,
+      include: { story: { include } },
+    });
+    return rows.map((r) => r.story as unknown as { id: string });
+  }
+
+  /**
+   * Tops a fresh section list up to `take` items with already-read stories
+   * (recent first) when there aren't enough fresh ones. Used by the home-page
+   * carousels. Guests (no userId) get the fresh list back unchanged.
+   */
+  private async topUpWithRead<T extends { id: string }>(
+    fresh: T[],
+    baseWhere: Prisma.StoryWhereInput,
+    userId: string | undefined,
+    take: number,
+    include: Prisma.StoryInclude,
+    storyOrderBy?:
+      | Prisma.StoryOrderByWithRelationInput
+      | Prisma.StoryOrderByWithRelationInput[],
+  ): Promise<T[]> {
+    if (!userId) return fresh;
+    const deficit = take - fresh.length;
+    if (deficit <= 0) return fresh;
+    // When the section has a story-level ranking (e.g. most-liked), backfill by
+    // querying read stories with that same ordering so the section's ranking
+    // contract is preserved. Otherwise backfill most-recently-read (ordered via
+    // the progress row, which is where lastAccessed lives).
+    if (storyOrderBy) {
+      const stories = await this.storyRepository.findManyStoriesRaw({
+        where: this.withUserReadFilter(baseWhere, userId, 'read'),
+        orderBy: storyOrderBy,
+        take: deficit,
+        include,
+      });
+      return [...fresh, ...(stories as unknown as T[])];
+    }
+    const rows = await this.storyRepository.findManyUserStoryProgressRaw({
+      where: { userId, isDeleted: false, story: { ...baseWhere } },
+      orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+      take: deficit,
+      include: { story: { include } },
+    });
+    return [...fresh, ...rows.map((r) => r.story as unknown as T)];
   }
 
   // Sort stories so unread appear first, then reading, then done.
@@ -711,86 +991,134 @@ export class StoryFeedService {
     // 1. Recommended Stories (based on preferred categories)
     let recommended: Story[] = [];
     const preferredCategories = user?.preferredCategories ?? [];
-    if (preferredCategories.length > 0) {
-      recommended = await this.storyRepository.findManyStoriesRaw({
-        where: {
-          isDeleted: false,
-          categories: {
-            some: {
-              id: { in: preferredCategories.map((c: Category) => c.id) },
+    const recInclude: Prisma.StoryInclude = { images: true, categories: true };
+    const recBaseWhere: Prisma.StoryWhereInput =
+      preferredCategories.length > 0
+        ? {
+            isDeleted: false,
+            categories: {
+              some: {
+                id: { in: preferredCategories.map((c: Category) => c.id) },
+              },
             },
-          },
-        },
-        take: limitRecommended,
-        include: { images: true, categories: true },
-        orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
-      });
-    } else {
-      // Fallback if no preferences: just fresh stories
-      recommended = await this.storyRepository.findManyStoriesRaw({
-        where: { isDeleted: false },
-        orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
-        take: limitRecommended,
-        include: { images: true, categories: true },
-      });
-    }
+          }
+        : { isDeleted: false };
+    // Fresh-first: fetch unread recommendations, then top up with read ones.
+    recommended = await this.storyRepository.findManyStoriesRaw({
+      where: this.withUserReadFilter(recBaseWhere, userId, 'fresh'),
+      take: limitRecommended,
+      include: recInclude,
+      orderBy: [{ createdAt: 'desc' as const }, { id: 'asc' as const }],
+    });
+    recommended = await this.topUpWithRead(
+      recommended,
+      recBaseWhere,
+      userId,
+      limitRecommended,
+      recInclude,
+    );
 
     // 2. Seasonal Stories (Logic: find active season based on today's date)
     const { activeSeasons, backfillSeasons } = await this.getRelevantSeasons();
 
     let seasonal: Story[] = [];
     let seasonalCount = 0;
+    const seasonalInclude: Prisma.StoryInclude = {
+      images: true,
+      themes: true,
+      seasons: true,
+    };
 
     if (activeSeasons.length > 0) {
+      // Fresh-first: only unread seasonal stories in the primary fetch.
       seasonal = await this.storyRepository.findManyStoriesRaw({
-        where: {
-          isDeleted: false,
-          seasons: {
-            some: {
-              id: { in: activeSeasons.map((s) => s.id) },
+        where: this.withUserReadFilter(
+          {
+            isDeleted: false,
+            seasons: {
+              some: {
+                id: { in: activeSeasons.map((s) => s.id) },
+              },
             },
           },
-        },
+          userId,
+          'fresh',
+        ),
         take: limitSeasonal,
-        include: { images: true, themes: true, seasons: true },
+        include: seasonalInclude,
       });
       seasonalCount = seasonal.length;
     }
 
-    // Backfill if needed
+    // Backfill with other (recent) seasons' fresh stories if needed
     if (seasonalCount < limitSeasonal && backfillSeasons.length > 0) {
       const needed = limitSeasonal - seasonalCount;
       const existingIds = new Set(seasonal.map((s) => s.id));
 
       const backfillStories = await this.storyRepository.findManyStoriesRaw({
-        where: {
-          isDeleted: false,
-          seasons: {
-            some: {
-              id: { in: backfillSeasons.map((s) => s.id) },
+        where: this.withUserReadFilter(
+          {
+            isDeleted: false,
+            seasons: {
+              some: {
+                id: { in: backfillSeasons.map((s) => s.id) },
+              },
             },
+            id: { notIn: Array.from(existingIds) },
           },
-          id: { notIn: Array.from(existingIds) },
-        },
+          userId,
+          'fresh',
+        ),
         take: needed,
-        include: { images: true, themes: true, seasons: true },
+        include: seasonalInclude,
         orderBy: { createdAt: 'desc' },
       });
 
       seasonal = [...seasonal, ...backfillStories];
     }
 
-    // 3. Top Liked by Parents
-    const topLiked = await this.storyRepository.findManyStoriesRaw({
-      where: { isDeleted: false },
+    // Final fresh-first top-up: if still short on fresh seasonal stories, fill
+    // with already-read seasonal stories (active or recent seasons).
+    seasonal = await this.topUpWithRead(
+      seasonal,
+      {
+        isDeleted: false,
+        seasons: {
+          some: {
+            id: {
+              in: [
+                ...activeSeasons.map((s) => s.id),
+                ...backfillSeasons.map((s) => s.id),
+              ],
+            },
+          },
+        },
+      },
+      userId,
+      limitSeasonal,
+      seasonalInclude,
+    );
+
+    // 3. Top Liked by Parents (fresh-first, then top up with read)
+    const topLikedInclude: Prisma.StoryInclude = { images: true };
+    let topLiked = await this.storyRepository.findManyStoriesRaw({
+      where: this.withUserReadFilter({ isDeleted: false }, userId, 'fresh'),
       orderBy: {
         parentFavorites: {
           _count: 'desc',
         },
       },
       take: limitTopLiked,
-      include: { images: true },
+      include: topLikedInclude,
     });
+    topLiked = await this.topUpWithRead(
+      topLiked,
+      { isDeleted: false },
+      userId,
+      limitTopLiked,
+      topLikedInclude,
+      { parentFavorites: { _count: 'desc' } },
+    );
 
     // Enrich all stories with readStatus in a single DB query
     const allStories = [...recommended, ...seasonal, ...topLiked];

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -39,6 +39,7 @@ const mockStoryRepository = {
   findManyCategoriesRaw: jest.fn(),
   findManySeasonsRaw: jest.fn(),
   findManyUserStoryProgressRaw: jest.fn(),
+  findFirstUserStoryProgressRaw: jest.fn(),
   findManyDailyChallengeAssignmentsRaw: jest.fn(),
   findFirstDailyChallengeAssignmentRaw: jest.fn(),
   createDailyChallengeAssignmentRaw: jest.fn(),
@@ -196,14 +197,25 @@ describe('StoryService - Library & Generation', () => {
 
         await service.getStories({ userId: 'user-1', minAge: 3, maxAge: 5 });
 
+        // Authenticated users fetch FRESH stories only: the catalog where is
+        // wrapped at the top level with the read anti-join.
         expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              // Check overlap logic: story.ageMin <= 5 AND story.ageMax >= 3
-              ageMin: { lte: 5 },
-              ageMax: { gte: 3 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  // Check overlap logic: story.ageMin <= 5 AND story.ageMax >= 3
+                  ageMin: { lte: 5 },
+                  ageMax: { gte: 3 },
+                }),
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
+              ],
+            },
           }),
         );
       });
@@ -217,10 +229,19 @@ describe('StoryService - Library & Generation', () => {
 
         expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              ageMax: { gte: 4 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  ageMax: { gte: 4 },
+                }),
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
+              ],
+            },
           }),
         );
       });
@@ -234,10 +255,19 @@ describe('StoryService - Library & Generation', () => {
 
         expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({
-              isDeleted: false,
-              ageMin: { lte: 8 },
-            }),
+            where: {
+              AND: [
+                expect.objectContaining({
+                  isDeleted: false,
+                  ageMin: { lte: 8 },
+                }),
+                {
+                  userProgress: {
+                    none: { userId: 'user-1', isDeleted: false },
+                  },
+                },
+              ],
+            },
           }),
         );
       });
@@ -250,10 +280,18 @@ describe('StoryService - Library & Generation', () => {
         ];
         prisma.countStoriesRaw.mockResolvedValue(3);
         prisma.findManyStoriesRaw.mockResolvedValue(stories);
-        prisma.findManyUserStoryProgressRaw.mockResolvedValue([
-          { storyId: 'story-1', completed: true },
-          { storyId: 'story-2', completed: false },
-        ]);
+        // The read-status enrich query uses `select`; the fresh-first backfill
+        // query uses `include`. Return progress for the former, nothing for the
+        // latter.
+        prisma.findManyUserStoryProgressRaw.mockImplementation(
+          (args: { select?: unknown }) =>
+            args?.select
+              ? Promise.resolve([
+                  { storyId: 'story-1', completed: true },
+                  { storyId: 'story-2', completed: false },
+                ])
+              : Promise.resolve([]),
+        );
 
         const result = await service.getStories({ userId: 'user-1' });
 
@@ -267,7 +305,12 @@ describe('StoryService - Library & Generation', () => {
         expect(result.data[2]).toEqual(
           expect.objectContaining({ id: 'story-1', readStatus: 'done' }),
         );
-        expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledTimes(1);
+        // Exactly one read-status enrich query (uses `select`).
+        const selectCalls =
+          prisma.findManyUserStoryProgressRaw.mock.calls.filter(
+            (c) => c[0]?.select,
+          );
+        expect(selectCalls).toHaveLength(1);
         expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledWith({
           where: {
             userId: 'user-1',
@@ -358,19 +401,29 @@ describe('StoryService - Library & Generation', () => {
         { id: 'story-3', title: 'Top Liked Unread' },
       ];
 
-      // story.findMany: 1st call = recommended, 2nd call = topLiked
-      // (no seasonal call since season.findMany returns [])
+      // findManyStoriesRaw: 1st = recommended (fresh), 2nd = topLiked (fresh),
+      // 3rd = topLiked read-backfill (ranked by likes; returns [] here since the
+      // fresh stories already fill the section). No seasonal call since
+      // findManySeasonsRaw returns [].
       prisma.findManyStoriesRaw
         .mockResolvedValueOnce(recommended)
-        .mockResolvedValueOnce(topLiked);
+        .mockResolvedValueOnce(topLiked)
+        .mockResolvedValueOnce([]);
 
       prisma.findManySeasonsRaw.mockResolvedValue([]);
 
-      prisma.findManyUserStoryProgressRaw.mockResolvedValue([
-        { storyId: 'story-1', completed: true },
-        { storyId: 'story-2', completed: false },
-        // story-3 has no progress (unread)
-      ]);
+      // Read-status enrich uses `select`; per-section fresh-first top-up uses
+      // `include`. Return progress for enrich, nothing for the top-ups.
+      prisma.findManyUserStoryProgressRaw.mockImplementation(
+        (args: { select?: unknown }) =>
+          args?.select
+            ? Promise.resolve([
+                { storyId: 'story-1', completed: true },
+                { storyId: 'story-2', completed: false },
+                // story-3 has no progress (unread)
+              ])
+            : Promise.resolve([]),
+      );
 
       const result = await service.getHomePageStories(userId);
 
@@ -386,8 +439,12 @@ describe('StoryService - Library & Generation', () => {
         expect.objectContaining({ id: 'story-2', readStatus: 'reading' }),
       );
 
-      // Verify only 1 DB call for progress (not 1 per section)
-      expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledTimes(1);
+      // Verify only 1 read-status enrich query for all sections (not 1 per
+      // section); the fresh-first top-ups use separate `include` queries.
+      const selectCalls = prisma.findManyUserStoryProgressRaw.mock.calls.filter(
+        (c) => c[0]?.select,
+      );
+      expect(selectCalls).toHaveLength(1);
     });
   });
 
@@ -521,6 +578,294 @@ describe('StoryService - Library & Generation', () => {
         expect(result.seasonal).toEqual([]);
         expect(result.topLiked[0]).toEqual(
           expect.objectContaining({ id: 'story-2', readStatus: null }),
+        );
+      });
+    });
+  });
+
+  // --- 3c. FRESH-FIRST FEED (authenticated users) ---
+  describe('Fresh-first feed (authenticated)', () => {
+    const userId = 'user-1';
+
+    describe('getStories (offset) read backfill', () => {
+      it('should top up a short fresh page with read stories ordered by lastAccessed desc', async () => {
+        prisma.countStoriesRaw.mockResolvedValue(3);
+        // Fresh pool only has one unread story for a limit-3 page.
+        prisma.findManyStoriesRaw.mockResolvedValue([
+          { id: 'fresh-1', title: 'Fresh' },
+        ]);
+        prisma.findManyUserStoryProgressRaw.mockImplementation(
+          (args: { select?: unknown }) =>
+            args?.select
+              ? Promise.resolve([
+                  { storyId: 'read-1', completed: true },
+                  { storyId: 'read-2', completed: false },
+                ])
+              : Promise.resolve([
+                  { id: 'prog-1', story: { id: 'read-1', title: 'Read 1' } },
+                  { id: 'prog-2', story: { id: 'read-2', title: 'Read 2' } },
+                ]),
+        );
+
+        const result = await service.getStories({ userId, limit: 3 });
+
+        // Fresh story first, then the read backfill in lastAccessed order.
+        expect(result.data.map((s) => s.id)).toEqual([
+          'fresh-1',
+          'read-1',
+          'read-2',
+        ]);
+        expect(result.data[1]).toEqual(
+          expect.objectContaining({ id: 'read-1', readStatus: 'done' }),
+        );
+        expect(result.data[2]).toEqual(
+          expect.objectContaining({ id: 'read-2', readStatus: 'reading' }),
+        );
+        // totalCount still reflects the unfiltered catalog (fresh + read).
+        expect(result.pagination.totalCount).toBe(3);
+        // Backfill reads the progress join table, recent-first.
+        expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              userId,
+              isDeleted: false,
+              story: { isDeleted: false },
+            },
+            orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+            take: 2,
+          }),
+        );
+      });
+
+      it('should compute readSkip as skip - freshCount on deeper pages', async () => {
+        // 1st count = totalCount (unfiltered), 2nd count = fresh pool size.
+        prisma.countStoriesRaw
+          .mockResolvedValueOnce(10)
+          .mockResolvedValueOnce(1);
+        prisma.findManyStoriesRaw.mockResolvedValue([]);
+        prisma.findManyUserStoryProgressRaw.mockResolvedValue([]);
+
+        await service.getStories({ userId, page: 2, limit: 3 });
+
+        // skip=3, freshCount=1 -> readSkip = 2 so page 2 continues the read
+        // stream where page 1's backfill left off (no overlap, no gap).
+        expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledWith(
+          expect.objectContaining({ skip: 2, take: 3 }),
+        );
+      });
+    });
+
+    describe('getStoriesCursor composite cursor', () => {
+      it('should serve fresh stories and emit an f: cursor while fresh remain', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue([
+          { id: 'story-1', title: 'S1' },
+          { id: 'story-2', title: 'S2' },
+          { id: 'story-3', title: 'S3' },
+        ]);
+
+        const result = await service.getStoriesCursor({ userId, limit: 2 });
+
+        // Fresh query is scoped by the top-level read anti-join.
+        expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              AND: [
+                expect.objectContaining({ isDeleted: false }),
+                { userProgress: { none: { userId, isDeleted: false } } },
+              ],
+            },
+            take: 3,
+          }),
+        );
+        expect(result.data.map((s) => s.id)).toEqual(['story-1', 'story-2']);
+        for (const story of result.data) {
+          expect(story).toEqual(expect.objectContaining({ readStatus: null }));
+        }
+        expect(result.pagination).toEqual(
+          expect.objectContaining({
+            nextCursor: 'f:story-2',
+            hasNextPage: true,
+          }),
+        );
+      });
+
+      it('should accept legacy bare story-id cursors as fresh-stream cursors', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue([]);
+        prisma.findManyUserStoryProgressRaw.mockResolvedValue([]);
+
+        const result = await service.getStoriesCursor({
+          userId,
+          cursor: 'story-5',
+          limit: 2,
+        });
+
+        expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cursor: { id: 'story-5' },
+            skip: 1,
+          }),
+        );
+        expect(result.pagination).toEqual(
+          expect.objectContaining({ nextCursor: null, hasNextPage: false }),
+        );
+      });
+
+      it('should accept f:-prefixed cursors for the fresh stream', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue([]);
+        prisma.findManyUserStoryProgressRaw.mockResolvedValue([]);
+
+        await service.getStoriesCursor({
+          userId,
+          cursor: 'f:story-5',
+          limit: 2,
+        });
+
+        expect(prisma.findManyStoriesRaw).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cursor: { id: 'story-5' },
+            skip: 1,
+          }),
+        );
+      });
+
+      it('should backfill from the read stream when fresh exhausts mid-page and emit an r:<progressId> cursor', async () => {
+        // Fresh returns 1 row for a limit-2 page -> deficit of 1.
+        prisma.findManyStoriesRaw.mockResolvedValue([
+          { id: 'fresh-1', title: 'Fresh' },
+        ]);
+        prisma.findManyUserStoryProgressRaw.mockImplementation(
+          (args: { select?: unknown }) =>
+            args?.select
+              ? Promise.resolve([{ storyId: 'read-1', completed: true }])
+              : Promise.resolve([
+                  { id: 'prog-1', story: { id: 'read-1', title: 'Read 1' } },
+                  { id: 'prog-2', story: { id: 'read-2', title: 'Read 2' } },
+                ]),
+        );
+
+        const result = await service.getStoriesCursor({ userId, limit: 2 });
+
+        expect(result.data.map((s) => s.id)).toEqual(['fresh-1', 'read-1']);
+        expect(result.data[0]).toEqual(
+          expect.objectContaining({ readStatus: null }),
+        );
+        expect(result.data[1]).toEqual(
+          expect.objectContaining({ id: 'read-1', readStatus: 'done' }),
+        );
+        // Cursor continues the READ stream from the progress row id.
+        expect(result.pagination).toEqual(
+          expect.objectContaining({
+            nextCursor: 'r:prog-1',
+            hasNextPage: true,
+          }),
+        );
+      });
+
+      it('should emit the r: sentinel when fresh exhausts exactly at page end and read stories exist', async () => {
+        // Fresh returns exactly `limit` rows (no limit+1 lookahead row).
+        prisma.findManyStoriesRaw.mockResolvedValue([
+          { id: 'story-1', title: 'S1' },
+          { id: 'story-2', title: 'S2' },
+        ]);
+        prisma.findFirstUserStoryProgressRaw.mockResolvedValue({
+          id: 'prog-1',
+        });
+
+        const result = await service.getStoriesCursor({ userId, limit: 2 });
+
+        expect(result.data.map((s) => s.id)).toEqual(['story-1', 'story-2']);
+        expect(result.pagination).toEqual(
+          expect.objectContaining({ nextCursor: 'r:', hasNextPage: true }),
+        );
+      });
+
+      it('should end pagination when fresh exhausts at page end and no read stories exist', async () => {
+        prisma.findManyStoriesRaw.mockResolvedValue([
+          { id: 'story-1', title: 'S1' },
+          { id: 'story-2', title: 'S2' },
+        ]);
+        prisma.findFirstUserStoryProgressRaw.mockResolvedValue(null);
+
+        const result = await service.getStoriesCursor({ userId, limit: 2 });
+
+        expect(result.pagination).toEqual(
+          expect.objectContaining({ nextCursor: null, hasNextPage: false }),
+        );
+      });
+
+      it('should continue the read stream from an r:<progressId> cursor', async () => {
+        prisma.findManyUserStoryProgressRaw.mockImplementation(
+          (args: { select?: unknown }) =>
+            args?.select
+              ? Promise.resolve([
+                  { storyId: 'read-2', completed: true },
+                  { storyId: 'read-3', completed: false },
+                ])
+              : Promise.resolve([
+                  { id: 'prog-2', story: { id: 'read-2', title: 'Read 2' } },
+                  { id: 'prog-3', story: { id: 'read-3', title: 'Read 3' } },
+                  { id: 'prog-4', story: { id: 'read-4', title: 'Read 4' } },
+                ]),
+        );
+
+        const result = await service.getStoriesCursor({
+          userId,
+          cursor: 'r:prog-1',
+          limit: 2,
+        });
+
+        // Pages the progress join table by lastAccessed desc from the cursor.
+        expect(prisma.findManyUserStoryProgressRaw).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              userId,
+              isDeleted: false,
+              story: { isDeleted: false },
+            },
+            orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
+            take: 3,
+            cursor: { id: 'prog-1' },
+            skip: 1,
+          }),
+        );
+        // The fresh stream must NOT be queried on an r: continuation.
+        expect(prisma.findManyStoriesRaw).not.toHaveBeenCalled();
+        expect(result.data.map((s) => s.id)).toEqual(['read-2', 'read-3']);
+        expect(result.data[0]).toEqual(
+          expect.objectContaining({ readStatus: 'done' }),
+        );
+        expect(result.pagination).toEqual(
+          expect.objectContaining({
+            nextCursor: 'r:prog-3',
+            hasNextPage: true,
+          }),
+        );
+      });
+
+      it('should start the read stream from the beginning on the bare r: sentinel', async () => {
+        prisma.findManyUserStoryProgressRaw.mockImplementation(
+          (args: { select?: unknown }) =>
+            args?.select
+              ? Promise.resolve([{ storyId: 'read-1', completed: false }])
+              : Promise.resolve([
+                  { id: 'prog-1', story: { id: 'read-1', title: 'Read 1' } },
+                ]),
+        );
+
+        const result = await service.getStoriesCursor({
+          userId,
+          cursor: 'r:',
+          limit: 2,
+        });
+
+        // No progress cursor -> read stream starts from the top.
+        const includeCall = prisma.findManyUserStoryProgressRaw.mock.calls.find(
+          (c) => !c[0]?.select,
+        );
+        expect(includeCall[0]).not.toHaveProperty('cursor');
+        expect(result.data.map((s) => s.id)).toEqual(['read-1']);
+        expect(result.pagination).toEqual(
+          expect.objectContaining({ nextCursor: null, hasNextPage: false }),
         );
       });
     });


### PR DESCRIPTION
Ports green's fresh-first story feed (develop-v1.2.0 commits `a3bab9e2` + guest follow-ups `e356d190`, `167b8cba`) into blue's refactored `StoryFeedService` / repository architecture. Authenticated feeds are served from UNREAD stories at the DB level and topped up with already-read stories; guests and anonymous callers are untouched.

## What it does

- **`withUserReadFilter(where, userId, 'fresh'|'read')`** wraps the catalog `where` at the TOP level (`AND`) with `userProgress: { none|some: { userId, isDeleted: false } }`, so the recommended-OR rewrite and the topPicks `id.in` / restricted `id.notIn` rewrites can never bypass it. No `userId` → clause returned unchanged.
- **`getStories` (offset)**: the primary query fetches fresh stories only; `totalCount` is still counted on the unfiltered `where` so pagination metadata reflects the full catalog. If the page comes up short after enrichment/sorting, `fetchReadBackfill` tops it up with read stories ordered `lastAccessed desc`, with `readSkip = max(0, skip - freshCount)` so deeper pages continue the read stream without overlap or gap (`readSkip = 0` for topPicksFromUs, whose pages are already scoped by a per-page id window).
- **`getStoriesCursor`**: composite cursor for authenticated users. Fresh stream first; when it exhausts mid-page the remainder is backfilled from the read stream (progress rows by `lastAccessed desc`) and an `r:<progressId>` cursor is emitted; when fresh exhausts exactly at page end, a read-probe emits the bare `r:` sentinel. `fetchReadStreamPage` serves `r:` continuations.
- **`getHomePageStories`**: recommended, seasonal (active + recent-season backfill), and topLiked carousels all query fresh-first and top up with read stories via `topUpWithRead`; topLiked's backfill keeps its likes ranking.
- **Repository**: one new method, `findFirstUserStoryProgressRaw` (generic passthrough, mirrors existing `*Raw` style) for the cursor read-probe; paging/backfill reuse the existing `findManyUserStoryProgressRaw` passthrough.

## Cursor compatibility guarantees

- **Legacy bare story-id cursors** (old clients) keep working: anything not prefixed `r:` is treated as a fresh-stream cursor, `f:`-prefixed or bare.
- **Green wire compat**: `f:<storyId>` and `r:<progressId>` cursors emitted by green are consumed identically here, and the cursors this branch emits are identical to green's — clients can move between green and blue mid-pagination.
- The cursor stays a single opaque string; blue's richer pagination envelope (`previousCursor`/`hasPreviousPage`/`limit`) is preserved on every authenticated response.

## Guest / anonymous byte-parity

Guests and anonymous callers take the exact pre-existing code paths: `withUserReadFilter` is a no-op without `userId`, `getStoriesCursor` keeps the original single-stream query behind `if (!filter.userId)`, and `topUpWithRead` returns the fresh list unchanged. Responses are byte-for-byte identical to before this PR (green makes the same guarantee).

## Composition with the tip's seasonal ordering (#479)

- Seasonal requests already route through **offset** pagination at the controller (`usesSeasonalOrdering` cursor bypass), so the composite cursor never sees season-recency ordering.
- In offset mode the fresh-first filter composes with the seasonal sort exactly as in green's final state: the season-recency sort ranks the **fresh** result set (fetched without skip/take), the page is sliced from it, and the read backfill then tops up short pages — the only line touching the seasonal block is `where: freshWhere` in the shared findMany.

## Test results

Pre-rebase (dev box, Node 20, on the identical feature diff at `a802eea1`):

- `pnpm build` — clean.
- `npx jest src/story/story.service.spec.ts` — **34/34 pass**, including new coverage: offset backfill ordering + `readSkip` math, `f:` cursor emission, legacy bare cursor, `f:`-prefixed cursor, mid-page read backfill with `r:<progressId>`, fresh-exhausts-exactly-at-page-end boundary (`r:` sentinel, with and without read rows), `r:<progressId>` continuation (fresh stream not queried), bare `r:` restart. All pre-existing guest/anonymous tests pass unchanged.
- `npx jest src/story/story.controller.spec.ts` — 17/17 pass.

Post-rebase onto the current tip, on-box re-validation attempts (one `nice -n 19 pnpm build`, one `nice -n 19 npx jest --runInBand`) were **OOM-killed by the dev box** (exit 137; the host is swap-exhausted under unrelated load — not code failures). The rebase's only conflict resolution is a one-hunk composition (`where: freshWhere` in the findMany both features share), so CI on this PR is the authoritative post-rebase build/test run — please confirm it is green before merging.

## Deliberate deviations from green

1. Kept blue's `enrichWithReadStatus` (selects `completed` only) instead of green's `deriveReadStatus(progress, completed)` variant — that change is a separate read-status alignment outside this feature's scope.
2. All new authenticated cursor responses populate blue's extra pagination fields (`previousCursor: null`, `hasPreviousPage`, `limit`) to preserve blue's response contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story feeds now prioritize stories users haven’t read yet.
  * Read stories fill remaining slots while preserving relevance and ordering.
  * Improved pagination provides consistent continuation across fresh and previously read stories.
  * Home-page recommendations, seasonal stories, and top-liked sections prioritize unread content.
  * Guest and public story feeds continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->