### PR TITLE
fix(story): strict-hide unpublished stories from library/history joins

### DIFF
--- a/src/guest/repositories/prisma-guest.repository.ts
+++ b/src/guest/repositories/prisma-guest.repository.ts
@@ -63,7 +63,7 @@ export class PrismaGuestRepository implements IGuestRepository {
     });
   }
 
-  async findUserReadingHistory(userId: string): Promise<GuestUserHistoryRow[]> {
+  findUserReadingHistory(userId: string): Promise<GuestUserHistoryRow[]> {
     return this.prisma.userStoryProgress.findMany({
       // Hide history rows whose story has since been unpublished (draft).
       where: { userId, isDeleted: false, story: { isPublished: true } },

--- a/src/guest/repositories/prisma-guest.repository.ts
+++ b/src/guest/repositories/prisma-guest.repository.ts
@@ -58,14 +58,15 @@ export class PrismaGuestRepository implements IGuestRepository {
 
   async findStoryDetail(storyId: string): Promise<GuestStoryDetail | null> {
     return this.prisma.story.findFirst({
-      where: { id: storyId, isDeleted: false },
+      where: { id: storyId, isDeleted: false, isPublished: true },
       select: GUEST_STORY_DETAIL_SELECT,
     });
   }
 
   async findUserReadingHistory(userId: string): Promise<GuestUserHistoryRow[]> {
     return this.prisma.userStoryProgress.findMany({
-      where: { userId, isDeleted: false },
+      // Hide history rows whose story has since been unpublished (draft).
+      where: { userId, isDeleted: false, story: { isPublished: true } },
       select: {
         storyId: true,
         progress: true,
@@ -84,6 +85,7 @@ export class PrismaGuestRepository implements IGuestRepository {
       where: {
         id: { in: storyIds },
         isDeleted: false,
+        isPublished: true,
       },
       select: GUEST_STORY_DETAIL_SELECT,
     });

--- a/src/story/repositories/draft-hiding-joins.spec.ts
+++ b/src/story/repositories/draft-hiding-joins.spec.ts
@@ -1,0 +1,95 @@
+import { PrismaStoryRepository } from './prisma-story.repository';
+import { PrismaStoryFavoriteRepository } from './prisma-story-favorite.repository';
+import { PrismaStoryDownloadRepository } from './prisma-story-download.repository';
+import { PrismaGuestRepository } from '../../guest/repositories/prisma-guest.repository';
+
+// Caveat A: library / history / progress joins that return story objects must
+// hide stories that have since been unpublished (draft). Each of these read
+// paths must carry a `story: { isPublished: true }` (or, for direct story
+// reads, `isPublished: true`) predicate in its parent `where`.
+
+const whereOf = (mockFn: jest.Mock) => mockFn.mock.calls[0][0].where;
+
+describe('draft-hiding on library/history joins', () => {
+  describe('PrismaStoryRepository progress joins', () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const repo = new PrismaStoryRepository({
+      storyProgress: { findMany },
+      userStoryProgress: { findMany },
+    } as never);
+
+    beforeEach(() => findMany.mockClear());
+
+    it('findContinueReadingProgress filters story.isPublished', async () => {
+      await repo.findContinueReadingProgress('kid1');
+      expect(whereOf(findMany).story).toEqual({ isPublished: true });
+    });
+
+    it('findCompletedProgress filters story.isPublished', async () => {
+      await repo.findCompletedProgress('kid1');
+      expect(whereOf(findMany).story).toEqual({ isPublished: true });
+    });
+
+    it('findUserContinueReadingProgress filters story.isPublished', async () => {
+      await repo.findUserContinueReadingProgress('user1');
+      expect(whereOf(findMany).story).toEqual({ isPublished: true });
+    });
+
+    it('findUserCompletedProgress filters story.isPublished', async () => {
+      await repo.findUserCompletedProgress('user1');
+      expect(whereOf(findMany).story).toEqual({ isPublished: true });
+    });
+  });
+
+  it('favorites join filters story.isPublished', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const repo = new PrismaStoryFavoriteRepository({
+      favorite: { findMany },
+    } as never);
+    await repo.findFavoritesByKidId('kid1');
+    expect(whereOf(findMany).story).toEqual({
+      isDeleted: false,
+      isPublished: true,
+    });
+  });
+
+  it('downloads join filters story.isPublished', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const repo = new PrismaStoryDownloadRepository({
+      downloadedStory: { findMany },
+    } as never);
+    await repo.findDownloadsByKidId('kid1');
+    expect(whereOf(findMany).story).toEqual({ isPublished: true });
+  });
+
+  describe('guest reads', () => {
+    const findFirst = jest.fn().mockResolvedValue(null);
+    const storyFindMany = jest.fn().mockResolvedValue([]);
+    const progressFindMany = jest.fn().mockResolvedValue([]);
+    const repo = new PrismaGuestRepository({
+      story: { findFirst, findMany: storyFindMany },
+      userStoryProgress: { findMany: progressFindMany },
+    } as never);
+
+    it('findStoryDetail requires isPublished', async () => {
+      await repo.findStoryDetail('s1');
+      expect(findFirst.mock.calls[0][0].where).toMatchObject({
+        isPublished: true,
+      });
+    });
+
+    it('findStoryDetailsByIds requires isPublished', async () => {
+      await repo.findStoryDetailsByIds(['s1']);
+      expect(storyFindMany.mock.calls[0][0].where).toMatchObject({
+        isPublished: true,
+      });
+    });
+
+    it('findUserReadingHistory filters story.isPublished', async () => {
+      await repo.findUserReadingHistory('user1');
+      expect(progressFindMany.mock.calls[0][0].where.story).toEqual({
+        isPublished: true,
+      });
+    });
+  });
+});

--- a/src/story/repositories/prisma-story-download.repository.ts
+++ b/src/story/repositories/prisma-story-download.repository.ts
@@ -48,7 +48,8 @@ export class PrismaStoryDownloadRepository implements IStoryDownloadRepository {
     opts?: { take?: number; cursor?: string },
   ): Promise<DownloadedStoryWithStory[]> {
     return await this.prisma.downloadedStory.findMany({
-      where: { kidId },
+      // Hide downloaded stories that have since been unpublished (draft).
+      where: { kidId, story: { isPublished: true } },
       include: { story: true },
       orderBy: [{ downloadedAt: 'desc' }, { id: 'asc' }],
       ...(opts?.take !== undefined ? { take: opts.take } : {}),

--- a/src/story/repositories/prisma-story-favorite.repository.ts
+++ b/src/story/repositories/prisma-story-favorite.repository.ts
@@ -33,7 +33,11 @@ export class PrismaStoryFavoriteRepository implements IStoryFavoriteRepository {
     opts?: { take?: number; cursor?: string },
   ): Promise<FavoriteWithStory[]> {
     return await this.prisma.favorite.findMany({
-      where: { kidId, isDeleted: false, story: { isDeleted: false } },
+      where: {
+        kidId,
+        isDeleted: false,
+        story: { isDeleted: false, isPublished: true },
+      },
       include: { story: true },
       orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
       ...(opts?.take !== undefined ? { take: opts.take } : {}),

--- a/src/story/repositories/prisma-story.repository.ts
+++ b/src/story/repositories/prisma-story.repository.ts
@@ -275,6 +275,8 @@ export class PrismaStoryRepository implements IStoryRepository {
         completed: false,
         progress: { gt: 0 },
         isDeleted: false,
+        // Hide progress rows whose story has since been unpublished (draft).
+        story: { isPublished: true },
       },
       include: { story: true },
       orderBy: { lastAccessed: 'desc' },
@@ -289,6 +291,7 @@ export class PrismaStoryRepository implements IStoryRepository {
         kidId,
         completed: true,
         isDeleted: false,
+        story: { isPublished: true },
       },
       include: { story: true },
       orderBy: { lastAccessed: 'desc' },
@@ -355,6 +358,8 @@ export class PrismaStoryRepository implements IStoryRepository {
         completed: false,
         progress: { gt: 0 },
         isDeleted: false,
+        // Hide progress rows whose story has since been unpublished (draft).
+        story: { isPublished: true },
       },
       include: { story: true },
       orderBy: { lastAccessed: 'desc' },
@@ -369,6 +374,7 @@ export class PrismaStoryRepository implements IStoryRepository {
         userId,
         completed: true,
         isDeleted: false,
+        story: { isPublished: true },
       },
       include: { story: true },
       orderBy: { lastAccessed: 'desc' },

--- a/src/story/story-recommendation.service.ts
+++ b/src/story/story-recommendation.service.ts
@@ -107,7 +107,12 @@ export class StoryRecommendationService {
     );
     if (!kid) throw new NotFoundException('Kid not found or access denied');
     const story = await this.storyCoreRepository.findStoryById(dto.storyId);
-    if (!story) throw new NotFoundException('Story not found');
+    // Reject a known draft id: an unpublished story can't be recommended to a
+    // kid. findStoryById is shared with existence checks, so gate here, not in
+    // the repository.
+    if (!story || !story.isPublished) {
+      throw new NotFoundException('Story not found');
+    }
 
     const isRestricted = await this.storyCoreRepository.findRestrictedStory(
       dto.kidId,

--- a/src/story/story.service.ts
+++ b/src/story/story.service.ts
@@ -631,7 +631,8 @@ export class StoryService {
 
   async addDownload(kidId: string, storyId: string) {
     const story = await this.storyRepository.findUniqueStoryRaw({
-      where: { id: storyId, isDeleted: false },
+      // Reject a known draft id: a draft can't be added to a kid's library.
+      where: { id: storyId, isDeleted: false, isPublished: true },
     });
     if (!story) throw new NotFoundException('Story not found');
     return await this.storyRepository.upsertDownload(kidId, storyId);


### PR DESCRIPTION
Follow-up to #514 (Caveat A). Closes the documented limitation: a story unpublished **after** a user already had progress on / downloaded / favorited it could still appear in their continue-reading / library / history lists, and a **known** draft id could be seeded into a library or kid recommendation.

## Changes
Add `story: { isPublished: true }` to the parent `where` of the joins that return story objects to end users:
- `prisma-story.repository.ts`: kid + user continue-reading / completed progress joins
- `prisma-story-favorite.repository.ts`: favorites (already filtered `story.isDeleted`)
- `prisma-story-download.repository.ts`: downloads
- `prisma-guest.repository.ts`: guest `findStoryDetail`, `findStoryDetailsByIds`, `findUserReadingHistory`

Defense-in-depth (reject a known draft id):
- `addDownload` — filters `isPublished: true` (a draft can't be added to a library)
- `recommendStoryToKid` — gated in the service (the shared `findStoryById` is left untouched so existence checks keep working)

Admin paths and a kid's own-created-story view are untouched.

## Tests
New `draft-hiding-joins.spec.ts` (9 tests) asserts the nested filter reaches each join's `where`. Build + eslint clean; story + guest suites 130/130 (one pre-existing unrelated `uuid@13` ESM suite-load failure). No migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unpublished stories are now excluded from reading history, progress, favorites, downloads, and guest story listings.
  * Recommendations and downloads can no longer be created for unpublished stories.
  * Existing favorites and downloads for stories that become unpublished are no longer displayed.
* **Tests**
  * Added coverage confirming unpublished stories are consistently hidden across story-related views and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->