### PR TITLE
test(e2e): provide REDIS_CLIENT and NotificationService in fixtures

### DIFF
--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Global, INestApplication, Module, ValidationPipe } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import request from 'supertest';
 import { Server } from 'http';
@@ -24,6 +24,23 @@ import { PushQueueService } from '../src/notification/queue/push-queue.service';
 import { PushProcessor } from '../src/notification/queue/push.processor';
 import { EmailProvider } from '../src/notification/providers/email.provider';
 import { AuthThrottleGuard } from '../src/shared/guards/auth-throttle.guard';
+import { REDIS_CLIENT } from '../src/redis/redis.constants';
+
+// SharedModule's InfraMetricsService injects REDIS_CLIENT, which the app gets
+// from the @Global RedisModule. Tests don't have a Redis server, so provide an
+// inert client the same way — via a global module — so it resolves inside
+// SharedModule's context.
+@Global()
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useValue: { status: 'end', info: jest.fn(), on: jest.fn() },
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+class MockRedisModule {}
 
 /**
  * E2E Tests for Authentication Flows
@@ -98,6 +115,7 @@ describe('Authentication (e2e)', () => {
           }),
         }),
         EventEmitterModule.forRoot(),
+        MockRedisModule,
         SharedModule,
         PrismaModule,
         AuthModule,

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Global, INestApplication, Module, ValidationPipe } from '@nestjs/common';
+import {
+  Global,
+  INestApplication,
+  Module,
+  ValidationPipe,
+} from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import request from 'supertest';
 import { Server } from 'http';

--- a/test/payment.e2e-spec.ts
+++ b/test/payment.e2e-spec.ts
@@ -116,7 +116,9 @@ describe('Payment (e2e)', () => {
         // NotificationModule; provide an inert stand-in here.
         {
           provide: NotificationService,
-          useValue: { sendNotification: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            sendNotification: jest.fn().mockResolvedValue(undefined),
+          },
         },
         {
           provide: GoogleVerificationService,

--- a/test/payment.e2e-spec.ts
+++ b/test/payment.e2e-spec.ts
@@ -21,6 +21,7 @@ import { GoogleVerificationService } from '../src/payment/google-verification.se
 import { AppleVerificationService } from '../src/payment/apple-verification.service';
 import { SubscriptionService } from '../src/subscription/subscription.service';
 import { CacheMetricsService } from '../src/shared/services/cache-metrics.service';
+import { NotificationService } from '../src/notification/notification.service';
 import {
   SUBSCRIPTION_REPOSITORY,
   PrismaSubscriptionRepository,
@@ -110,6 +111,12 @@ describe('Payment (e2e)', () => {
         {
           provide: PAYMENT_TRANSACTION_REPOSITORY,
           useClass: PrismaPaymentTransactionRepository,
+        },
+        // PaymentService resolves NotificationService from the app's @Global
+        // NotificationModule; provide an inert stand-in here.
+        {
+          provide: NotificationService,
+          useValue: { sendNotification: jest.fn().mockResolvedValue(undefined) },
         },
         {
           provide: GoogleVerificationService,


### PR DESCRIPTION
The staging pipeline (#492) is the only lane that runs e2e, so two blue-only DI changes went unnoticed until the first v1.3.0 staging cut failed its Test job (60 failures across test/auth.e2e-spec.ts and test/payment.e2e-spec.ts, all at module compile):

- **auth.e2e**: `SharedModule` now carries `InfraMetricsService`, which injects `REDIS_CLIENT` — provided in the real app by the `@Global` RedisModule, absent from the spec's hand-built module graph. Fixed with a global `MockRedisModule` exporting an inert client (`status: 'end'` short-circuits the INFO collection path).
- **payment.e2e**: `PaymentService` now injects `NotificationService` (resolved from the `@Global` NotificationModule in the app). Fixed with a jest stub provider.

No production code changes. Unblocks the staging cut PR #492.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability with test-safe substitutes for Redis and notification services.
  * Tests no longer require a live Redis server or external notification delivery during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->