### PR TITLE
fix(admin): attribute topPlans revenue per payment plan, not payer's current plan

### DIFF
--- a/prisma/migrations/20260810000000_add_plan_to_payment_transaction/migration.sql
+++ b/prisma/migrations/20260810000000_add_plan_to_payment_transaction/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable: add nullable `plan` for per-plan revenue attribution.
+-- Nullable column with no default = metadata-only change in Postgres (no table
+-- rewrite, no long lock), safe to run on the shared DB via `migrate deploy`.
+ALTER TABLE "payment_transactions" ADD COLUMN "plan" TEXT;
+
+-- Best-effort backfill of historical rows by matching the charged amount to the
+-- canonical USD plan prices. Deliberately conservative: only exact matches on
+-- USD (or unspecified currency) are attributed; everything else stays NULL
+-- ("unknown") rather than risk a wrong plan. A coupon/promo/localized amount
+-- simply won't match and remains NULL, which is the correct, non-misleading
+-- outcome. Going forward the column is populated from the store productId at
+-- purchase time, so this only affects rows created before this migration.
+UPDATE "payment_transactions"
+SET "plan" = CASE
+    WHEN "amount" = 1.5 THEN 'weekly'
+    WHEN "amount" = 4.99 THEN 'monthly'
+    WHEN "amount" = 47.99 THEN 'yearly'
+    WHEN "amount" = 0 THEN 'free'
+END
+WHERE "plan" IS NULL
+  AND ("currency" = 'USD' OR "currency" IS NULL)
+  AND "amount" IN (1.5, 4.99, 47.99, 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -599,6 +599,12 @@ model PaymentTransaction {
   reference       String?
   amount          Float
   status          String
+  // Plan this payment was for (weekly/monthly/yearly/free), resolved from the
+  // store productId at purchase time. Nullable: pre-existing rows predate this
+  // column, and it stays null when the productId can't be mapped. Enables
+  // per-plan revenue attribution instead of charging a user's whole payment
+  // history to whatever plan they happen to be on now.
+  plan            String?
   createdAt       DateTime       @default(now())
   // SOFT DELETE FIELDS
   isDeleted       Boolean        @default(false)

--- a/src/admin/admin-revenue-analytics.service.spec.ts
+++ b/src/admin/admin-revenue-analytics.service.spec.ts
@@ -6,14 +6,19 @@ import {
   ADMIN_ACTIVITY_REPOSITORY,
 } from './repositories';
 
-describe('AdminRevenueAnalyticsService — churn rate', () => {
+describe('AdminRevenueAnalyticsService', () => {
   let service: AdminRevenueAnalyticsService;
   let subscriptionRepo: {
     count: jest.Mock;
     groupByStartedAt: jest.Mock;
     groupByActivePlan: jest.Mock;
   };
-  let paymentRepo: { groupRevenueByCreatedAt: jest.Mock };
+  let paymentRepo: {
+    groupRevenueByCreatedAt: jest.Mock;
+    groupRevenueByCreatedAtOrdered: jest.Mock;
+    findSuccessfulInRange: jest.Mock;
+    groupRevenueByPlan: jest.Mock;
+  };
 
   const range = { startDate: '2026-07-01', endDate: '2026-07-31' };
 
@@ -23,7 +28,12 @@ describe('AdminRevenueAnalyticsService — churn rate', () => {
       groupByStartedAt: jest.fn().mockResolvedValue([]),
       groupByActivePlan: jest.fn().mockResolvedValue([]),
     };
-    paymentRepo = { groupRevenueByCreatedAt: jest.fn().mockResolvedValue([]) };
+    paymentRepo = {
+      groupRevenueByCreatedAt: jest.fn().mockResolvedValue([]),
+      groupRevenueByCreatedAtOrdered: jest.fn().mockResolvedValue([]),
+      findSuccessfulInRange: jest.fn().mockResolvedValue([]),
+      groupRevenueByPlan: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -84,5 +94,55 @@ describe('AdminRevenueAnalyticsService — churn rate', () => {
     const result = await service.getSubscriptionAnalytics(range);
 
     expect(result.churnRate).toBe(0);
+  });
+
+  describe('topPlans revenue attribution', () => {
+    it('attributes revenue to the plan each payment was for, not the payer current plan', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([
+        { plan: 'monthly', _sum: { amount: 100 }, _count: 20 },
+        { plan: 'yearly', _sum: { amount: 480 }, _count: 10 },
+      ]);
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([
+        { plan: 'monthly', _count: 5 },
+        { plan: 'yearly', _count: 8 },
+      ]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      // Sorted by revenue desc: yearly (480) before monthly (100).
+      expect(result.topPlans).toEqual([
+        { plan: 'yearly', subscription_count: 8, total_revenue: 480 },
+        { plan: 'monthly', subscription_count: 5, total_revenue: 100 },
+      ]);
+    });
+
+    it('keeps plans with revenue but no active subscribers, and buckets unattributed revenue as "unknown"', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([
+        { plan: 'weekly', _sum: { amount: 30 }, _count: 20 },
+        { plan: null, _sum: { amount: 12 }, _count: 4 }, // historical, unmapped
+      ]);
+      // weekly has no currently-active subs; that plan must still appear.
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      expect(result.topPlans).toEqual([
+        { plan: 'weekly', subscription_count: 0, total_revenue: 30 },
+        { plan: 'unknown', subscription_count: 0, total_revenue: 12 },
+      ]);
+    });
+
+    it('includes active-subscription counts for plans that have no attributed revenue yet', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([]);
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([
+        { plan: 'monthly', _count: 3 },
+      ]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      expect(result.topPlans).toEqual([
+        { plan: 'monthly', subscription_count: 3, total_revenue: 0 },
+      ]);
+    });
   });
 });

--- a/src/admin/admin-revenue-analytics.service.ts
+++ b/src/admin/admin-revenue-analytics.service.ts
@@ -168,30 +168,45 @@ export class AdminRevenueAnalyticsService {
         }),
       );
 
-      // Get top plans
-      const subscriptionsWithRevenue =
-        await this.subscriptionRepo.findActiveWithUserRevenue();
+      // Top plans: attribute each payment to the plan it was actually for
+      // (summed DB-side), and pair it with the number of currently-active
+      // subscriptions on that plan. The old version summed every active
+      // subscriber's entire lifetime spend and charged it all to their current
+      // plan — so an upgrader's past-plan revenue was misattributed, and the
+      // whole payment history was loaded into memory.
+      const [revenueByPlan, activePlanCounts] = await Promise.all([
+        this.paymentRepo.groupRevenueByPlan(),
+        this.subscriptionRepo.groupByActivePlan(new Date()),
+      ]);
 
       const planRevenueMap = new Map<
         string,
         { subscription_count: number; total_revenue: number }
       >();
-
-      subscriptionsWithRevenue.forEach((sub) => {
-        const current = planRevenueMap.get(sub.plan) || {
+      const bumpPlan = (
+        plan: string,
+        revenue: number,
+        subscriptions: number,
+      ) => {
+        const current = planRevenueMap.get(plan) || {
           subscription_count: 0,
           total_revenue: 0,
         };
-        const userRevenue = sub.user.paymentTransactions.reduce(
-          (sum, t) => sum + t.amount,
-          0,
-        );
-
-        planRevenueMap.set(sub.plan, {
-          subscription_count: current.subscription_count + 1,
-          total_revenue: current.total_revenue + userRevenue,
+        planRevenueMap.set(plan, {
+          subscription_count: current.subscription_count + subscriptions,
+          total_revenue: current.total_revenue + revenue,
         });
-      });
+      };
+
+      // Revenue per plan; historical rows we couldn't attribute land in 'unknown'.
+      for (const row of revenueByPlan) {
+        bumpPlan(row.plan ?? 'unknown', row._sum.amount ?? 0, 0);
+      }
+      // Active-subscription counts per plan (plans may have revenue but no
+      // active subs left, or vice versa, so this is a union).
+      for (const row of activePlanCounts) {
+        bumpPlan(row.plan, 0, row._count);
+      }
 
       const topPlans = Array.from(planRevenueMap.entries())
         .map(([plan, stats]) => ({

--- a/src/admin/repositories/admin-payment.repository.interface.ts
+++ b/src/admin/repositories/admin-payment.repository.interface.ts
@@ -19,6 +19,12 @@ export interface DatedPaymentAmount {
   createdAt: Date;
 }
 
+export interface RevenueByPlan {
+  plan: string | null;
+  _sum: { amount: number | null };
+  _count: number;
+}
+
 export interface IAdminPaymentRepository {
   // Aggregate successful revenue for an arbitrary where clause
   sumRevenue(where: Prisma.PaymentTransactionWhereInput): Promise<RevenueSum>;
@@ -43,6 +49,11 @@ export interface IAdminPaymentRepository {
     startDate: Date,
     endDate: Date,
   ): Promise<DatedPaymentAmount[]>;
+
+  // Successful revenue + transaction count grouped by the plan each payment was
+  // for (top-plans analytics). Attributes each payment to its own plan rather
+  // than to the payer's current subscription.
+  groupRevenueByPlan(): Promise<RevenueByPlan[]>;
 }
 
 export const ADMIN_PAYMENT_REPOSITORY = Symbol('ADMIN_PAYMENT_REPOSITORY');

--- a/src/admin/repositories/admin-subscription.repository.interface.ts
+++ b/src/admin/repositories/admin-subscription.repository.interface.ts
@@ -10,19 +10,6 @@ export interface SubscriptionStartedAtCount {
   _count: number;
 }
 
-// Active subscriptions joined with each owner's successful payments (revenue)
-export type SubscriptionWithUserRevenue = Prisma.SubscriptionGetPayload<{
-  include: {
-    user: {
-      include: {
-        paymentTransactions: {
-          select: { amount: true };
-        };
-      };
-    };
-  };
-}>;
-
 export type SubscriptionWithUser = Prisma.SubscriptionGetPayload<{
   include: {
     user: { select: { id: true; email: true; name: true } };
@@ -40,9 +27,6 @@ export interface IAdminSubscriptionRepository {
     startDate: Date,
     endDate: Date,
   ): Promise<SubscriptionStartedAtCount[]>;
-
-  // All active subscriptions with owner revenue (top plans)
-  findActiveWithUserRevenue(): Promise<SubscriptionWithUserRevenue[]>;
 
   findByUserId(userId: string): Promise<Subscription | null>;
 

--- a/src/admin/repositories/prisma-admin-payment.repository.ts
+++ b/src/admin/repositories/prisma-admin-payment.repository.ts
@@ -5,6 +5,7 @@ import type {
   IAdminPaymentRepository,
   RevenueSum,
   RevenueByDate,
+  RevenueByPlan,
   UserPaymentAmount,
   DatedPaymentAmount,
 } from './admin-payment.repository.interface';
@@ -68,6 +69,23 @@ export class PrismaAdminPaymentRepository implements IAdminPaymentRepository {
         createdAt: new Date(`${day}T00:00:00.000Z`),
         _sum: { amount },
       }));
+  }
+
+  // Sum revenue and count transactions per plan, in the DB. Replaces loading
+  // every active subscriber's entire transaction history into memory and
+  // charging their lifetime spend to their current plan.
+  async groupRevenueByPlan(): Promise<RevenueByPlan[]> {
+    const rows = await this.prisma.paymentTransaction.groupBy({
+      by: ['plan'],
+      where: { status: 'success', deletedAt: null },
+      _sum: { amount: true },
+      _count: true,
+    });
+    return rows.map((row) => ({
+      plan: row.plan,
+      _sum: { amount: row._sum.amount },
+      _count: row._count,
+    }));
   }
 
   findSuccessfulInRange(

--- a/src/admin/repositories/prisma-admin-subscription.repository.ts
+++ b/src/admin/repositories/prisma-admin-subscription.repository.ts
@@ -5,7 +5,6 @@ import type {
   IAdminSubscriptionRepository,
   SubscriptionPlanCount,
   SubscriptionStartedAtCount,
-  SubscriptionWithUserRevenue,
   SubscriptionWithUser,
 } from './admin-subscription.repository.interface';
 
@@ -57,29 +56,6 @@ export class PrismaAdminSubscriptionRepository
         startedAt: new Date(`${day}T00:00:00.000Z`),
         _count: count,
       }));
-  }
-
-  findActiveWithUserRevenue(): Promise<SubscriptionWithUserRevenue[]> {
-    return this.prisma.subscription.findMany({
-      where: {
-        status: 'active',
-      },
-      include: {
-        user: {
-          include: {
-            paymentTransactions: {
-              where: {
-                status: 'success',
-                deletedAt: null,
-              },
-              select: {
-                amount: true,
-              },
-            },
-          },
-        },
-      },
-    });
   }
 
   findByUserId(userId: string): Promise<Subscription | null> {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -222,6 +222,7 @@ export class PaymentService {
       receiptHash,
       result.amount ?? planDef.amount,
       result.currency ?? 'USD',
+      plan,
     );
 
     if (alreadyProcessed) {
@@ -358,6 +359,7 @@ export class PaymentService {
       receiptHash,
       result.amount ?? planDef.amount,
       result.currency ?? 'USD',
+      plan,
     );
 
     if (alreadyProcessed) {
@@ -661,6 +663,7 @@ export class PaymentService {
     reference: string,
     amount: number,
     currency: string,
+    plan: string,
   ): Promise<{ tx: TransactionRecord; alreadyProcessed: boolean }> {
     try {
       const tx = await this.paymentTransactionRepository.create({
@@ -670,6 +673,7 @@ export class PaymentService {
         currency,
         status: 'success',
         reference,
+        plan,
       });
       return { tx, alreadyProcessed: false };
     } catch (error) {


### PR DESCRIPTION
## Problem

Revenue analytics `topPlans` misattributed revenue and loaded all payment history into memory.

`PaymentTransaction` had **no plan linkage** (just `userId`, `amount`, `status`, `createdAt`). The old code loaded every active subscriber together with their **entire lifetime** successful payments, summed that spend, and charged all of it to the subscriber's **current** plan. So a user who spent months on Monthly and later upgraded to Yearly had all their Monthly revenue counted as Yearly. It also pulled every transaction row into the app to reduce in JS.

## Fix

**Give payments a plan, then aggregate by it.**

- **Schema** — add nullable `PaymentTransaction.plan`. Nullable `ADD COLUMN` with no default is a metadata-only change in Postgres (no table rewrite, no long lock), safe to run on the shared DB via `migrate deploy`. Migration is **hand-authored** (not `migrate dev`) per the shared-DB constraint.
- **Backfill** — conservative: historical rows are attributed only on an **exact** match of `amount` to the canonical **USD** plan prices (1.5 / 4.99 / 47.99 / 0). Anything else (coupons, localized amounts, other currencies) stays `NULL` rather than risk a wrong plan.
- **Write path** — both `verify-purchase` entry points already compute `plan = mapProductIdToPlan(productId)` right before creating the transaction; that value is now persisted.
- **Analytics** — `topPlans` sums revenue **per plan in the DB** (`groupRevenueByPlan`) and pairs it with active-subscription counts per plan (reusing `groupByActivePlan`). Unattributed historical revenue is surfaced as an `unknown` bucket. The in-memory lifetime scan (`findActiveWithUserRevenue`) is removed as dead code.

## Tests

`admin-revenue-analytics.service.spec.ts`:
- revenue attributed to each payment's own plan, sorted by revenue
- plans with revenue but no active subs still appear; `null` plan → `unknown`
- plans with active subs but no revenue yet still appear (count-only)

Build + eslint + specs green; real-tree `payment.service.spec.ts` 20/20 pass.

## Note

Going-forward attribution is exact. Historical attribution is best-effort by amount (unmatched rows read as `unknown`) — a full historical reconstruction isn't possible from the data that predates this column.