### PR TITLE
fix(admin): scope churn rate to the period so it can't exceed 100%

### DIFF
--- a/src/admin/admin-revenue-analytics.service.spec.ts
+++ b/src/admin/admin-revenue-analytics.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminRevenueAnalyticsService } from './admin-revenue-analytics.service';
+import {
+  ADMIN_SUBSCRIPTION_REPOSITORY,
+  ADMIN_PAYMENT_REPOSITORY,
+  ADMIN_ACTIVITY_REPOSITORY,
+} from './repositories';
+
+describe('AdminRevenueAnalyticsService — churn rate', () => {
+  let service: AdminRevenueAnalyticsService;
+  let subscriptionRepo: {
+    count: jest.Mock;
+    groupByStartedAt: jest.Mock;
+    groupByActivePlan: jest.Mock;
+  };
+  let paymentRepo: { groupRevenueByCreatedAt: jest.Mock };
+
+  const range = { startDate: '2026-07-01', endDate: '2026-07-31' };
+
+  beforeEach(async () => {
+    subscriptionRepo = {
+      count: jest.fn(),
+      groupByStartedAt: jest.fn().mockResolvedValue([]),
+      groupByActivePlan: jest.fn().mockResolvedValue([]),
+    };
+    paymentRepo = { groupRevenueByCreatedAt: jest.fn().mockResolvedValue([]) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminRevenueAnalyticsService,
+        { provide: ADMIN_SUBSCRIPTION_REPOSITORY, useValue: subscriptionRepo },
+        { provide: ADMIN_PAYMENT_REPOSITORY, useValue: paymentRepo },
+        { provide: ADMIN_ACTIVITY_REPOSITORY, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(AdminRevenueAnalyticsService);
+  });
+
+  it('scopes the churn base and the churned count to the window via endsAt', async () => {
+    // count() is called twice: first the base (denominator), then the churned
+    // (numerator).
+    subscriptionRepo.count.mockResolvedValueOnce(200); // base
+    subscriptionRepo.count.mockResolvedValueOnce(10); // churned in window
+
+    const result = await service.getSubscriptionAnalytics(range);
+
+    const [baseWhere] = subscriptionRepo.count.mock.calls[0];
+    const [churnedWhere] = subscriptionRepo.count.mock.calls[1];
+
+    // Base: started before the window and still had access at the window start.
+    expect(baseWhere.startedAt).toEqual({ lt: new Date(range.startDate) });
+    expect(baseWhere.OR).toEqual([
+      { endsAt: null },
+      { endsAt: { gte: new Date(range.startDate) } },
+    ]);
+
+    // Churned: cancelled subs from that base whose access ended inside the window.
+    expect(churnedWhere.startedAt).toEqual({ lt: new Date(range.startDate) });
+    expect(churnedWhere.status).toBe('cancelled');
+    expect(churnedWhere.endsAt).toEqual({
+      gte: new Date(range.startDate),
+      lte: new Date(range.endDate),
+    });
+
+    expect(result.churnRate).toBe(5); // 10 / 200 * 100
+  });
+
+  it('never exceeds 100% even when every base subscriber churned', async () => {
+    // The numerator is a strict subset of the denominator, so churn is bounded.
+    subscriptionRepo.count.mockResolvedValueOnce(50); // base
+    subscriptionRepo.count.mockResolvedValueOnce(50); // all of them churned
+
+    const result = await service.getSubscriptionAnalytics(range);
+
+    expect(result.churnRate).toBe(100);
+    expect(result.churnRate).toBeLessThanOrEqual(100);
+  });
+
+  it('returns 0 churn when there is no starting base (no divide-by-zero)', async () => {
+    subscriptionRepo.count.mockResolvedValueOnce(0); // base
+    subscriptionRepo.count.mockResolvedValueOnce(3); // churned (should be ignored)
+
+    const result = await service.getSubscriptionAnalytics(range);
+
+    expect(result.churnRate).toBe(0);
+  });
+});

--- a/src/admin/admin-revenue-analytics.service.ts
+++ b/src/admin/admin-revenue-analytics.service.ts
@@ -72,26 +72,38 @@ export class AdminRevenueAnalyticsService {
     };
   }
 
+  // Period-scoped churn: of the subscribers who had access at the START of the
+  // window, what fraction lost it DURING the window.
+  //
+  // The previous version counted EVERY cancelled subscription ever (unscoped) in
+  // the numerator while the denominator only counted currently-active subs, so
+  // the ratio routinely exceeded 100%. Both terms are now scoped to the window
+  // via `endsAt`, and the numerator is a strict subset of the denominator (both
+  // require startedAt < startDate; the numerator additionally requires endsAt in
+  // [start, end], which satisfies the denominator's endsAt >= start), so the
+  // result is always in [0, 100].
   private async calculateChurnRate(
     startDate: Date,
     endDate: Date,
   ): Promise<number> {
+    // Base: had access at the start of the window (started before it and either
+    // never ended or ended on/after the window start).
     const totalSubscriptionsAtStart = await this.subscriptionRepo.count({
       startedAt: { lt: startDate },
-      status: 'active',
+      OR: [{ endsAt: null }, { endsAt: { gte: startDate } }],
     });
 
+    // Churned within the window: from that base, cancelled subs whose access
+    // actually ended inside [startDate, endDate]. Requiring status 'cancelled'
+    // avoids miscounting active auto-renewing subs whose endsAt (current period
+    // boundary) happens to fall in the window.
     const churnedSubscriptions = await this.subscriptionRepo.count({
-      OR: [
-        { status: 'cancelled' },
-        {
-          status: 'active',
-          endsAt: {
-            gte: startDate,
-            lte: endDate,
-          },
-        },
-      ],
+      startedAt: { lt: startDate },
+      status: 'cancelled',
+      endsAt: {
+        gte: startDate,
+        lte: endDate,
+      },
     });
 
     return totalSubscriptionsAtStart > 0


### PR DESCRIPTION
## Problem

The subscription-analytics churn rate could exceed 100%.

- **Numerator** counted **every cancelled subscription ever** (`{ status: 'cancelled' }` with no date bound) plus active subs ending in the window.
- **Denominator** only counted subs that are **currently** active and started before the window.

Because a subscriber who cancelled inside the window flips from the denominator (active) into the numerator (cancelled, all-time), and because the numerator wasn't period-bounded at all, the ratio routinely read well above 100%.

## Fix

Scope **both** terms to the window using `endsAt` (the timestamp cancellation writes as the access-end date):

- **Base (denominator)** — had access at the window start: `startedAt < start` AND (`endsAt` is null OR `endsAt >= start`). This now includes subs later cancelled, which the old denominator wrongly excluded.
- **Churned (numerator)** — from that base, cancelled subs whose access ended inside the window: `startedAt < start` AND `status = 'cancelled'` AND `endsAt ∈ [start, end]`. Requiring `cancelled` avoids miscounting active auto-renewing subs whose period boundary falls in the window.

The numerator is a **strict subset** of the denominator (both require `startedAt < start`; the numerator's `endsAt >= start` satisfies the denominator's OR), so the result is bounded to **[0, 100]**.

## Tests

New `admin-revenue-analytics.service.spec.ts`:
- asserts the period-scoped `where` clauses for base and churned counts
- 50/50 base → exactly 100%, never above
- empty base → 0% (no divide-by-zero)

Build + eslint + the new spec all pass. No interface or consumer changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved churn-rate analytics by accurately limiting subscriber and cancellation calculations to the selected reporting period.
  - Prevented churn rates from exceeding 100%.
  - Returns a zero churn rate when no subscribers were active at the start of the period.

- **Tests**
  - Added coverage for date-scoped subscriber counts, cancellation periods, percentage calculations, upper bounds, and empty subscriber bases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->