### PR TITLE
security: detect injector variants that evade the literal marker check

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -57,10 +57,10 @@ jobs:
           SRC_INCLUDES="--include=*.js --include=*.mjs --include=*.cjs --include=*.ts --include=*.tsx --include=*.jsx --include=*.json --include=*.vue --include=*.svelte"
           variants=$(
             {
-              grep -rlE "global(\.[A-Za-z_$]|\['[^']{1,2}'\])[[:space:]]*=[[:space:]]*[\"']A[0-9]+-[0-9]+-[0-9]+[\"']" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
-              grep -rlE "(_0x[0-9a-f]{4,}.*){20,}" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
-              grep -rlE "[;\})] {200,}[^ ]" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
-            } | grep -v "^\./\.github/workflows/malware-scan.yml$" | sort -u
+              grep -rlE "global(\.[A-Za-z_$]{1,3}|\[[[:space:]]*[\"'][^\"']{1,3}[\"'][[:space:]]*\])[[:space:]]*=[[:space:]]*[\"']A[0-9]+-[0-9]+-[0-9]+[\"']" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+              grep -rlE "(_0x[0-9a-fA-F]+.*){20,}" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+              grep -rlE "\S {200,}\S" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+            } | grep -v "^\./\.github/workflows/malware-scan.yml$" | sort -u || true
           )
           if [ -n "${hits}${fonts}${variants}" ]; then
             echo "::error::Malware indicators found (injector marker / obfuscated payload / disguised font):"

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -49,13 +49,27 @@ jobs:
             --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null || true)
           fonts=$(find . -name '*.woff2' -not -path '*/node_modules/*' -not -path '*/.git/*' \
             -exec grep -lF "$MARK" {} + 2>/dev/null || true)
-          if [ -n "${hits}${fonts}" ]; then
-            echo "::error::Malware indicators found (global['!'] injector / disguised font):"
+          # Variant indicators (added 2026-08-17 after the global.i="A8-2503-2"
+          # payload in eslint.config.mjs evaded the literal marker above):
+          #  1. the marker family: global.<single-char> = "A<digits>-<digits>-<digits>"
+          #  2. hex-array obfuscator identifiers (_0x....) repeated densely on one line
+          #  3. code hidden behind a run of 200+ spaces on an otherwise normal line
+          SRC_INCLUDES="--include=*.js --include=*.mjs --include=*.cjs --include=*.ts --include=*.tsx --include=*.jsx --include=*.json --include=*.vue --include=*.svelte"
+          variants=$(
+            {
+              grep -rlE "global(\.[A-Za-z_$]|\['[^']{1,2}'\])[[:space:]]*=[[:space:]]*[\"']A[0-9]+-[0-9]+-[0-9]+[\"']" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+              grep -rlE "(_0x[0-9a-f]{4,}.*){20,}" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+              grep -rlE "[;\})] {200,}[^ ]" . $SRC_INCLUDES --exclude-dir=node_modules --exclude-dir=.git 2>/dev/null
+            } | grep -v "^\./\.github/workflows/malware-scan.yml$" | sort -u
+          )
+          if [ -n "${hits}${fonts}${variants}" ]; then
+            echo "::error::Malware indicators found (injector marker / obfuscated payload / disguised font):"
             [ -n "$hits" ] && printf '%s\n' "$hits"
             [ -n "$fonts" ] && printf '%s\n' "$fonts"
+            [ -n "$variants" ] && printf '%s\n' "$variants"
             exit 1
           fi
-          echo "Clean — no global['!'] injector marker or disguised fonts."
+          echo "Clean — no injector markers, obfuscated payloads, or disguised fonts."
 
       # Marker-agnostic backstop for the injector above. The 2026-08 org-wide
       # incident used this same worm family but MUTATED its marker (global.o=


### PR DESCRIPTION
Follow-up to #517. The injected eslint.config.mjs payload evaded the fast injector check for a week because it used `global.i="A8-2503-2"` (not the literal `global['!']` the check greps) and hid behind ~250 trailing spaces.

Adds three variant indicators to the per-PR check, each verified against the actual removed payload:
1. Marker family: `global.<single-char> = "A<digits>-<digits>-<digits>"` (dot or bracket form)
2. Dense hex-obfuscator signature: 20+ `_0x…` identifiers on one line
3. Whitespace-hiding: code resuming after 200+ consecutive spaces

The workflow file itself is excluded from the sweep (it now contains pattern text), consistent with the deep-scan's existing note about not self-flagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved malware scanning to detect additional obfuscated and suspicious code patterns.
  - Reports new variant findings alongside existing scan results.
  - Ensures scans fail when any malware category is detected.
  - Excludes the scanning workflow itself from variant findings.
  - Updated the clean-scan status message for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->