### PR TITLE
fix(admin): treat date-only analytics endDate as inclusive of the whole day

### DIFF
--- a/src/admin/admin-revenue-analytics.service.spec.ts
+++ b/src/admin/admin-revenue-analytics.service.spec.ts
@@ -58,12 +58,27 @@ describe('AdminRevenueAnalyticsService — churn rate', () => {
     // Churned: cancelled subs from that base whose access ended inside the window.
     expect(churnedWhere.startedAt).toEqual({ lt: new Date(range.startDate) });
     expect(churnedWhere.status).toBe('cancelled');
+    // Date-only endDate is inclusive through the whole day, not just midnight.
     expect(churnedWhere.endsAt).toEqual({
       gte: new Date(range.startDate),
-      lte: new Date(range.endDate),
+      lte: new Date(`${range.endDate}T23:59:59.999Z`),
     });
 
     expect(result.churnRate).toBe(5); // 10 / 200 * 100
+  });
+
+  it('keeps an explicit endDate timestamp unchanged', async () => {
+    subscriptionRepo.count.mockResolvedValueOnce(200);
+    subscriptionRepo.count.mockResolvedValueOnce(10);
+
+    const explicitEnd = '2026-07-31T12:30:00.000Z';
+    await service.getSubscriptionAnalytics({
+      startDate: range.startDate,
+      endDate: explicitEnd,
+    });
+
+    const [churnedWhere] = subscriptionRepo.count.mock.calls[1];
+    expect(churnedWhere.endsAt.lte).toEqual(new Date(explicitEnd));
   });
 
   it('never exceeds 100% even when every base subscriber churned', async () => {

--- a/src/admin/admin-revenue-analytics.service.ts
+++ b/src/admin/admin-revenue-analytics.service.ts
@@ -33,6 +33,18 @@ export class AdminRevenueAnalyticsService {
     private readonly activityRepo: IAdminActivityRepository,
   ) {}
 
+  // A date-only endDate ('2026-07-31') parses to midnight UTC, which would
+  // silently exclude everything that happened later that day from `lte`
+  // filters. Treat day-level input as inclusive through the end of that day
+  // (.999 is the max millisecond Prisma DateTime can store); explicit
+  // timestamps pass through unchanged.
+  private static parseInclusiveEndDate(value: string): Date {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return new Date(`${value}T23:59:59.999Z`);
+    }
+    return new Date(value);
+  }
+
   async getSubscriptionAnalytics(
     dateRange?: DateRangeDto,
   ): Promise<SubscriptionAnalyticsDto> {
@@ -40,7 +52,7 @@ export class AdminRevenueAnalyticsService {
       ? new Date(dateRange.startDate)
       : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const endDate = dateRange?.endDate
-      ? new Date(dateRange.endDate)
+      ? AdminRevenueAnalyticsService.parseInclusiveEndDate(dateRange.endDate)
       : new Date();
 
     const [subscriptions, revenue, planBreakdown] = await Promise.all([
@@ -118,7 +130,7 @@ export class AdminRevenueAnalyticsService {
       ? new Date(dateRange.startDate)
       : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const endDate = dateRange?.endDate
-      ? new Date(dateRange.endDate)
+      ? AdminRevenueAnalyticsService.parseInclusiveEndDate(dateRange.endDate)
       : new Date();
 
     try {


### PR DESCRIPTION
Follow-up to #496, addressing the CodeRabbit finding that landed after merge.

A date-only `endDate` (`2026-07-31`) parses to midnight UTC, so the `lte` bounds in the churn and revenue analytics silently excluded everything that happened later that day. Day-level input is now normalized to `23:59:59.999Z` (the max millisecond a Prisma DateTime stores, so `lte` covers the full day); explicit timestamps pass through unchanged.

Applied at both parse sites in `AdminRevenueAnalyticsService` (subscription analytics + revenue analytics). Spec updated to pin the inclusive end-of-day contract and the explicit-timestamp passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics searches using an end date without a time now include the entire day.
  * End dates with an explicitly specified time continue to be honored as entered.
  * Subscription and revenue analytics now provide more accurate results for date-range queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->