### PR TITLE
fix(admin): bucket revenue & subscription analytics by calendar day

### DIFF
--- a/src/admin/repositories/prisma-admin-payment.repository.ts
+++ b/src/admin/repositories/prisma-admin-payment.repository.ts
@@ -27,49 +27,47 @@ export class PrismaAdminPaymentRepository implements IAdminPaymentRepository {
     });
   }
 
+  // Aggregate revenue per CALENDAR DAY. A Prisma groupBy on `createdAt` groups
+  // by the full timestamp, so every transaction becomes its own bucket and the
+  // caller (which maps createdAt -> YYYY-MM-DD) emits per-transaction points
+  // instead of a daily total. Fetch the rows in range and bucket by UTC day.
   async groupRevenueByCreatedAt(
     startDate: Date,
     endDate: Date,
   ): Promise<RevenueByDate[]> {
-    const result = await this.prisma.paymentTransaction.groupBy({
-      by: ['createdAt'],
+    const rows = await this.prisma.paymentTransaction.findMany({
       where: {
-        createdAt: {
-          gte: startDate,
-          lte: endDate,
-        },
+        createdAt: { gte: startDate, lte: endDate },
         status: 'success',
         deletedAt: null,
       },
-      _sum: {
-        amount: true,
-      },
+      select: { createdAt: true, amount: true },
     });
-    return result as RevenueByDate[];
+    return this.bucketRevenueByDay(rows);
   }
 
-  async groupRevenueByCreatedAtOrdered(
+  // Same daily aggregation; result is already day-ascending.
+  groupRevenueByCreatedAtOrdered(
     startDate: Date,
     endDate: Date,
   ): Promise<RevenueByDate[]> {
-    const result = await this.prisma.paymentTransaction.groupBy({
-      by: ['createdAt'],
-      where: {
-        createdAt: {
-          gte: startDate,
-          lte: endDate,
-        },
-        status: 'success',
-        deletedAt: null,
-      },
-      _sum: {
-        amount: true,
-      },
-      orderBy: {
-        createdAt: 'asc',
-      },
-    });
-    return result as RevenueByDate[];
+    return this.groupRevenueByCreatedAt(startDate, endDate);
+  }
+
+  private bucketRevenueByDay(
+    rows: { createdAt: Date; amount: number }[],
+  ): RevenueByDate[] {
+    const byDay = new Map<string, number>();
+    for (const row of rows) {
+      const day = row.createdAt.toISOString().slice(0, 10);
+      byDay.set(day, (byDay.get(day) ?? 0) + row.amount);
+    }
+    return Array.from(byDay.entries())
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([day, amount]) => ({
+        createdAt: new Date(`${day}T00:00:00.000Z`),
+        _sum: { amount },
+      }));
   }
 
   findSuccessfulInRange(

--- a/src/admin/repositories/prisma-admin-subscription.repository.ts
+++ b/src/admin/repositories/prisma-admin-subscription.repository.ts
@@ -31,21 +31,32 @@ export class PrismaAdminSubscriptionRepository
     return result as SubscriptionPlanCount[];
   }
 
+  // Count new subscriptions per CALENDAR DAY. groupBy on `startedAt` buckets by
+  // the full timestamp, so the caller (which maps startedAt -> YYYY-MM-DD) would
+  // emit one point per subscription instead of a daily count. Fetch in range and
+  // bucket by UTC day.
   async groupByStartedAt(
     startDate: Date,
     endDate: Date,
   ): Promise<SubscriptionStartedAtCount[]> {
-    const result = await this.prisma.subscription.groupBy({
-      by: ['startedAt'],
+    const rows = await this.prisma.subscription.findMany({
       where: {
-        startedAt: {
-          gte: startDate,
-          lte: endDate,
-        },
+        startedAt: { gte: startDate, lte: endDate },
       },
-      _count: true,
+      select: { startedAt: true },
     });
-    return result as SubscriptionStartedAtCount[];
+
+    const byDay = new Map<string, number>();
+    for (const row of rows) {
+      const day = row.startedAt.toISOString().slice(0, 10);
+      byDay.set(day, (byDay.get(day) ?? 0) + 1);
+    }
+    return Array.from(byDay.entries())
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([day, count]) => ({
+        startedAt: new Date(`${day}T00:00:00.000Z`),
+        _count: count,
+      }));
   }
 
   findActiveWithUserRevenue(): Promise<SubscriptionWithUserRevenue[]> {


### PR DESCRIPTION
## Problem

The revenue and subscription time-series in the admin analytics were bucketed by full timestamp, not by day.

`groupRevenueByCreatedAt` / `groupRevenueByCreatedAtOrdered` (payment repo) and `groupByStartedAt` (subscription repo) used Prisma `groupBy({ by: ['createdAt'|'startedAt'] })`. Because those columns are full `DateTime`s, every row landed in its own bucket. The consumer (`admin-revenue-analytics.service.ts`) then maps each bucket's date to `YYYY-MM-DD`, so a day with N transactions produced N separate data points (often with duplicate dates) instead of one daily total.

## Fix

Replace the timestamp `groupBy` with a `findMany` over the same `where` range, then aggregate into per-UTC-day buckets in JS:
- payment: sum `amount` per day → `RevenueByDate[]`, day-ascending
- subscription: count per day → `SubscriptionStartedAtCount[]`, day-ascending

Return shapes are unchanged, so no consumer or interface changes are needed. `groupRevenueByCreatedAtOrdered` now delegates to the base method (both are already day-sorted).

No raw SQL, type-preserving. Build + eslint clean.