### PR TITLE
fix(admin): compute newUsersThisWeek instead of hardcoding 0

### DIFF
--- a/src/admin/admin-dashboard-metrics.service.ts
+++ b/src/admin/admin-dashboard-metrics.service.ts
@@ -97,6 +97,7 @@ export class AdminDashboardMetricsService {
       activeUsers7d,
       activeUsers30d,
       newUsersToday,
+      newUsersThisWeek,
       newUsersThisMonth,
       totalStoryProgress,
       totalFavorites,
@@ -127,6 +128,7 @@ export class AdminDashboardMetricsService {
 
       // New Users
       countBetween(rangeToday.start, rangeToday.end),
+      countBetween(range7d.start, range7d.end),
       countBetween(rangeThisMonth.start, rangeThisMonth.end),
 
       // Engagement
@@ -265,7 +267,7 @@ export class AdminDashboardMetricsService {
       activeUsers24h,
       activeUsers7d,
       newUsersToday,
-      newUsersThisWeek: 0,
+      newUsersThisWeek,
       newUsersThisMonth,
       totalStoryViews: totalStoryProgress,
       totalFavorites,


### PR DESCRIPTION
Admin-audit follow-up. `DashboardStatsDto.newUsersThisWeek` was returned as a hardcoded `0` while `newUsersToday`/`newUsersThisMonth` were real values — so the dashboard always showed 0 new users this week.

Adds a 7-day count using the existing `countBetween` helper and `range7d` (already computed for `activeUsers7d`): one extra element in the metrics `Promise.all`, wired to the DTO field. `nest build` + eslint clean; no shape change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard metrics now accurately report the number of new users added during the last seven days instead of always showing zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->