### PR TITLE
feat(admin): real draftStories + averageSessionTime dashboard metrics

### DIFF
--- a/docs/superpowers/plans/2026-08-13-admin-dashboard-stubs.md
+++ b/docs/superpowers/plans/2026-08-13-admin-dashboard-stubs.md
@@ -1,0 +1,828 @@
+# Admin Dashboard Stubs (`draftStories` + `avgSessionTime`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace two hardcoded admin-dashboard stubs with real data: `draftStories` (via a new `Story.isPublished` flag) and `averageSessionTime` (via a new `Session.lastActivityAt` timestamp).
+
+**Architecture:** Two independent, additive features. Feature 1 adds a boolean `Story.isPublished` (default `true`), surfaces it to admins (filter + toggle + counts), and filters it out of every public read path so drafts never reach kids/parents. Feature 2 adds `Session.lastActivityAt`, bumped throttled in the auth guard, and averages `lastActivityAt − createdAt` over a 30-day window for the dashboard.
+
+**Tech Stack:** NestJS 11, Prisma 6 (PostgreSQL), Jest, pnpm.
+
+## Global Constraints
+
+- **Shared DB:** `DATABASE_URL` points at the shared prod/dev RDS. **NEVER run `prisma migrate dev`.** Migrations are hand-authored SQL files under `prisma/migrations/`, applied by the deploy pipeline via `db:migrate:deploy`.
+- **Migrations are additive & safe:** bool `NOT NULL DEFAULT true`; nullable timestamp. Both are metadata-only ALTERs (no table rewrite).
+- **Public vs admin filtering rule:** public read paths filter `isPublished: true`; admin repositories and a kid's own-created-story views do NOT filter.
+- **No Claude signature** in commits/PRs (verify per-commit `git log -1 --format=%b`).
+- **Branch:** `feat/admin-dashboard-stubs`; PR base `develop-v1.3.0`.
+- **Build:** `pnpm build`. If `nest build`/eslint hits a transient `Segmentation fault (core dumped)`, retry once.
+- **Lint** (avoid the segfaulting wrapper): `node ./node_modules/eslint/bin/eslint.js <files>`.
+- **Test:** `npx jest <path> --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src` (the `--roots`/ignore flags suppress stale `.claude/worktrees` haste-map collisions; ignore any `jest-haste-map` warnings).
+
+---
+
+## File Structure
+
+**Feature 1 — Story draft/published:**
+- `prisma/schema.prisma` — add `Story.isPublished`
+- `prisma/migrations/20260813000000_add_ispublished_to_story/migration.sql` — new
+- `src/admin/admin-dashboard-metrics.service.ts` — real published/draft counts in `getStoryStats`
+- `src/admin/dto/admin-filters.dto.ts` — `isPublished?` on `StoryFilterDto`
+- `src/admin/dto/admin-responses.dto.ts` — `isPublished` on `StoryListItemDto`
+- `src/admin/admin-story.service.ts` — filter wiring + `toggleStoryPublish`
+- `src/admin/repositories/admin-story.repository.interface.ts` + `prisma-admin-story.repository.ts` — `updateStoryPublished`
+- `src/admin/admin-story-admin.controller.ts` — `PATCH stories/:storyId/publish`
+- `src/story/story-feed.service.ts`, `src/story/story.service.ts`, `src/story/services/daily-challenge.service.ts`, `src/story/repositories/prisma-story.repository.ts` — public draft-hiding
+
+**Feature 2 — avgSessionTime:**
+- `prisma/schema.prisma` — add `Session.lastActivityAt`
+- `prisma/migrations/20260813000001_add_lastactivityat_to_session/migration.sql` — new
+- `src/shared/guards/auth.guard.ts` — throttled `lastActivityAt` bump
+- `src/admin/repositories/admin-engagement.repository.interface.ts` + `prisma-admin-engagement.repository.ts` — `getAverageSessionSeconds`
+- `src/admin/admin-dashboard-metrics.service.ts` — wire into `getDashboardStats`
+
+---
+
+## Task 1: Add `Story.isPublished` schema + migration
+
+**Files:**
+- Modify: `prisma/schema.prisma` (Story model)
+- Create: `prisma/migrations/20260813000000_add_ispublished_to_story/migration.sql`
+
+**Interfaces:**
+- Produces: `Story.isPublished: boolean` (Prisma-typed, default `true`).
+
+- [ ] **Step 1: Add the field to the Story model**
+
+In `prisma/schema.prisma`, inside `model Story`, add after the `aiGenerated` line:
+
+```prisma
+  // Draft/published state. Default true = every existing + newly generated
+  // story is published (no behavior change). Admins can unpublish to make a
+  // story a draft; public read paths filter isPublished: true.
+  isPublished           Boolean                @default(true)
+```
+
+- [ ] **Step 2: Write the migration SQL**
+
+Create `prisma/migrations/20260813000000_add_ispublished_to_story/migration.sql`:
+
+```sql
+-- AlterTable: add draft/published flag. Nullable-free but safe: a NOT NULL
+-- column WITH a constant DEFAULT is a metadata-only change in Postgres (no
+-- table rewrite). Default true keeps every existing story published.
+ALTER TABLE "stories" ADD COLUMN "isPublished" BOOLEAN NOT NULL DEFAULT true;
+```
+
+- [ ] **Step 3: Regenerate the Prisma client (generate only — no DB access)**
+
+Run: `pnpm db:generate`
+Expected: "Generated Prisma Client".
+
+- [ ] **Step 4: Validate schema + build**
+
+Run: `npx prisma validate && pnpm build`
+Expected: schema valid, build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/20260813000000_add_ispublished_to_story
+git commit -m "feat(story): add isPublished flag (default true) + migration"
+```
+
+---
+
+## Task 2: Real `publishedStories` / `draftStories` counts
+
+**Files:**
+- Modify: `src/admin/admin-dashboard-metrics.service.ts` (`getStoryStats`, ~line 488-519)
+- Test: `src/admin/admin-dashboard-metrics.story-stats.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: `storyRepo.countStories(where)` (existing).
+- Produces: `getStoryStats()` returns `publishedStories`/`draftStories` counted by `isPublished`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/admin/admin-dashboard-metrics.story-stats.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminDashboardMetricsService } from './admin-dashboard-metrics.service';
+import {
+  ADMIN_USER_REPOSITORY,
+  ADMIN_SUBSCRIPTION_REPOSITORY,
+  ADMIN_PAYMENT_REPOSITORY,
+  ADMIN_STORY_REPOSITORY,
+  ADMIN_CONTENT_REPOSITORY,
+  ADMIN_ENGAGEMENT_REPOSITORY,
+} from './repositories';
+
+describe('AdminDashboardMetricsService.getStoryStats', () => {
+  let service: AdminDashboardMetricsService;
+  const countStories = jest.fn();
+
+  beforeEach(async () => {
+    countStories.mockReset();
+    // Return a distinct count per where so we can assert mapping regardless of
+    // call order.
+    countStories.mockImplementation((where: Record<string, unknown>) => {
+      if (where.isDeleted === true) return Promise.resolve(7); // deleted
+      if (where.isPublished === true) return Promise.resolve(300); // published
+      if (where.isPublished === false) return Promise.resolve(12); // draft
+      if (where.aiGenerated === true) return Promise.resolve(40);
+      if (where.recommended === true) return Promise.resolve(15);
+      return Promise.resolve(312); // total (isDeleted:false only)
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminDashboardMetricsService,
+        { provide: ADMIN_USER_REPOSITORY, useValue: {} },
+        { provide: ADMIN_SUBSCRIPTION_REPOSITORY, useValue: {} },
+        { provide: ADMIN_PAYMENT_REPOSITORY, useValue: {} },
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { countStories } },
+        { provide: ADMIN_CONTENT_REPOSITORY, useValue: {} },
+        {
+          provide: ADMIN_ENGAGEMENT_REPOSITORY,
+          useValue: {
+            countStoryProgress: jest.fn().mockResolvedValue(0),
+            countFavorites: jest.fn().mockResolvedValue(0),
+          },
+        },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(AdminDashboardMetricsService);
+  });
+
+  it('counts published and draft stories by isPublished', async () => {
+    const result = await service.getStoryStats();
+
+    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: true });
+    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: false });
+    expect(result.publishedStories).toBe(300);
+    expect(result.draftStories).toBe(12);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/admin/admin-dashboard-metrics.story-stats.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — `publishedStories` is 312 (total) and `draftStories` is 0.
+
+- [ ] **Step 3: Implement the counts**
+
+In `src/admin/admin-dashboard-metrics.service.ts`, in `getStoryStats`, change the `publishedStories` count (currently `countStories({ isDeleted: false })`) and add a `draftStories` count. In the destructured array (around line 488) add `draftStories,` after `publishedStories,`; in the `Promise.all` change the second entry and add a new one:
+
+```typescript
+      this.storyRepo.countStories({ isDeleted: false, isPublished: true }), // publishedStories
+      this.storyRepo.countStories({ isDeleted: false, isPublished: false }), // draftStories
+```
+
+Then in the returned `StoryStatsDto`, replace `draftStories: 0,` with `draftStories,`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/admin/admin-dashboard-metrics.story-stats.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: PASS.
+
+- [ ] **Step 5: Build + commit**
+
+```bash
+pnpm build && git add src/admin/admin-dashboard-metrics.service.ts src/admin/admin-dashboard-metrics.story-stats.spec.ts
+git commit -m "feat(admin): count published/draft stories by isPublished"
+```
+
+---
+
+## Task 3: Admin `isPublished` filter + response field
+
+**Files:**
+- Modify: `src/admin/dto/admin-filters.dto.ts` (`StoryFilterDto`)
+- Modify: `src/admin/dto/admin-responses.dto.ts` (`StoryListItemDto`)
+- Modify: `src/admin/admin-story.service.ts` (`getAllStories`)
+- Test: `src/admin/admin-story.filter.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: `StoryFilterDto`, `adminStoryRepository.findStories`/`countStories`.
+- Produces: `getAllStories({ isPublished })` filters by `isPublished`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/admin/admin-story.filter.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminStoryService } from './admin-story.service';
+import { ADMIN_STORY_REPOSITORY } from './repositories';
+
+describe('AdminStoryService.getAllStories isPublished filter', () => {
+  let service: AdminStoryService;
+  const findStories = jest.fn().mockResolvedValue([]);
+  const countStories = jest.fn().mockResolvedValue(0);
+
+  beforeEach(async () => {
+    findStories.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminStoryService,
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { findStories, countStories } },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(AdminStoryService);
+  });
+
+  it('passes isPublished:false through to the where clause', async () => {
+    await service.getAllStories({ isPublished: false } as never);
+    expect(findStories).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublished: false }) }),
+    );
+  });
+
+  it('omits isPublished from where when not provided', async () => {
+    await service.getAllStories({} as never);
+    const arg = findStories.mock.calls[0][0];
+    expect(arg.where).not.toHaveProperty('isPublished');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/admin/admin-story.filter.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — `isPublished` not in where.
+
+- [ ] **Step 3: Add the filter field to `StoryFilterDto`**
+
+In `src/admin/dto/admin-filters.dto.ts`, in `StoryFilterDto`, after the `aiGenerated`/`isAiGenerated` block add:
+
+```typescript
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  isPublished?: boolean;
+```
+
+- [ ] **Step 4: Wire it into `getAllStories`**
+
+In `src/admin/admin-story.service.ts`, `getAllStories`, add `isPublished` to the destructured `filters` and add the where clause next to the other booleans:
+
+```typescript
+    if (typeof isPublished === 'boolean') where.isPublished = isPublished;
+```
+
+- [ ] **Step 5: Expose `isPublished` on the response DTO**
+
+In `src/admin/dto/admin-responses.dto.ts`, in `StoryListItemDto`, after the `aiGenerated` property add:
+
+```typescript
+  @ApiProperty({ example: true })
+  isPublished: boolean;
+```
+
+(The value already flows via `...storyData` — the admin `findStories` uses `include`, returning all scalar fields.)
+
+- [ ] **Step 6: Run test + build**
+
+Run: `npx jest src/admin/admin-story.filter.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src && pnpm build`
+Expected: PASS + build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/admin/dto/admin-filters.dto.ts src/admin/dto/admin-responses.dto.ts src/admin/admin-story.service.ts src/admin/admin-story.filter.spec.ts
+git commit -m "feat(admin): filter stories by isPublished + expose it in list DTO"
+```
+
+---
+
+## Task 4: Publish toggle endpoint
+
+**Files:**
+- Modify: `src/admin/repositories/admin-story.repository.interface.ts` (add `updateStoryPublished`)
+- Modify: `src/admin/repositories/prisma-admin-story.repository.ts` (impl)
+- Modify: `src/admin/admin-story.service.ts` (`toggleStoryPublish`)
+- Modify: `src/admin/admin-story-admin.controller.ts` (route)
+- Test: `src/admin/admin-story.toggle-publish.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: `adminStoryRepository.findStoryById`, `storyExists`.
+- Produces: `AdminStoryService.toggleStoryPublish(storyId): Promise<Story>`; repo `updateStoryPublished({ storyId, isPublished }): Promise<Story>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/admin/admin-story.toggle-publish.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminStoryService } from './admin-story.service';
+import { ADMIN_STORY_REPOSITORY } from './repositories';
+
+describe('AdminStoryService.toggleStoryPublish', () => {
+  let service: AdminStoryService;
+  const storyExists = jest.fn().mockResolvedValue(true);
+  const findStoryById = jest.fn().mockResolvedValue({ id: 's1', isPublished: true });
+  const updateStoryPublished = jest.fn().mockResolvedValue({ id: 's1', isPublished: false });
+
+  beforeEach(async () => {
+    updateStoryPublished.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminStoryService,
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { storyExists, findStoryById, updateStoryPublished } },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(AdminStoryService);
+  });
+
+  it('flips isPublished to the opposite of current', async () => {
+    const result = await service.toggleStoryPublish('s1');
+    expect(updateStoryPublished).toHaveBeenCalledWith({ storyId: 's1', isPublished: false });
+    expect(result.isPublished).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/admin/admin-story.toggle-publish.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — `toggleStoryPublish` / `updateStoryPublished` don't exist.
+
+- [ ] **Step 3: Add repo interface method**
+
+In `src/admin/repositories/admin-story.repository.interface.ts`, after `updateStoryRecommendation`, add:
+
+```typescript
+  updateStoryPublished(params: {
+    storyId: string;
+    isPublished: boolean;
+  }): Promise<Story>;
+```
+
+- [ ] **Step 4: Implement in the prisma repo**
+
+In `src/admin/repositories/prisma-admin-story.repository.ts`, after `updateStoryRecommendation`, add:
+
+```typescript
+  async updateStoryPublished(params: {
+    storyId: string;
+    isPublished: boolean;
+  }): Promise<Story> {
+    return this.prisma.story.update({
+      where: { id: params.storyId },
+      data: { isPublished: params.isPublished },
+    });
+  }
+```
+
+- [ ] **Step 5: Add the service method**
+
+In `src/admin/admin-story.service.ts`, mirror `toggleStoryRecommendation`:
+
+```typescript
+  async toggleStoryPublish(storyId: string): Promise<Story> {
+    const storyExists = await this.adminStoryRepository.storyExists(storyId);
+    if (!storyExists) {
+      throw new ResourceNotFoundException('Story', storyId);
+    }
+    const story = await this.adminStoryRepository.findStoryById(storyId);
+    if (!story) {
+      throw new ResourceNotFoundException('Story', storyId);
+    }
+    const result = await this.adminStoryRepository.updateStoryPublished({
+      storyId,
+      isPublished: !story.isPublished,
+    });
+    try {
+      await this.cacheManager.del(CACHE_KEYS.STORY_STATS);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to invalidate story stats cache: ${error.message}`,
+      );
+    }
+    return result;
+  }
+```
+
+- [ ] **Step 6: Add the controller route**
+
+In `src/admin/admin-story-admin.controller.ts`, mirror the `stories/:storyId/recommend` route:
+
+```typescript
+  @Patch('stories/:storyId/publish')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Toggle story published state',
+    description: 'Toggles the isPublished flag for a story (publish/unpublish).',
+  })
+  @ApiParam({ name: 'storyId', type: String, description: 'Story ID' })
+  @ApiOkResponse({ description: 'Story published state toggled successfully' })
+  @ApiResponse({ status: 404, description: 'Story not found' })
+  async toggleStoryPublish(@Param('storyId') storyId: string) {
+    const data = await this.adminService.toggleStoryPublish(storyId);
+    return {
+      statusCode: 200,
+      message: 'Story published state toggled successfully',
+      data,
+    };
+  }
+```
+
+- [ ] **Step 7: Run test + build**
+
+Run: `npx jest src/admin/admin-story.toggle-publish.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src && pnpm build`
+Expected: PASS + build.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/admin/repositories/admin-story.repository.interface.ts src/admin/repositories/prisma-admin-story.repository.ts src/admin/admin-story.service.ts src/admin/admin-story-admin.controller.ts src/admin/admin-story.toggle-publish.spec.ts
+git commit -m "feat(admin): add publish/unpublish toggle endpoint for stories"
+```
+
+---
+
+## Task 5: Hide drafts from all public read paths
+
+**Files:**
+- Modify: `src/story/story-feed.service.ts` (base where + home carousels + topPicks count)
+- Modify: `src/story/story.service.ts` (`getStoryById`, `getTopPicksFromParents`, `getTopPicksFromUs`, daily-challenge pool)
+- Modify: `src/story/services/daily-challenge.service.ts` (assignment pool)
+- Modify: `src/story/repositories/prisma-story.repository.ts` (raw-SQL id generators)
+- Test: `src/story/story-feed.draft-hiding.spec.ts` (create) — chokepoint coverage
+
+**Interfaces:**
+- Consumes: existing story repos.
+- Produces: no draft (`isPublished:false`) appears in any public list/feed or single-read.
+
+**Rule:** add `isPublished: true` to each public **where**. Do NOT touch the admin repo, and do NOT add it to a kid's own-created-story view (`getCreatedStories`) — a kid always sees their own generations.
+
+- [ ] **Step 1: Write the failing tests (chokepoints)**
+
+Create `src/story/story-feed.draft-hiding.spec.ts`. This asserts the two chokepoints pass `isPublished: true` to the repo. Mock only what these methods touch; if a method needs more collaborators, extend the mocks until it runs.
+
+```typescript
+import { StoryFeedService } from './story-feed.service';
+
+describe('public read paths hide drafts', () => {
+  it('buildStoryWhereClause base where includes isPublished: true', async () => {
+    const svc = new StoryFeedService(...deps); // construct with mocked deps
+    // buildStoryWhereClause is private; call the public getStories and assert
+    // the repo received a where with isPublished: true.
+    const findManyStoriesRaw = jest.fn().mockResolvedValue([]);
+    // ...wire findManyStoriesRaw into the mocked story repo...
+    await svc.getStories({} as never);
+    expect(findManyStoriesRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublished: true }) }),
+    );
+  });
+});
+```
+
+Note: `StoryFeedService`'s constructor deps must be read from `src/story/story-feed.service.ts` and mocked. If wiring the full service is impractical, instead assert at `StoryService.getStoryById`:
+
+```typescript
+import { StoryService } from './story.service';
+
+it('getStoryById filters isPublished: true', async () => {
+  const findUniqueStoryRaw = jest.fn().mockResolvedValue({ id: 's1' });
+  const svc = new StoryService(...deps); // storyRepository.findUniqueStoryRaw = findUniqueStoryRaw
+  await svc.getStoryById('s1');
+  expect(findUniqueStoryRaw).toHaveBeenCalledWith(
+    expect.objectContaining({ where: expect.objectContaining({ id: 's1', isPublished: true }) }),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/story/story-feed.draft-hiding.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — where has no `isPublished`.
+
+- [ ] **Step 3: Edit `story-feed.service.ts`**
+
+- `buildStoryWhereClause` base where (~line 74): change `{ isDeleted: false }` to `{ isDeleted: false, isPublished: true }`.
+- topPicks count branch (~line 305): `countStoriesRaw({ isDeleted: false, isPublished: true })`.
+- `getHomePageStories` carousels — add `isPublished: true` to each inline `where`: recommended base (~999/1006), seasonal (~1038, ~1063, ~1086), topLiked (~1106, ~1117).
+
+- [ ] **Step 4: Edit `story.service.ts`**
+
+- `getStoryById` (~line 553): `where: { id, isDeleted: false, isPublished: true }`.
+- `getTopPicksFromParents` (~line 696): add `isPublished: true` to the `{ id: { in }, isDeleted: false }` where.
+- `getTopPicksFromUs` second query (~line 744-745): add `isPublished: true` alongside `id: { in: randomIds }`.
+- daily-challenge pool query (~line 474-478): add `isPublished: true`.
+- Leave `getCreatedStories` (~610) unfiltered (kid's own content).
+
+- [ ] **Step 5: Edit `daily-challenge.service.ts`**
+
+- Assignment pool `findStories({ where: { isDeleted: false } })` (~line 117): add `isPublished: true`.
+
+- [ ] **Step 6: Edit raw-SQL id generators in `prisma-story.repository.ts`**
+
+- `getRandomStoryIdsFromStories` (~line 1185): change `WHERE "isDeleted" = false` to `WHERE "isDeleted" = false AND "isPublished" = true`.
+- `getDeterministicStoryIdsFromStories` (~line 1199): same edit.
+
+- [ ] **Step 7: Run test + build**
+
+Run: `npx jest src/story/story-feed.draft-hiding.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src && pnpm build`
+Expected: PASS + build.
+
+- [ ] **Step 8: Regression-run the story test suite**
+
+Run: `npx jest src/story --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: existing story tests still pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/story/story-feed.service.ts src/story/story.service.ts src/story/services/daily-challenge.service.ts src/story/repositories/prisma-story.repository.ts src/story/story-feed.draft-hiding.spec.ts
+git commit -m "feat(story): hide unpublished (draft) stories from public read paths"
+```
+
+**Known limitation (documented, out of scope):** a story unpublished *after* a user already has progress on / downloaded / favorited it can still appear in that user's continue-reading / library joins (`prisma-story.repository.ts:269,284,349,364` and download/favorite joins). Strict-hiding those requires a nested `story: { isPublished: true }` filter; deferred.
+
+---
+
+## Task 6: Add `Session.lastActivityAt` schema + migration
+
+**Files:**
+- Modify: `prisma/schema.prisma` (Session model)
+- Create: `prisma/migrations/20260813000001_add_lastactivityat_to_session/migration.sql`
+
+**Interfaces:**
+- Produces: `Session.lastActivityAt: Date | null`.
+
+- [ ] **Step 1: Add the field**
+
+In `prisma/schema.prisma`, in `model Session`, after `createdAt`, add:
+
+```prisma
+  // Last time an authenticated request used this session (bumped, throttled, by
+  // AuthSessionGuard). Nullable: pre-existing sessions predate it. Enables
+  // avg session duration = lastActivityAt - createdAt.
+  lastActivityAt DateTime?
+```
+
+- [ ] **Step 2: Write the migration SQL**
+
+Create `prisma/migrations/20260813000001_add_lastactivityat_to_session/migration.sql`:
+
+```sql
+-- AlterTable: add nullable last-activity timestamp (metadata-only, no rewrite).
+ALTER TABLE "sessions" ADD COLUMN "lastActivityAt" TIMESTAMP(3);
+```
+
+- [ ] **Step 3: Generate + validate + build**
+
+Run: `pnpm db:generate && npx prisma validate && pnpm build`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/20260813000001_add_lastactivityat_to_session
+git commit -m "feat(session): add lastActivityAt timestamp + migration"
+```
+
+---
+
+## Task 7: Throttled `lastActivityAt` bump in the auth guard
+
+**Files:**
+- Modify: `src/shared/guards/auth.guard.ts`
+- Test: `src/shared/guards/auth.guard.last-activity.spec.ts` (create)
+
+**Interfaces:**
+- Consumes: the `session` object already loaded in `validateRequest`, `this.prisma.session.update`.
+- Produces: on a valid session, `lastActivityAt` is set to now when it is null or older than 60s; the update is fire-and-forget (never awaited, errors swallowed).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/shared/guards/auth.guard.last-activity.spec.ts`:
+
+```typescript
+import { AuthSessionGuard } from './auth.guard';
+
+const THRESHOLD_MS = 60_000;
+
+function makeGuard(session: Record<string, unknown>) {
+  const update = jest.fn().mockResolvedValue({});
+  const prisma = { session: { findUnique: jest.fn().mockResolvedValue(session), update } } as never;
+  const jwt = { verify: jest.fn().mockReturnValue({ userId: 'u1', authSessionId: 'sess1' }) } as never;
+  const reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as never;
+  const guard = new AuthSessionGuard(jwt, reflector, prisma);
+  const ctx = {
+    switchToHttp: () => ({ getRequest: () => ({ headers: { authorization: 'Bearer t' } }) }),
+    getHandler: () => null,
+    getClass: () => null,
+  } as never;
+  return { guard, update, ctx };
+}
+
+const baseSession = {
+  id: 'sess1',
+  isDeleted: false,
+  deletedAt: null,
+  expiresAt: new Date(Date.now() + 3_600_000),
+  createdAt: new Date(Date.now() - 7_200_000),
+};
+
+it('bumps lastActivityAt when null', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: null });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r)); // let the fire-and-forget settle
+  expect(update).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { id: 'sess1' }, data: expect.objectContaining({ lastActivityAt: expect.any(Date) }) }),
+  );
+});
+
+it('bumps when lastActivityAt is stale (> 60s)', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - THRESHOLD_MS - 1000) });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r));
+  expect(update).toHaveBeenCalled();
+});
+
+it('does NOT bump when lastActivityAt is fresh (< 60s)', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - 5000) });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r));
+  expect(update).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/shared/guards/auth.guard.last-activity.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — no update call.
+
+- [ ] **Step 3: Implement the throttled bump**
+
+In `src/shared/guards/auth.guard.ts`, inside `validateRequest`, after the `session.expiresAt < new Date()` check passes and before `return true`, add:
+
+```typescript
+      // Track last activity for avg-session-time analytics. Throttled to at most
+      // one write per 60s per session; fire-and-forget so it never adds latency
+      // or fails an otherwise-valid request.
+      const ACTIVITY_THROTTLE_MS = 60_000;
+      const last = session.lastActivityAt?.getTime() ?? 0;
+      if (Date.now() - last > ACTIVITY_THROTTLE_MS) {
+        void this.prisma.session
+          .update({ where: { id: session.id }, data: { lastActivityAt: new Date() } })
+          .catch(() => undefined);
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/shared/guards/auth.guard.last-activity.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: PASS (all 3).
+
+- [ ] **Step 5: Build + commit**
+
+```bash
+pnpm build && git add src/shared/guards/auth.guard.ts src/shared/guards/auth.guard.last-activity.spec.ts
+git commit -m "feat(auth): track session lastActivityAt (throttled, fire-and-forget)"
+```
+
+---
+
+## Task 8: Compute `avgSessionTime` + wire into dashboard
+
+**Files:**
+- Modify: `src/admin/repositories/admin-engagement.repository.interface.ts`
+- Modify: `src/admin/repositories/prisma-admin-engagement.repository.ts`
+- Modify: `src/admin/admin-dashboard-metrics.service.ts` (`getDashboardStats`)
+- Test: `src/admin/prisma-admin-engagement.avg-session.spec.ts` (create)
+
+**Interfaces:**
+- Produces: `IAdminEngagementRepository.getAverageSessionSeconds(start: Date, end: Date): Promise<number>`.
+- Consumes (in metrics): `range30d.start`, `range30d.end` (already computed in `getDashboardStats`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/admin/prisma-admin-engagement.avg-session.spec.ts`:
+
+```typescript
+import { PrismaAdminEngagementRepository } from './repositories/prisma-admin-engagement.repository';
+
+describe('getAverageSessionSeconds', () => {
+  function repoWith(rows: { createdAt: Date; lastActivityAt: Date | null }[]) {
+    const prisma = { session: { findMany: jest.fn().mockResolvedValue(rows) } } as never;
+    return new PrismaAdminEngagementRepository(prisma);
+  }
+
+  it('averages (lastActivityAt - createdAt) in seconds, excluding nulls', async () => {
+    const base = new Date('2026-08-01T00:00:00Z').getTime();
+    const repo = repoWith([
+      { createdAt: new Date(base), lastActivityAt: new Date(base + 100_000) }, // 100s
+      { createdAt: new Date(base), lastActivityAt: new Date(base + 300_000) }, // 300s
+    ]);
+    const avg = await repo.getAverageSessionSeconds(new Date(base - 1000), new Date(base + 1_000_000));
+    expect(avg).toBe(200);
+  });
+
+  it('returns 0 when there are no qualifying sessions', async () => {
+    const repo = repoWith([]);
+    expect(await repo.getAverageSessionSeconds(new Date(), new Date())).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/admin/prisma-admin-engagement.avg-session.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src`
+Expected: FAIL — method missing.
+
+- [ ] **Step 3: Add the interface method**
+
+In `src/admin/repositories/admin-engagement.repository.interface.ts`, add to `IAdminEngagementRepository`:
+
+```typescript
+  // Average session duration (seconds) over sessions active in [start, end].
+  // Uses lastActivityAt - createdAt; sessions without lastActivityAt excluded.
+  getAverageSessionSeconds(start: Date, end: Date): Promise<number>;
+```
+
+- [ ] **Step 4: Implement it**
+
+In `src/admin/repositories/prisma-admin-engagement.repository.ts`, add:
+
+```typescript
+  async getAverageSessionSeconds(start: Date, end: Date): Promise<number> {
+    const rows = await this.prisma.session.findMany({
+      where: {
+        isDeleted: false,
+        lastActivityAt: { not: null, gte: start, lte: end },
+      },
+      select: { createdAt: true, lastActivityAt: true },
+    });
+    if (rows.length === 0) return 0;
+    const totalSeconds = rows.reduce((sum, r) => {
+      const lastActivity = r.lastActivityAt as Date;
+      return sum + (lastActivity.getTime() - r.createdAt.getTime()) / 1000;
+    }, 0);
+    return totalSeconds / rows.length;
+  }
+```
+
+- [ ] **Step 5: Wire into `getDashboardStats`**
+
+In `src/admin/admin-dashboard-metrics.service.ts`, replace `const avgSessionTime = 0; // Placeholder` with:
+
+```typescript
+    const avgSessionTime = await this.engagementRepo.getAverageSessionSeconds(
+      range30d.start,
+      range30d.end,
+    );
+```
+
+(`range30d` is already computed near the top of `getDashboardStats`.)
+
+- [ ] **Step 6: Run test + build**
+
+Run: `npx jest src/admin/prisma-admin-engagement.avg-session.spec.ts --modulePathIgnorePatterns='/.claude/worktrees/' --roots=/home/williams/Documents/storytime/storytime_be/src && pnpm build`
+Expected: PASS + build.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/admin/repositories/admin-engagement.repository.interface.ts src/admin/repositories/prisma-admin-engagement.repository.ts src/admin/admin-dashboard-metrics.service.ts src/admin/prisma-admin-engagement.avg-session.spec.ts
+git commit -m "feat(admin): compute averageSessionTime from session lastActivityAt"
+```
+
+---
+
+## Task 9: Final lint + PR
+
+- [ ] **Step 1: Lint all changed files**
+
+Run: `node ./node_modules/eslint/bin/eslint.js $(git diff --name-only develop-v1.3.0...HEAD -- '*.ts')`
+Expected: exit 0.
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push "https://x-access-token:$(gh auth token)@github.com/Bolt-Silverfox/storytime_be.git" HEAD:feat/admin-dashboard-stubs
+gh pr create --repo Bolt-Silverfox/storytime_be --base develop-v1.3.0 --head feat/admin-dashboard-stubs \
+  --title "feat(admin): real draftStories + averageSessionTime dashboard metrics" \
+  --body "Implements docs/superpowers/specs/2026-08-13-admin-dashboard-stubs-design.md. Adds Story.isPublished (default true; admin filter/toggle/counts; hidden from public read paths) and Session.lastActivityAt (throttled bump in auth guard; averaged over 30d for the dashboard). Two additive migrations."
+```
+
+- [ ] **Step 3: Babysit checks; merge when green** (Build, Code Quality, CodeQL, Test, CodeRabbit). Deploy runs `db:migrate:deploy` on merge — confirm the "Run database migrations" step succeeds (both migrations are additive/safe).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Story schema (T1) · publishedStories/draftStories (T2) · admin filter+DTO (T3) · publish toggle (T4) · public draft-hiding (T5) · Session schema (T6) · guard tracking (T7) · avg computation + wiring (T8). All spec sections mapped.
+- **Rollout caveat** from spec (avgSessionTime starts ~0, no backfill; draftStories 0 until admin unpublishes) holds — no task backfills, matching the design.
+- **Non-goals** respected: boolean not enum; no client session events; no `stories.isPublished` index; kid-created stories stay published via `@default(true)` (no creator-kid exemption needed).

--- a/docs/superpowers/specs/2026-08-13-admin-dashboard-stubs-design.md
+++ b/docs/superpowers/specs/2026-08-13-admin-dashboard-stubs-design.md
@@ -1,0 +1,148 @@
+# Admin dashboard stubs: `draftStories` + `avgSessionTime`
+
+**Date:** 2026-08-13
+**Status:** Approved (design)
+**Line:** `develop-v1.3.0`
+
+## Background
+
+Two admin-dashboard metrics were hardcoded stubs (from the admin-section audit):
+
+- `draftStories` is always `0`, and `publishedStories` is just the total story
+  count — because `Story` has no draft/published concept.
+- `averageSessionTime` is a `= 0` placeholder — session duration is recorded
+  nowhere. The `Session` model has `createdAt` and `expiresAt` (token expiry),
+  but no logout or last-seen timestamp.
+
+This spec adds the minimal data + logic to make both metrics real. The two
+features are independent but small, so they share one spec and one plan.
+
+Both schema changes are additive and **hand-authored** (no `prisma migrate dev`
+— `DATABASE_URL` points at the shared prod/dev RDS), applied via
+`db:migrate:deploy` in the deploy pipeline.
+
+## Feature 1 — Story draft/published
+
+### Schema
+
+Add to `model Story`:
+
+```prisma
+isPublished Boolean @default(true)
+```
+
+Migration:
+
+```sql
+ALTER TABLE "stories" ADD COLUMN "isPublished" BOOLEAN NOT NULL DEFAULT true;
+```
+
+`DEFAULT true` = every existing story stays published → zero behavior change on
+deploy. No index in this change (stories table is small and story-count metrics
+are cached; an `@@index([isPublished, isDeleted])` can be added later if a query
+shows up hot).
+
+### Admin surface
+
+- `StoryFilterDto`: add optional `isPublished?: boolean` filter; wire into
+  `AdminStoryService.getAllStories` `where` (same pattern as `recommended` /
+  `aiGenerated`).
+- Admin story DTOs (`StoryListItemDto`, `StoryDetailDto`): expose `isPublished`.
+- Publish toggle: add `toggleStoryPublish(storyId)` mirroring the existing
+  `toggleStoryRecommendation` (service + repository method + controller route +
+  cache invalidation of story-stats).
+- Metrics (`admin-dashboard-metrics.service.ts`):
+  - `publishedStories = countStories({ isDeleted: false, isPublished: true })`
+  - `draftStories = countStories({ isDeleted: false, isPublished: false })`
+  - (replaces the current `publishedStories = total` and `draftStories: 0`.)
+
+### Public surface (correctness-critical)
+
+Drafts must never reach kids/parents. The public-facing story **list/feed**
+queries get `isPublished: true` added to their `where`; single-story lookups
+used by public read paths are gated too. **Admin** repository queries stay
+unfiltered (admins see drafts). The exact query sites (across
+`src/story/repositories/*`) are enumerated in the implementation plan; the rule
+is: public read path → filter `isPublished: true`; admin path → no filter.
+
+## Feature 2 — avgSessionTime via `Session.lastActivityAt`
+
+### Schema
+
+Add to `model Session`:
+
+```prisma
+lastActivityAt DateTime?
+```
+
+Migration:
+
+```sql
+ALTER TABLE "sessions" ADD COLUMN "lastActivityAt" TIMESTAMP(3);
+```
+
+Nullable — pre-existing sessions have no activity timestamp.
+
+### Write path (tracking)
+
+`AuthSessionGuard.validateRequest` already loads the session via
+`findUnique` on every authenticated request. After the session passes
+validation, do a **throttled** bump:
+
+```
+if session.lastActivityAt is null OR (now - session.lastActivityAt) > 60_000ms:
+    fire-and-forget prisma.session.update({ where:{id}, data:{ lastActivityAt: now } })
+```
+
+The update is **not awaited** and its rejection is swallowed (`.catch`), so it
+adds no latency and can never fail an otherwise-valid request. The 60s throttle
+keeps this from becoming a write on every request.
+
+### Read path (metric)
+
+New engagement-repo method:
+
+```
+getAverageSessionSeconds(start: Date, end: Date): Promise<number>
+```
+
+`findMany` sessions with `lastActivityAt` in `[start, end]`, `lastActivityAt`
+not null, not soft-deleted; select `createdAt` + `lastActivityAt`; return the
+mean of `(lastActivityAt - createdAt) / 1000` seconds (0 when there are none).
+Sessions with null `lastActivityAt` (login but no subsequent authenticated
+request) are excluded — their duration is unknown, not zero.
+
+Wire into `getDashboardStats` over a trailing 30-day window, replacing
+`const avgSessionTime = 0`.
+
+### Honest caveat
+
+This measures **going forward**. Historical sessions have no activity timestamp,
+so the metric starts near 0 and builds up as sessions accrue `lastActivityAt`.
+No backfill is possible — the data never existed.
+
+## Testing
+
+- **Story metrics:** `publishedStories` / `draftStories` count by `isPublished`.
+- **Public feed excludes drafts:** a story with `isPublished:false` does not
+  appear in the public list query; admin list still shows it.
+- **Admin filter:** `getAllStories({ isPublished:false })` returns only drafts.
+- **Guard throttle:** bumps `lastActivityAt` when null/stale (>60s); skips the
+  write when fresh (<60s).
+- **Average:** excludes null `lastActivityAt`, averages `(last-created)` in
+  seconds, returns 0 on empty.
+
+## Non-goals
+
+- No enum/`ARCHIVED` state for stories (YAGNI — boolean chosen).
+- No client-side session events (mobile/web) — server-derived tracking only.
+- No backfill of historical session durations.
+- No index on `stories.isPublished` in this change.
+
+## Rollout
+
+Two additive migrations (bool NOT NULL DEFAULT true; nullable timestamp), both
+safe on the shared DB. On merge to `develop-v1.3.0`, the deploy job runs
+`db:migrate:deploy` (verified working on PR #498). `avgSessionTime` reads ~0
+immediately post-deploy and climbs; `draftStories` reads 0 until an admin marks
+a story as a draft.

--- a/prisma/migrations/20260810000000_add_plan_to_payment_transaction/migration.sql
+++ b/prisma/migrations/20260810000000_add_plan_to_payment_transaction/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable: add nullable `plan` for per-plan revenue attribution.
+-- Nullable column with no default = metadata-only change in Postgres (no table
+-- rewrite, no long lock), safe to run on the shared DB via `migrate deploy`.
+ALTER TABLE "payment_transactions" ADD COLUMN "plan" TEXT;
+
+-- Best-effort backfill of historical rows by matching the charged amount to the
+-- canonical USD plan prices. Deliberately conservative: only exact matches on
+-- USD (or unspecified currency) are attributed; everything else stays NULL
+-- ("unknown") rather than risk a wrong plan. A coupon/promo/localized amount
+-- simply won't match and remains NULL, which is the correct, non-misleading
+-- outcome. Going forward the column is populated from the store productId at
+-- purchase time, so this only affects rows created before this migration.
+UPDATE "payment_transactions"
+SET "plan" = CASE
+    WHEN "amount" = 1.5 THEN 'weekly'
+    WHEN "amount" = 4.99 THEN 'monthly'
+    WHEN "amount" = 47.99 THEN 'yearly'
+    WHEN "amount" = 0 THEN 'free'
+END
+WHERE "plan" IS NULL
+  AND ("currency" = 'USD' OR "currency" IS NULL)
+  AND "amount" IN (1.5, 4.99, 47.99, 0);

--- a/prisma/migrations/20260813000000_add_ispublished_to_story/migration.sql
+++ b/prisma/migrations/20260813000000_add_ispublished_to_story/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: add draft/published flag. Nullable-free but safe: a NOT NULL
+-- column WITH a constant DEFAULT is a metadata-only change in Postgres (no
+-- table rewrite). Default true keeps every existing story published.
+ALTER TABLE "stories" ADD COLUMN "isPublished" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260813000001_add_lastactivityat_to_session/migration.sql
+++ b/prisma/migrations/20260813000001_add_lastactivityat_to_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add nullable last-activity timestamp (metadata-only, no rewrite).
+ALTER TABLE "sessions" ADD COLUMN "lastActivityAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -226,6 +226,10 @@ model Session {
   token     String    @unique
   expiresAt DateTime
   createdAt DateTime  @default(now())
+  // Last time an authenticated request used this session (bumped, throttled, by
+  // AuthSessionGuard). Nullable: pre-existing sessions predate it. Enables
+  // avg session duration = lastActivityAt - createdAt.
+  lastActivityAt DateTime?
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   // SOFT DELETE FIELDS
   isDeleted Boolean   @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -332,6 +332,10 @@ model Story {
   backgroundColor       String                 @default("#5E3A54")
   recommended           Boolean                @default(false)
   aiGenerated           Boolean                @default(false)
+  // Draft/published state. Default true = every existing + newly generated
+  // story is published (no behavior change). Admins can unpublish to make a
+  // story a draft; public read paths filter isPublished: true.
+  isPublished           Boolean                @default(true)
   difficultyLevel       Int                    @default(1)
   wordCount             Int                    @default(0)
   durationSeconds       Int? // Estimated reading time in seconds

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -599,6 +599,12 @@ model PaymentTransaction {
   reference       String?
   amount          Float
   status          String
+  // Plan this payment was for (weekly/monthly/yearly/free), resolved from the
+  // store productId at purchase time. Nullable: pre-existing rows predate this
+  // column, and it stays null when the productId can't be mapped. Enables
+  // per-plan revenue attribution instead of charging a user's whole payment
+  // history to whatever plan they happen to be on now.
+  plan            String?
   createdAt       DateTime       @default(now())
   // SOFT DELETE FIELDS
   isDeleted       Boolean        @default(false)

--- a/src/admin/admin-dashboard-metrics.service.ts
+++ b/src/admin/admin-dashboard-metrics.service.ts
@@ -250,7 +250,10 @@ export class AdminDashboardMetricsService {
     const subscriptionPlans =
       await this.subscriptionRepo.groupByActivePlan(now);
 
-    const avgSessionTime = 0; // Placeholder
+    const avgSessionTime = await this.engagementRepo.getAverageSessionSeconds(
+      range30d.start,
+      range30d.end,
+    );
     const paidUsers = activeSubscriptionsCount;
     const unpaidUsers = totalUsersCount - paidUsers;
     const prevPaidUsers = prevActiveSubscriptionsCount;

--- a/src/admin/admin-dashboard-metrics.service.ts
+++ b/src/admin/admin-dashboard-metrics.service.ts
@@ -488,6 +488,7 @@ export class AdminDashboardMetricsService {
     const [
       totalStories,
       publishedStories,
+      draftStories,
       aiGeneratedStories,
       recommendedStories,
       deletedStories,
@@ -495,7 +496,8 @@ export class AdminDashboardMetricsService {
       totalFavorites,
     ] = await Promise.all([
       this.storyRepo.countStories({ isDeleted: false }),
-      this.storyRepo.countStories({ isDeleted: false }),
+      this.storyRepo.countStories({ isDeleted: false, isPublished: true }), // publishedStories
+      this.storyRepo.countStories({ isDeleted: false, isPublished: false }), // draftStories
       this.storyRepo.countStories({
         aiGenerated: true,
         isDeleted: false,
@@ -512,7 +514,7 @@ export class AdminDashboardMetricsService {
     const result: StoryStatsDto = {
       totalStories,
       publishedStories,
-      draftStories: 0,
+      draftStories,
       aiGeneratedStories,
       recommendedStories,
       deletedStories,

--- a/src/admin/admin-dashboard-metrics.story-stats.spec.ts
+++ b/src/admin/admin-dashboard-metrics.story-stats.spec.ts
@@ -42,7 +42,10 @@ describe('AdminDashboardMetricsService.getStoryStats', () => {
             countFavorites: jest.fn().mockResolvedValue(0),
           },
         },
-        { provide: CACHE_MANAGER, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -52,8 +55,14 @@ describe('AdminDashboardMetricsService.getStoryStats', () => {
   it('counts published and draft stories by isPublished', async () => {
     const result = await service.getStoryStats();
 
-    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: true });
-    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: false });
+    expect(countStories).toHaveBeenCalledWith({
+      isDeleted: false,
+      isPublished: true,
+    });
+    expect(countStories).toHaveBeenCalledWith({
+      isDeleted: false,
+      isPublished: false,
+    });
     expect(result.publishedStories).toBe(300);
     expect(result.draftStories).toBe(12);
   });

--- a/src/admin/admin-dashboard-metrics.story-stats.spec.ts
+++ b/src/admin/admin-dashboard-metrics.story-stats.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminDashboardMetricsService } from './admin-dashboard-metrics.service';
+import {
+  ADMIN_USER_REPOSITORY,
+  ADMIN_SUBSCRIPTION_REPOSITORY,
+  ADMIN_PAYMENT_REPOSITORY,
+  ADMIN_STORY_REPOSITORY,
+  ADMIN_CONTENT_REPOSITORY,
+  ADMIN_ENGAGEMENT_REPOSITORY,
+} from './repositories';
+
+describe('AdminDashboardMetricsService.getStoryStats', () => {
+  let service: AdminDashboardMetricsService;
+  const countStories = jest.fn();
+
+  beforeEach(async () => {
+    countStories.mockReset();
+    // Return a distinct count per where so we can assert mapping regardless of
+    // call order.
+    countStories.mockImplementation((where: Record<string, unknown>) => {
+      if (where.isDeleted === true) return Promise.resolve(7); // deleted
+      if (where.isPublished === true) return Promise.resolve(300); // published
+      if (where.isPublished === false) return Promise.resolve(12); // draft
+      if (where.aiGenerated === true) return Promise.resolve(40);
+      if (where.recommended === true) return Promise.resolve(15);
+      return Promise.resolve(312); // total (isDeleted:false only)
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminDashboardMetricsService,
+        { provide: ADMIN_USER_REPOSITORY, useValue: {} },
+        { provide: ADMIN_SUBSCRIPTION_REPOSITORY, useValue: {} },
+        { provide: ADMIN_PAYMENT_REPOSITORY, useValue: {} },
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { countStories } },
+        { provide: ADMIN_CONTENT_REPOSITORY, useValue: {} },
+        {
+          provide: ADMIN_ENGAGEMENT_REPOSITORY,
+          useValue: {
+            countStoryProgress: jest.fn().mockResolvedValue(0),
+            countFavorites: jest.fn().mockResolvedValue(0),
+          },
+        },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(AdminDashboardMetricsService);
+  });
+
+  it('counts published and draft stories by isPublished', async () => {
+    const result = await service.getStoryStats();
+
+    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: true });
+    expect(countStories).toHaveBeenCalledWith({ isDeleted: false, isPublished: false });
+    expect(result.publishedStories).toBe(300);
+    expect(result.draftStories).toBe(12);
+  });
+});

--- a/src/admin/admin-revenue-analytics.service.spec.ts
+++ b/src/admin/admin-revenue-analytics.service.spec.ts
@@ -6,14 +6,19 @@ import {
   ADMIN_ACTIVITY_REPOSITORY,
 } from './repositories';
 
-describe('AdminRevenueAnalyticsService — churn rate', () => {
+describe('AdminRevenueAnalyticsService', () => {
   let service: AdminRevenueAnalyticsService;
   let subscriptionRepo: {
     count: jest.Mock;
     groupByStartedAt: jest.Mock;
     groupByActivePlan: jest.Mock;
   };
-  let paymentRepo: { groupRevenueByCreatedAt: jest.Mock };
+  let paymentRepo: {
+    groupRevenueByCreatedAt: jest.Mock;
+    groupRevenueByCreatedAtOrdered: jest.Mock;
+    findSuccessfulInRange: jest.Mock;
+    groupRevenueByPlan: jest.Mock;
+  };
 
   const range = { startDate: '2026-07-01', endDate: '2026-07-31' };
 
@@ -23,7 +28,12 @@ describe('AdminRevenueAnalyticsService — churn rate', () => {
       groupByStartedAt: jest.fn().mockResolvedValue([]),
       groupByActivePlan: jest.fn().mockResolvedValue([]),
     };
-    paymentRepo = { groupRevenueByCreatedAt: jest.fn().mockResolvedValue([]) };
+    paymentRepo = {
+      groupRevenueByCreatedAt: jest.fn().mockResolvedValue([]),
+      groupRevenueByCreatedAtOrdered: jest.fn().mockResolvedValue([]),
+      findSuccessfulInRange: jest.fn().mockResolvedValue([]),
+      groupRevenueByPlan: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -99,5 +109,55 @@ describe('AdminRevenueAnalyticsService — churn rate', () => {
     const result = await service.getSubscriptionAnalytics(range);
 
     expect(result.churnRate).toBe(0);
+  });
+
+  describe('topPlans revenue attribution', () => {
+    it('attributes revenue to the plan each payment was for, not the payer current plan', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([
+        { plan: 'monthly', _sum: { amount: 100 }, _count: 20 },
+        { plan: 'yearly', _sum: { amount: 480 }, _count: 10 },
+      ]);
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([
+        { plan: 'monthly', _count: 5 },
+        { plan: 'yearly', _count: 8 },
+      ]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      // Sorted by revenue desc: yearly (480) before monthly (100).
+      expect(result.topPlans).toEqual([
+        { plan: 'yearly', subscription_count: 8, total_revenue: 480 },
+        { plan: 'monthly', subscription_count: 5, total_revenue: 100 },
+      ]);
+    });
+
+    it('keeps plans with revenue but no active subscribers, and buckets unattributed revenue as "unknown"', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([
+        { plan: 'weekly', _sum: { amount: 30 }, _count: 20 },
+        { plan: null, _sum: { amount: 12 }, _count: 4 }, // historical, unmapped
+      ]);
+      // weekly has no currently-active subs; that plan must still appear.
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      expect(result.topPlans).toEqual([
+        { plan: 'weekly', subscription_count: 0, total_revenue: 30 },
+        { plan: 'unknown', subscription_count: 0, total_revenue: 12 },
+      ]);
+    });
+
+    it('includes active-subscription counts for plans that have no attributed revenue yet', async () => {
+      paymentRepo.groupRevenueByPlan.mockResolvedValue([]);
+      subscriptionRepo.groupByActivePlan.mockResolvedValue([
+        { plan: 'monthly', _count: 3 },
+      ]);
+
+      const result = await service.getRevenueAnalytics(range);
+
+      expect(result.topPlans).toEqual([
+        { plan: 'monthly', subscription_count: 3, total_revenue: 0 },
+      ]);
+    });
   });
 });

--- a/src/admin/admin-revenue-analytics.service.ts
+++ b/src/admin/admin-revenue-analytics.service.ts
@@ -180,30 +180,45 @@ export class AdminRevenueAnalyticsService {
         }),
       );
 
-      // Get top plans
-      const subscriptionsWithRevenue =
-        await this.subscriptionRepo.findActiveWithUserRevenue();
+      // Top plans: attribute each payment to the plan it was actually for
+      // (summed DB-side), and pair it with the number of currently-active
+      // subscriptions on that plan. The old version summed every active
+      // subscriber's entire lifetime spend and charged it all to their current
+      // plan — so an upgrader's past-plan revenue was misattributed, and the
+      // whole payment history was loaded into memory.
+      const [revenueByPlan, activePlanCounts] = await Promise.all([
+        this.paymentRepo.groupRevenueByPlan(),
+        this.subscriptionRepo.groupByActivePlan(new Date()),
+      ]);
 
       const planRevenueMap = new Map<
         string,
         { subscription_count: number; total_revenue: number }
       >();
-
-      subscriptionsWithRevenue.forEach((sub) => {
-        const current = planRevenueMap.get(sub.plan) || {
+      const bumpPlan = (
+        plan: string,
+        revenue: number,
+        subscriptions: number,
+      ) => {
+        const current = planRevenueMap.get(plan) || {
           subscription_count: 0,
           total_revenue: 0,
         };
-        const userRevenue = sub.user.paymentTransactions.reduce(
-          (sum, t) => sum + t.amount,
-          0,
-        );
-
-        planRevenueMap.set(sub.plan, {
-          subscription_count: current.subscription_count + 1,
-          total_revenue: current.total_revenue + userRevenue,
+        planRevenueMap.set(plan, {
+          subscription_count: current.subscription_count + subscriptions,
+          total_revenue: current.total_revenue + revenue,
         });
-      });
+      };
+
+      // Revenue per plan; historical rows we couldn't attribute land in 'unknown'.
+      for (const row of revenueByPlan) {
+        bumpPlan(row.plan ?? 'unknown', row._sum.amount ?? 0, 0);
+      }
+      // Active-subscription counts per plan (plans may have revenue but no
+      // active subs left, or vice versa, so this is a union).
+      for (const row of activePlanCounts) {
+        bumpPlan(row.plan, 0, row._count);
+      }
 
       const topPlans = Array.from(planRevenueMap.entries())
         .map(([plan, stats]) => ({

--- a/src/admin/admin-story-admin.controller.ts
+++ b/src/admin/admin-story-admin.controller.ts
@@ -303,7 +303,8 @@ export class AdminStoryAdminController {
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Toggle story published state',
-    description: 'Toggles the isPublished flag for a story (publish/unpublish).',
+    description:
+      'Toggles the isPublished flag for a story (publish/unpublish).',
   })
   @ApiParam({ name: 'storyId', type: String, description: 'Story ID' })
   @ApiOkResponse({ description: 'Story published state toggled successfully' })

--- a/src/admin/admin-story-admin.controller.ts
+++ b/src/admin/admin-story-admin.controller.ts
@@ -299,6 +299,24 @@ export class AdminStoryAdminController {
     };
   }
 
+  @Patch('stories/:storyId/publish')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Toggle story published state',
+    description: 'Toggles the isPublished flag for a story (publish/unpublish).',
+  })
+  @ApiParam({ name: 'storyId', type: String, description: 'Story ID' })
+  @ApiOkResponse({ description: 'Story published state toggled successfully' })
+  @ApiResponse({ status: 404, description: 'Story not found' })
+  async toggleStoryPublish(@Param('storyId') storyId: string) {
+    const data = await this.adminStoryService.toggleStoryPublish(storyId);
+    return {
+      statusCode: 200,
+      message: 'Story published state toggled successfully',
+      data,
+    };
+  }
+
   @Delete('stories/:storyId')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth()

--- a/src/admin/admin-story.filter.spec.ts
+++ b/src/admin/admin-story.filter.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminStoryService } from './admin-story.service';
+import { ADMIN_STORY_REPOSITORY } from './repositories';
+
+describe('AdminStoryService.getAllStories isPublished filter', () => {
+  let service: AdminStoryService;
+  const findStories = jest.fn().mockResolvedValue([]);
+  const countStories = jest.fn().mockResolvedValue(0);
+
+  beforeEach(async () => {
+    findStories.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminStoryService,
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { findStories, countStories } },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(AdminStoryService);
+  });
+
+  it('passes isPublished:false through to the where clause', async () => {
+    await service.getAllStories({ isPublished: false } as never);
+    expect(findStories).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublished: false }) }),
+    );
+  });
+
+  it('omits isPublished from where when not provided', async () => {
+    await service.getAllStories({} as never);
+    const arg = findStories.mock.calls[0][0];
+    expect(arg.where).not.toHaveProperty('isPublished');
+  });
+});

--- a/src/admin/admin-story.filter.spec.ts
+++ b/src/admin/admin-story.filter.spec.ts
@@ -13,8 +13,14 @@ describe('AdminStoryService.getAllStories isPublished filter', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminStoryService,
-        { provide: ADMIN_STORY_REPOSITORY, useValue: { findStories, countStories } },
-        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+        {
+          provide: ADMIN_STORY_REPOSITORY,
+          useValue: { findStories, countStories },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
       ],
     }).compile();
     service = module.get(AdminStoryService);
@@ -23,7 +29,9 @@ describe('AdminStoryService.getAllStories isPublished filter', () => {
   it('passes isPublished:false through to the where clause', async () => {
     await service.getAllStories({ isPublished: false } as never);
     expect(findStories).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ isPublished: false }) }),
+      expect.objectContaining({
+        where: expect.objectContaining({ isPublished: false }),
+      }),
     );
   });
 

--- a/src/admin/admin-story.service.ts
+++ b/src/admin/admin-story.service.ts
@@ -38,6 +38,7 @@ export class AdminStoryService {
       search,
       recommended,
       aiGenerated,
+      isPublished,
       isDeleted,
       language,
       minAge,
@@ -58,6 +59,7 @@ export class AdminStoryService {
 
     if (typeof recommended === 'boolean') where.recommended = recommended;
     if (typeof aiGenerated === 'boolean') where.aiGenerated = aiGenerated;
+    if (typeof isPublished === 'boolean') where.isPublished = isPublished;
     if (typeof isDeleted === 'boolean') where.isDeleted = isDeleted;
     if (language) where.language = language;
     if (minAge) where.ageMin = { gte: minAge };

--- a/src/admin/admin-story.service.ts
+++ b/src/admin/admin-story.service.ts
@@ -165,6 +165,29 @@ export class AdminStoryService {
     return result;
   }
 
+  async toggleStoryPublish(storyId: string): Promise<Story> {
+    const storyExists = await this.adminStoryRepository.storyExists(storyId);
+    if (!storyExists) {
+      throw new ResourceNotFoundException('Story', storyId);
+    }
+    const story = await this.adminStoryRepository.findStoryById(storyId);
+    if (!story) {
+      throw new ResourceNotFoundException('Story', storyId);
+    }
+    const result = await this.adminStoryRepository.updateStoryPublished({
+      storyId,
+      isPublished: !story.isPublished,
+    });
+    try {
+      await this.cacheManager.del(CACHE_KEYS.STORY_STATS);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to invalidate story stats cache: ${error.message}`,
+      );
+    }
+    return result;
+  }
+
   async deleteStory(
     storyId: string,
     permanent: boolean = false,

--- a/src/admin/admin-story.toggle-publish.spec.ts
+++ b/src/admin/admin-story.toggle-publish.spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AdminStoryService } from './admin-story.service';
+import { ADMIN_STORY_REPOSITORY } from './repositories';
+
+describe('AdminStoryService.toggleStoryPublish', () => {
+  let service: AdminStoryService;
+  const storyExists = jest.fn().mockResolvedValue(true);
+  const findStoryById = jest.fn().mockResolvedValue({ id: 's1', isPublished: true });
+  const updateStoryPublished = jest.fn().mockResolvedValue({ id: 's1', isPublished: false });
+
+  beforeEach(async () => {
+    updateStoryPublished.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminStoryService,
+        { provide: ADMIN_STORY_REPOSITORY, useValue: { storyExists, findStoryById, updateStoryPublished } },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(AdminStoryService);
+  });
+
+  it('flips isPublished to the opposite of current', async () => {
+    const result = await service.toggleStoryPublish('s1');
+    expect(updateStoryPublished).toHaveBeenCalledWith({ storyId: 's1', isPublished: false });
+    expect(result.isPublished).toBe(false);
+  });
+});

--- a/src/admin/admin-story.toggle-publish.spec.ts
+++ b/src/admin/admin-story.toggle-publish.spec.ts
@@ -6,16 +6,26 @@ import { ADMIN_STORY_REPOSITORY } from './repositories';
 describe('AdminStoryService.toggleStoryPublish', () => {
   let service: AdminStoryService;
   const storyExists = jest.fn().mockResolvedValue(true);
-  const findStoryById = jest.fn().mockResolvedValue({ id: 's1', isPublished: true });
-  const updateStoryPublished = jest.fn().mockResolvedValue({ id: 's1', isPublished: false });
+  const findStoryById = jest
+    .fn()
+    .mockResolvedValue({ id: 's1', isPublished: true });
+  const updateStoryPublished = jest
+    .fn()
+    .mockResolvedValue({ id: 's1', isPublished: false });
 
   beforeEach(async () => {
     updateStoryPublished.mockClear();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminStoryService,
-        { provide: ADMIN_STORY_REPOSITORY, useValue: { storyExists, findStoryById, updateStoryPublished } },
-        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() } },
+        {
+          provide: ADMIN_STORY_REPOSITORY,
+          useValue: { storyExists, findStoryById, updateStoryPublished },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
       ],
     }).compile();
     service = module.get(AdminStoryService);
@@ -23,7 +33,10 @@ describe('AdminStoryService.toggleStoryPublish', () => {
 
   it('flips isPublished to the opposite of current', async () => {
     const result = await service.toggleStoryPublish('s1');
-    expect(updateStoryPublished).toHaveBeenCalledWith({ storyId: 's1', isPublished: false });
+    expect(updateStoryPublished).toHaveBeenCalledWith({
+      storyId: 's1',
+      isPublished: false,
+    });
     expect(result.isPublished).toBe(false);
   });
 });

--- a/src/admin/dto/admin-filters.dto.ts
+++ b/src/admin/dto/admin-filters.dto.ts
@@ -111,6 +111,10 @@ export class StoryFilterDto extends PaginationDto {
 
   @IsOptional()
   @Transform(({ value }) => value === 'true' || value === true)
+  isPublished?: boolean;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
   isDeleted?: boolean;
 
   @IsOptional()

--- a/src/admin/dto/admin-responses.dto.ts
+++ b/src/admin/dto/admin-responses.dto.ts
@@ -1254,6 +1254,9 @@ export class StoryListItemDto {
   @ApiProperty({ example: false })
   aiGenerated: boolean;
 
+  @ApiProperty({ example: true })
+  isPublished: boolean;
+
   @ApiProperty({ example: 2 })
   difficultyLevel: number;
 

--- a/src/admin/dto/admin-responses.dto.ts
+++ b/src/admin/dto/admin-responses.dto.ts
@@ -815,6 +815,9 @@ export class StoryDetailDto {
   @ApiProperty({ description: 'Is AI generated', example: false })
   aiGenerated: boolean;
 
+  @ApiProperty({ example: true })
+  isPublished: boolean;
+
   @ApiProperty({ description: 'Difficulty level', example: 1 })
   difficultyLevel: number;
 

--- a/src/admin/prisma-admin-engagement.avg-session.spec.ts
+++ b/src/admin/prisma-admin-engagement.avg-session.spec.ts
@@ -1,0 +1,23 @@
+import { PrismaAdminEngagementRepository } from './repositories/prisma-admin-engagement.repository';
+
+describe('getAverageSessionSeconds', () => {
+  function repoWith(rows: { createdAt: Date; lastActivityAt: Date | null }[]) {
+    const prisma = { session: { findMany: jest.fn().mockResolvedValue(rows) } } as never;
+    return new PrismaAdminEngagementRepository(prisma);
+  }
+
+  it('averages (lastActivityAt - createdAt) in seconds, excluding nulls', async () => {
+    const base = new Date('2026-08-01T00:00:00Z').getTime();
+    const repo = repoWith([
+      { createdAt: new Date(base), lastActivityAt: new Date(base + 100_000) }, // 100s
+      { createdAt: new Date(base), lastActivityAt: new Date(base + 300_000) }, // 300s
+    ]);
+    const avg = await repo.getAverageSessionSeconds(new Date(base - 1000), new Date(base + 1_000_000));
+    expect(avg).toBe(200);
+  });
+
+  it('returns 0 when there are no qualifying sessions', async () => {
+    const repo = repoWith([]);
+    expect(await repo.getAverageSessionSeconds(new Date(), new Date())).toBe(0);
+  });
+});

--- a/src/admin/prisma-admin-engagement.avg-session.spec.ts
+++ b/src/admin/prisma-admin-engagement.avg-session.spec.ts
@@ -2,7 +2,9 @@ import { PrismaAdminEngagementRepository } from './repositories/prisma-admin-eng
 
 describe('getAverageSessionSeconds', () => {
   function repoWith(rows: { createdAt: Date; lastActivityAt: Date | null }[]) {
-    const prisma = { session: { findMany: jest.fn().mockResolvedValue(rows) } } as never;
+    const prisma = {
+      session: { findMany: jest.fn().mockResolvedValue(rows) },
+    } as never;
     return new PrismaAdminEngagementRepository(prisma);
   }
 
@@ -12,7 +14,10 @@ describe('getAverageSessionSeconds', () => {
       { createdAt: new Date(base), lastActivityAt: new Date(base + 100_000) }, // 100s
       { createdAt: new Date(base), lastActivityAt: new Date(base + 300_000) }, // 300s
     ]);
-    const avg = await repo.getAverageSessionSeconds(new Date(base - 1000), new Date(base + 1_000_000));
+    const avg = await repo.getAverageSessionSeconds(
+      new Date(base - 1000),
+      new Date(base + 1_000_000),
+    );
     expect(avg).toBe(200);
   });
 

--- a/src/admin/repositories/admin-engagement.repository.interface.ts
+++ b/src/admin/repositories/admin-engagement.repository.interface.ts
@@ -4,6 +4,9 @@ export interface IAdminEngagementRepository {
   countKids(where: Prisma.KidWhereInput): Promise<number>;
   countStoryProgress(where?: Prisma.StoryProgressWhereInput): Promise<number>;
   countFavorites(where?: Prisma.FavoriteWhereInput): Promise<number>;
+  // Average session duration (seconds) over sessions active in [start, end].
+  // Uses lastActivityAt - createdAt; sessions without lastActivityAt excluded.
+  getAverageSessionSeconds(start: Date, end: Date): Promise<number>;
 }
 
 export const ADMIN_ENGAGEMENT_REPOSITORY = Symbol(

--- a/src/admin/repositories/admin-payment.repository.interface.ts
+++ b/src/admin/repositories/admin-payment.repository.interface.ts
@@ -19,6 +19,12 @@ export interface DatedPaymentAmount {
   createdAt: Date;
 }
 
+export interface RevenueByPlan {
+  plan: string | null;
+  _sum: { amount: number | null };
+  _count: number;
+}
+
 export interface IAdminPaymentRepository {
   // Aggregate successful revenue for an arbitrary where clause
   sumRevenue(where: Prisma.PaymentTransactionWhereInput): Promise<RevenueSum>;
@@ -43,6 +49,11 @@ export interface IAdminPaymentRepository {
     startDate: Date,
     endDate: Date,
   ): Promise<DatedPaymentAmount[]>;
+
+  // Successful revenue + transaction count grouped by the plan each payment was
+  // for (top-plans analytics). Attributes each payment to its own plan rather
+  // than to the payer's current subscription.
+  groupRevenueByPlan(): Promise<RevenueByPlan[]>;
 }
 
 export const ADMIN_PAYMENT_REPOSITORY = Symbol('ADMIN_PAYMENT_REPOSITORY');

--- a/src/admin/repositories/admin-story.repository.interface.ts
+++ b/src/admin/repositories/admin-story.repository.interface.ts
@@ -86,6 +86,12 @@ export interface IAdminStoryRepository {
     recommended: boolean;
   }): Promise<Story>;
 
+  // Update story published status
+  updateStoryPublished(params: {
+    storyId: string;
+    isPublished: boolean;
+  }): Promise<Story>;
+
   // Soft delete story
   softDeleteStory(storyId: string): Promise<Story>;
 

--- a/src/admin/repositories/admin-subscription.repository.interface.ts
+++ b/src/admin/repositories/admin-subscription.repository.interface.ts
@@ -10,19 +10,6 @@ export interface SubscriptionStartedAtCount {
   _count: number;
 }
 
-// Active subscriptions joined with each owner's successful payments (revenue)
-export type SubscriptionWithUserRevenue = Prisma.SubscriptionGetPayload<{
-  include: {
-    user: {
-      include: {
-        paymentTransactions: {
-          select: { amount: true };
-        };
-      };
-    };
-  };
-}>;
-
 export type SubscriptionWithUser = Prisma.SubscriptionGetPayload<{
   include: {
     user: { select: { id: true; email: true; name: true } };
@@ -40,9 +27,6 @@ export interface IAdminSubscriptionRepository {
     startDate: Date,
     endDate: Date,
   ): Promise<SubscriptionStartedAtCount[]>;
-
-  // All active subscriptions with owner revenue (top plans)
-  findActiveWithUserRevenue(): Promise<SubscriptionWithUserRevenue[]>;
 
   findByUserId(userId: string): Promise<Subscription | null>;
 

--- a/src/admin/repositories/prisma-admin-engagement.repository.ts
+++ b/src/admin/repositories/prisma-admin-engagement.repository.ts
@@ -20,4 +20,20 @@ export class PrismaAdminEngagementRepository
   countFavorites(where?: Prisma.FavoriteWhereInput): Promise<number> {
     return this.prisma.favorite.count({ where });
   }
+
+  async getAverageSessionSeconds(start: Date, end: Date): Promise<number> {
+    const rows = await this.prisma.session.findMany({
+      where: {
+        isDeleted: false,
+        lastActivityAt: { not: null, gte: start, lte: end },
+      },
+      select: { createdAt: true, lastActivityAt: true },
+    });
+    if (rows.length === 0) return 0;
+    const totalSeconds = rows.reduce((sum, r) => {
+      const lastActivity = r.lastActivityAt as Date;
+      return sum + (lastActivity.getTime() - r.createdAt.getTime()) / 1000;
+    }, 0);
+    return totalSeconds / rows.length;
+  }
 }

--- a/src/admin/repositories/prisma-admin-payment.repository.ts
+++ b/src/admin/repositories/prisma-admin-payment.repository.ts
@@ -5,6 +5,7 @@ import type {
   IAdminPaymentRepository,
   RevenueSum,
   RevenueByDate,
+  RevenueByPlan,
   UserPaymentAmount,
   DatedPaymentAmount,
 } from './admin-payment.repository.interface';
@@ -68,6 +69,23 @@ export class PrismaAdminPaymentRepository implements IAdminPaymentRepository {
         createdAt: new Date(`${day}T00:00:00.000Z`),
         _sum: { amount },
       }));
+  }
+
+  // Sum revenue and count transactions per plan, in the DB. Replaces loading
+  // every active subscriber's entire transaction history into memory and
+  // charging their lifetime spend to their current plan.
+  async groupRevenueByPlan(): Promise<RevenueByPlan[]> {
+    const rows = await this.prisma.paymentTransaction.groupBy({
+      by: ['plan'],
+      where: { status: 'success', deletedAt: null },
+      _sum: { amount: true },
+      _count: true,
+    });
+    return rows.map((row) => ({
+      plan: row.plan,
+      _sum: { amount: row._sum.amount },
+      _count: row._count,
+    }));
   }
 
   findSuccessfulInRange(

--- a/src/admin/repositories/prisma-admin-story.repository.ts
+++ b/src/admin/repositories/prisma-admin-story.repository.ts
@@ -98,6 +98,16 @@ export class PrismaAdminStoryRepository implements IAdminStoryRepository {
     });
   }
 
+  async updateStoryPublished(params: {
+    storyId: string;
+    isPublished: boolean;
+  }): Promise<Story> {
+    return this.prisma.story.update({
+      where: { id: params.storyId },
+      data: { isPublished: params.isPublished },
+    });
+  }
+
   async softDeleteStory(storyId: string): Promise<Story> {
     return this.prisma.story.update({
       where: { id: storyId },

--- a/src/admin/repositories/prisma-admin-subscription.repository.ts
+++ b/src/admin/repositories/prisma-admin-subscription.repository.ts
@@ -5,7 +5,6 @@ import type {
   IAdminSubscriptionRepository,
   SubscriptionPlanCount,
   SubscriptionStartedAtCount,
-  SubscriptionWithUserRevenue,
   SubscriptionWithUser,
 } from './admin-subscription.repository.interface';
 
@@ -57,29 +56,6 @@ export class PrismaAdminSubscriptionRepository
         startedAt: new Date(`${day}T00:00:00.000Z`),
         _count: count,
       }));
-  }
-
-  findActiveWithUserRevenue(): Promise<SubscriptionWithUserRevenue[]> {
-    return this.prisma.subscription.findMany({
-      where: {
-        status: 'active',
-      },
-      include: {
-        user: {
-          include: {
-            paymentTransactions: {
-              where: {
-                status: 'success',
-                deletedAt: null,
-              },
-              select: {
-                amount: true,
-              },
-            },
-          },
-        },
-      },
-    });
   }
 
   findByUserId(userId: string): Promise<Subscription | null> {

--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -122,6 +122,9 @@ const mockPrismaService = {
   screenTimeSession: {
     findMany: jest.fn(),
   },
+  session: {
+    findMany: jest.fn(),
+  },
   $queryRaw: jest.fn(),
 };
 
@@ -303,6 +306,8 @@ describe('AdminService', () => {
         { duration: 10 },
         { duration: 20 },
       ]);
+      // No sessions with lastActivityAt in the window → averageSessionTime = 0.
+      prisma.session.findMany.mockResolvedValue([]);
       prisma.subscription.groupBy.mockResolvedValue([
         { plan: 'monthly', _count: 10 },
         { plan: 'yearly', _count: 5 },
@@ -320,7 +325,7 @@ describe('AdminService', () => {
       expect(result.unpaidUsers).toBe(85); // totalUsers - paidUsers = 100 - 15
       expect(result.totalKids).toBe(5);
       expect(result.totalRevenue).toBe(5000);
-      expect(result.averageSessionTime).toBe(0); // Placeholder in service
+      expect(result.averageSessionTime).toBe(0); // No sessions with lastActivityAt in window
       expect(result.subscriptionPlans).toHaveLength(2);
     });
   });

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -222,6 +222,7 @@ export class PaymentService {
       receiptHash,
       result.amount ?? planDef.amount,
       result.currency ?? 'USD',
+      plan,
     );
 
     if (alreadyProcessed) {
@@ -358,6 +359,7 @@ export class PaymentService {
       receiptHash,
       result.amount ?? planDef.amount,
       result.currency ?? 'USD',
+      plan,
     );
 
     if (alreadyProcessed) {
@@ -661,6 +663,7 @@ export class PaymentService {
     reference: string,
     amount: number,
     currency: string,
+    plan: string,
   ): Promise<{ tx: TransactionRecord; alreadyProcessed: boolean }> {
     try {
       const tx = await this.paymentTransactionRepository.create({
@@ -670,6 +673,7 @@ export class PaymentService {
         currency,
         status: 'success',
         reference,
+        plan,
       });
       return { tx, alreadyProcessed: false };
     } catch (error) {

--- a/src/shared/guards/auth.guard.last-activity.spec.ts
+++ b/src/shared/guards/auth.guard.last-activity.spec.ts
@@ -4,12 +4,20 @@ const THRESHOLD_MS = 60_000;
 
 function makeGuard(session: Record<string, unknown>) {
   const update = jest.fn().mockResolvedValue({});
-  const prisma = { session: { findUnique: jest.fn().mockResolvedValue(session), update } } as never;
-  const jwt = { verify: jest.fn().mockReturnValue({ userId: 'u1', authSessionId: 'sess1' }) } as never;
-  const reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as never;
+  const prisma = {
+    session: { findUnique: jest.fn().mockResolvedValue(session), update },
+  } as never;
+  const jwt = {
+    verify: jest.fn().mockReturnValue({ userId: 'u1', authSessionId: 'sess1' }),
+  } as never;
+  const reflector = {
+    getAllAndOverride: jest.fn().mockReturnValue(false),
+  } as never;
   const guard = new AuthSessionGuard(jwt, reflector, prisma);
   const ctx = {
-    switchToHttp: () => ({ getRequest: () => ({ headers: { authorization: 'Bearer t' } }) }),
+    switchToHttp: () => ({
+      getRequest: () => ({ headers: { authorization: 'Bearer t' } }),
+    }),
     getHandler: () => null,
     getClass: () => null,
   } as never;
@@ -25,23 +33,35 @@ const baseSession = {
 };
 
 it('bumps lastActivityAt when null', async () => {
-  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: null });
+  const { guard, update, ctx } = makeGuard({
+    ...baseSession,
+    lastActivityAt: null,
+  });
   await guard.canActivate(ctx);
   await new Promise((r) => setImmediate(r)); // let the fire-and-forget settle
   expect(update).toHaveBeenCalledWith(
-    expect.objectContaining({ where: { id: 'sess1' }, data: expect.objectContaining({ lastActivityAt: expect.any(Date) }) }),
+    expect.objectContaining({
+      where: { id: 'sess1' },
+      data: expect.objectContaining({ lastActivityAt: expect.any(Date) }),
+    }),
   );
 });
 
 it('bumps when lastActivityAt is stale (> 60s)', async () => {
-  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - THRESHOLD_MS - 1000) });
+  const { guard, update, ctx } = makeGuard({
+    ...baseSession,
+    lastActivityAt: new Date(Date.now() - THRESHOLD_MS - 1000),
+  });
   await guard.canActivate(ctx);
   await new Promise((r) => setImmediate(r));
   expect(update).toHaveBeenCalled();
 });
 
 it('does NOT bump when lastActivityAt is fresh (< 60s)', async () => {
-  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - 5000) });
+  const { guard, update, ctx } = makeGuard({
+    ...baseSession,
+    lastActivityAt: new Date(Date.now() - 5000),
+  });
   await guard.canActivate(ctx);
   await new Promise((r) => setImmediate(r));
   expect(update).not.toHaveBeenCalled();

--- a/src/shared/guards/auth.guard.last-activity.spec.ts
+++ b/src/shared/guards/auth.guard.last-activity.spec.ts
@@ -1,0 +1,48 @@
+import { AuthSessionGuard } from './auth.guard';
+
+const THRESHOLD_MS = 60_000;
+
+function makeGuard(session: Record<string, unknown>) {
+  const update = jest.fn().mockResolvedValue({});
+  const prisma = { session: { findUnique: jest.fn().mockResolvedValue(session), update } } as never;
+  const jwt = { verify: jest.fn().mockReturnValue({ userId: 'u1', authSessionId: 'sess1' }) } as never;
+  const reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as never;
+  const guard = new AuthSessionGuard(jwt, reflector, prisma);
+  const ctx = {
+    switchToHttp: () => ({ getRequest: () => ({ headers: { authorization: 'Bearer t' } }) }),
+    getHandler: () => null,
+    getClass: () => null,
+  } as never;
+  return { guard, update, ctx };
+}
+
+const baseSession = {
+  id: 'sess1',
+  isDeleted: false,
+  deletedAt: null,
+  expiresAt: new Date(Date.now() + 3_600_000),
+  createdAt: new Date(Date.now() - 7_200_000),
+};
+
+it('bumps lastActivityAt when null', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: null });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r)); // let the fire-and-forget settle
+  expect(update).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { id: 'sess1' }, data: expect.objectContaining({ lastActivityAt: expect.any(Date) }) }),
+  );
+});
+
+it('bumps when lastActivityAt is stale (> 60s)', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - THRESHOLD_MS - 1000) });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r));
+  expect(update).toHaveBeenCalled();
+});
+
+it('does NOT bump when lastActivityAt is fresh (< 60s)', async () => {
+  const { guard, update, ctx } = makeGuard({ ...baseSession, lastActivityAt: new Date(Date.now() - 5000) });
+  await guard.canActivate(ctx);
+  await new Promise((r) => setImmediate(r));
+  expect(update).not.toHaveBeenCalled();
+});

--- a/src/shared/guards/auth.guard.ts
+++ b/src/shared/guards/auth.guard.ts
@@ -121,7 +121,10 @@ export class AuthSessionGuard implements CanActivate {
       const last = session.lastActivityAt?.getTime() ?? 0;
       if (Date.now() - last > ACTIVITY_THROTTLE_MS) {
         void this.prisma.session
-          .update({ where: { id: session.id }, data: { lastActivityAt: new Date() } })
+          .update({
+            where: { id: session.id },
+            data: { lastActivityAt: new Date() },
+          })
           .catch(() => undefined);
       }
 

--- a/src/shared/guards/auth.guard.ts
+++ b/src/shared/guards/auth.guard.ts
@@ -114,6 +114,17 @@ export class AuthSessionGuard implements CanActivate {
         throw new UnauthorizedException('Session has expired');
       }
 
+      // Track last activity for avg-session-time analytics. Throttled to at most
+      // one write per 60s per session; fire-and-forget so it never adds latency
+      // or fails an otherwise-valid request.
+      const ACTIVITY_THROTTLE_MS = 60_000;
+      const last = session.lastActivityAt?.getTime() ?? 0;
+      if (Date.now() - last > ACTIVITY_THROTTLE_MS) {
+        void this.prisma.session
+          .update({ where: { id: session.id }, data: { lastActivityAt: new Date() } })
+          .catch(() => undefined);
+      }
+
       this.logger.debug(
         `Auth success [userId=${payload.userId.substring(0, 8)}...]`,
       );

--- a/src/story/daily-challenge.service.ts
+++ b/src/story/daily-challenge.service.ts
@@ -114,7 +114,9 @@ export class DailyChallengeService {
     // Batch fetch all required data upfront
     const [kids, allStories, allPastAssignments] = await Promise.all([
       this.storyRepository.findAllKids(),
-      this.storyRepository.findStories({ where: { isDeleted: false } }),
+      this.storyRepository.findStories({
+        where: { isDeleted: false, isPublished: true },
+      }),
       this.storyRepository.findAllDailyChallengeAssignments(),
     ]);
 

--- a/src/story/repositories/prisma-story.repository.ts
+++ b/src/story/repositories/prisma-story.repository.ts
@@ -1182,7 +1182,7 @@ export class PrismaStoryRepository implements IStoryRepository {
   async getRandomStoryIdsFromStories(limit: number): Promise<string[]> {
     const randomIds = await this.prisma.$queryRaw<{ id: string }[]>`
       SELECT id FROM "stories"
-      WHERE "isDeleted" = false
+      WHERE "isDeleted" = false AND "isPublished" = true
       ORDER BY RANDOM()
       LIMIT ${limit}
     `;
@@ -1196,7 +1196,7 @@ export class PrismaStoryRepository implements IStoryRepository {
   ): Promise<string[]> {
     const ids = await this.prisma.$queryRaw<{ id: string }[]>`
       SELECT id FROM "stories"
-      WHERE "isDeleted" = false
+      WHERE "isDeleted" = false AND "isPublished" = true
       ORDER BY "createdAt" DESC, id ASC
       LIMIT ${limit}
       OFFSET ${offset}

--- a/src/story/story-feed.draft-hiding.spec.ts
+++ b/src/story/story-feed.draft-hiding.spec.ts
@@ -1,0 +1,66 @@
+import { StoryFeedService } from './story-feed.service';
+import { StoryService } from './story.service';
+import { IStoryRepository } from './repositories/story.repository.interface';
+
+describe('public read paths hide drafts', () => {
+  it('getStories base where includes isPublished: true (StoryFeedService chokepoint)', async () => {
+    const findManyStoriesRaw = jest.fn().mockResolvedValue([]);
+    const countStoriesRaw = jest.fn().mockResolvedValue(0);
+
+    const storyRepository: Partial<IStoryRepository> = {
+      findManyStoriesRaw,
+      countStoriesRaw,
+    };
+
+    const svc = new StoryFeedService(
+      storyRepository as IStoryRepository,
+      {} as never, // cacheManager
+      {} as never, // guestSessionService
+    );
+
+    await svc.getStories({});
+
+    expect(findManyStoriesRaw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isPublished: true }),
+      }),
+    );
+    expect(countStoriesRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ isPublished: true }),
+    );
+  });
+
+  it('getStoryById filters isPublished: true (StoryService chokepoint)', async () => {
+    const findUniqueStoryRaw = jest
+      .fn()
+      .mockResolvedValue({ id: 's1', isPublished: true });
+
+    const storyRepository: Partial<IStoryRepository> = {
+      findUniqueStoryRaw,
+    };
+
+    const svc = new StoryService(
+      storyRepository as IStoryRepository,
+      {} as never, // cacheManager
+      {} as never, // uploadService
+      {} as never, // storyGenerationService
+      {} as never, // storyFavoriteService
+      {} as never, // storyDownloadService
+      {} as never, // storyPathService
+      {} as never, // storyMetadataService
+      {} as never, // storyProgressService
+      {} as never, // storyRecommendationService
+      {} as never, // dailyChallengeService
+      {} as never, // storyFeedService
+      {} as never, // notificationService
+    );
+
+    await svc.getStoryById('s1');
+
+    expect(findUniqueStoryRaw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 's1', isPublished: true }),
+      }),
+    );
+  });
+});

--- a/src/story/story-feed.service.ts
+++ b/src/story/story-feed.service.ts
@@ -72,6 +72,7 @@ export class StoryFeedService {
   }> {
     const where: Prisma.StoryWhereInput = {
       isDeleted: false,
+      isPublished: true,
     };
 
     if (filter.theme) where.themes = { some: { id: filter.theme } };
@@ -302,7 +303,10 @@ export class StoryFeedService {
     // For topPicksFromUs, pagination is handled in the raw SQL query
     const [totalCount, queriedStories] = await Promise.all([
       filter.topPicksFromUs
-        ? this.storyRepository.countStoriesRaw({ isDeleted: false })
+        ? this.storyRepository.countStoriesRaw({
+            isDeleted: false,
+            isPublished: true,
+          })
         : this.storyRepository.countStoriesRaw(where),
       this.storyRepository.findManyStoriesRaw({
         where: freshWhere,
@@ -997,13 +1001,14 @@ export class StoryFeedService {
       preferredCategories.length > 0
         ? {
             isDeleted: false,
+            isPublished: true,
             categories: {
               some: {
                 id: { in: preferredCategories.map((c: Category) => c.id) },
               },
             },
           }
-        : { isDeleted: false };
+        : { isDeleted: false, isPublished: true };
     // Fresh-first: fetch unread recommendations, then top up with read ones.
     recommended = await this.storyRepository.findManyStoriesRaw({
       where: this.withUserReadFilter(recBaseWhere, userId, 'fresh'),
@@ -1036,6 +1041,7 @@ export class StoryFeedService {
         where: this.withUserReadFilter(
           {
             isDeleted: false,
+            isPublished: true,
             seasons: {
               some: {
                 id: { in: activeSeasons.map((s) => s.id) },
@@ -1060,6 +1066,7 @@ export class StoryFeedService {
         where: this.withUserReadFilter(
           {
             isDeleted: false,
+            isPublished: true,
             seasons: {
               some: {
                 id: { in: backfillSeasons.map((s) => s.id) },
@@ -1084,6 +1091,7 @@ export class StoryFeedService {
       seasonal,
       {
         isDeleted: false,
+        isPublished: true,
         seasons: {
           some: {
             id: {
@@ -1103,7 +1111,11 @@ export class StoryFeedService {
     // 3. Top Liked by Parents (fresh-first, then top up with read)
     const topLikedInclude: Prisma.StoryInclude = { images: true };
     let topLiked = await this.storyRepository.findManyStoriesRaw({
-      where: this.withUserReadFilter({ isDeleted: false }, userId, 'fresh'),
+      where: this.withUserReadFilter(
+        { isDeleted: false, isPublished: true },
+        userId,
+        'fresh',
+      ),
       orderBy: {
         parentFavorites: {
           _count: 'desc',
@@ -1114,7 +1126,7 @@ export class StoryFeedService {
     });
     topLiked = await this.topUpWithRead(
       topLiked,
-      { isDeleted: false },
+      { isDeleted: false, isPublished: true },
       userId,
       limitTopLiked,
       topLikedInclude,

--- a/src/story/story.service.spec.ts
+++ b/src/story/story.service.spec.ts
@@ -629,7 +629,7 @@ describe('StoryService - Library & Generation', () => {
             where: {
               userId,
               isDeleted: false,
-              story: { isDeleted: false },
+              story: { isDeleted: false, isPublished: true },
             },
             orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
             take: 2,
@@ -820,7 +820,7 @@ describe('StoryService - Library & Generation', () => {
             where: {
               userId,
               isDeleted: false,
-              story: { isDeleted: false },
+              story: { isDeleted: false, isPublished: true },
             },
             orderBy: [{ lastAccessed: 'desc' }, { id: 'asc' }],
             take: 3,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -475,6 +475,7 @@ export class StoryService {
           ageMin: { lte: kidAge },
           ageMax: { gte: kidAge },
           isDeleted: false,
+          isPublished: true,
         },
       });
       if (stories.length === 0) continue;
@@ -551,7 +552,7 @@ export class StoryService {
 
   async getStoryById(id: string) {
     const story = await this.storyRepository.findUniqueStoryRaw({
-      where: { id, isDeleted: false },
+      where: { id, isDeleted: false, isPublished: true },
       include: {
         images: true,
         branches: true,
@@ -693,7 +694,7 @@ export class StoryService {
 
     const storyIds = topStories.map((s) => s.storyId);
     const stories = await this.storyRepository.findManyStoriesRaw({
-      where: { id: { in: storyIds }, isDeleted: false },
+      where: { id: { in: storyIds }, isDeleted: false, isPublished: true },
       include: {
         themes: true,
         categories: true,
@@ -742,7 +743,7 @@ export class StoryService {
 
     // Fetch full story objects with relations
     return this.storyRepository.findManyStoriesRaw({
-      where: { id: { in: randomIds } },
+      where: { id: { in: randomIds }, isPublished: true },
       include: {
         themes: true,
         categories: true,


### PR DESCRIPTION
# Pull Request

## Description
Replaces two hardcoded admin-dashboard stubs with real data, per `docs/superpowers/specs/2026-08-13-admin-dashboard-stubs-design.md`.

**Feature 1 — Story draft/published (`draftStories`):**
- New `Story.isPublished Boolean @default(true)` (+ additive migration). Default `true` = every existing/generated story stays published, zero behavior change.
- Admin: `isPublished` filter on the story list, field on the list + detail DTOs, and a `PATCH /admin/stories/:id/publish` toggle.
- `publishedStories` / `draftStories` dashboard counts are now real.
- **Public read paths filter `isPublished: true`** so drafts never reach kids/parents (feed, home carousels, top-picks, daily-challenge pool, single-read chokepoint, raw-SQL id generators). A kid's own-created-story view stays unfiltered.

**Feature 2 — `averageSessionTime`:**
- New `Session.lastActivityAt DateTime?` (+ additive migration), bumped **throttled (60s) + fire-and-forget** in `AuthSessionGuard` (never awaited — no added latency, can't fail a request).
- Averaged over a trailing 30-day window (`lastActivityAt − createdAt`, nulls excluded), replacing the `= 0` placeholder.

**Known limitation (documented):** progress/continue-reading/library joins are not strict-hidden — a story unpublished *after* a user already has progress on/downloaded it can still appear there. `avgSessionTime` tracks going forward (no backfill possible) so it reads ~0 at first and climbs.

## Type of change
- [x] New feature

## How Has This Been Tested?
- [x] Local development
- [x] Unit tests

New/updated specs: story-stats counts, admin filter, publish toggle, public draft-hiding chokepoints, guard throttle (null/stale/fresh), avg-session computation, and the `getDashboardStats` mock. `pnpm build` + eslint clean; affected suites 203/203 (one pre-existing, unrelated `uuid@13` ESM suite-load failure).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional context
Two additive migrations (`bool NOT NULL DEFAULT true`; nullable `TIMESTAMP(3)`) — metadata-only, safe on the shared DB; the deploy job runs `db:migrate:deploy` on merge. Built via a design→plan→subagent-execution flow with per-task + whole-branch review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboards now show published and draft story counts, average session duration, and revenue grouped by plan.
  * Administrators can filter stories by publication status and toggle stories between published and draft.
  * Payment records retain the associated plan for more accurate reporting.
* **Bug Fixes**
  * Draft stories are excluded from public feeds, recommendations, challenges, and direct story retrieval.
  * Session activity tracking improves engagement-time calculations without affecting authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->